### PR TITLE
PR 1: bootstrap projects + locked public API + OpenSpec scaffolding

### DIFF
--- a/.claude/commands/opsx/apply.md
+++ b/.claude/commands/opsx/apply.md
@@ -1,0 +1,152 @@
+---
+name: "OPSX: Apply"
+description: Implement tasks from an OpenSpec change (Experimental)
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - Context file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read the files listed in `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/commands/opsx/archive.md
+++ b/.claude/commands/opsx/archive.md
@@ -1,0 +1,157 @@
+---
+name: "OPSX: Archive"
+description: Archive a completed change in the experimental workflow
+category: Workflow
+tags: [workflow, archive, experimental]
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** openspec/changes/archive/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/commands/opsx/explore.md
+++ b/.claude/commands/opsx/explore.md
@@ -1,0 +1,173 @@
+---
+name: "OPSX: Explore"
+description: "Enter explore mode - think through ideas, investigate problems, clarify requirements"
+category: Workflow
+tags: [workflow, explore, experimental, thinking]
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│   ┌────────┐         ┌────────┐        │
+│   │ State  │────────▶│ State  │        │
+│   │   A    │         │   B    │        │
+│   └────────┘         └────────┘        │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+   | Insight Type | Where to Capture |
+   |--------------|------------------|
+   | New requirement discovered | `specs/<capability>/spec.md` |
+   | Requirement changed | `specs/<capability>/spec.md` |
+   | Design decision made | `design.md` |
+   | Scope changed | `proposal.md` |
+   | New work identified | `tasks.md` |
+   | Assumption invalidated | Relevant artifact |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/commands/opsx/propose.md
+++ b/.claude/commands/opsx/propose.md
@@ -1,0 +1,106 @@
+---
+name: "OPSX: Propose"
+description: Propose a new change - create it and generate all artifacts in one step
+category: Workflow
+tags: [workflow, artifacts, experimental]
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.claude/skills/openspec-apply-change/SKILL.md
+++ b/.claude/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - Context file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read the files listed in `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.claude/skills/openspec-archive-change/SKILL.md
+++ b/.claude/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.claude/skills/openspec-bulk-archive-change/SKILL.md
+++ b/.claude/skills/openspec-bulk-archive-change/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: openspec-bulk-archive-change
+description: Archive multiple completed changes at once. Use when archiving several parallel changes.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.1.1"
+---
+
+Archive multiple completed changes in a single operation.
+
+This skill allows you to batch-archive changes, handling spec conflicts intelligently by checking the codebase to determine what's actually implemented.
+
+**Input**: None required (prompts for selection)
+
+**Steps**
+
+1. **Get active changes**
+
+   Run `openspec list --json` to get all active changes.
+
+   If no active changes exist, inform user and stop.
+
+2. **Prompt for change selection**
+
+   Use **AskUserQuestion tool** with multi-select to let user choose changes:
+   - Show each change with its schema
+   - Include an option for "All changes"
+   - Allow any number of selections (1+ works, 2+ is the typical use case)
+
+   **IMPORTANT**: Do NOT auto-select. Always let the user choose.
+
+3. **Batch validation - gather status for all selected changes**
+
+   For each selected change, collect:
+
+   a. **Artifact status** - Run `openspec status --change "<name>" --json`
+      - Parse `schemaName` and `artifacts` list
+      - Note which artifacts are `done` vs other states
+
+   b. **Task completion** - Read `openspec/changes/<name>/tasks.md`
+      - Count `- [ ]` (incomplete) vs `- [x]` (complete)
+      - If no tasks file exists, note as "No tasks"
+
+   c. **Delta specs** - Check `openspec/changes/<name>/specs/` directory
+      - List which capability specs exist
+      - For each, extract requirement names (lines matching `### Requirement: <name>`)
+
+4. **Detect spec conflicts**
+
+   Build a map of `capability -> [changes that touch it]`:
+
+   ```
+   auth -> [change-a, change-b]  <- CONFLICT (2+ changes)
+   api  -> [change-c]            <- OK (only 1 change)
+   ```
+
+   A conflict exists when 2+ selected changes have delta specs for the same capability.
+
+5. **Resolve conflicts agentically**
+
+   **For each conflict**, investigate the codebase:
+
+   a. **Read the delta specs** from each conflicting change to understand what each claims to add/modify
+
+   b. **Search the codebase** for implementation evidence:
+      - Look for code implementing requirements from each delta spec
+      - Check for related files, functions, or tests
+
+   c. **Determine resolution**:
+      - If only one change is actually implemented -> sync that one's specs
+      - If both implemented -> apply in chronological order (older first, newer overwrites)
+      - If neither implemented -> skip spec sync, warn user
+
+   d. **Record resolution** for each conflict:
+      - Which change's specs to apply
+      - In what order (if both)
+      - Rationale (what was found in codebase)
+
+6. **Show consolidated status table**
+
+   Display a table summarizing all changes:
+
+   ```
+   | Change               | Artifacts | Tasks | Specs   | Conflicts | Status |
+   |---------------------|-----------|-------|---------|-----------|--------|
+   | schema-management   | Done      | 5/5   | 2 delta | None      | Ready  |
+   | project-config      | Done      | 3/3   | 1 delta | None      | Ready  |
+   | add-oauth           | Done      | 4/4   | 1 delta | auth (!)  | Ready* |
+   | add-verify-skill    | 1 left    | 2/5   | None    | None      | Warn   |
+   ```
+
+   For conflicts, show the resolution:
+   ```
+   * Conflict resolution:
+     - auth spec: Will apply add-oauth then add-jwt (both implemented, chronological order)
+   ```
+
+   For incomplete changes, show warnings:
+   ```
+   Warnings:
+   - add-verify-skill: 1 incomplete artifact, 3 incomplete tasks
+   ```
+
+7. **Confirm batch operation**
+
+   Use **AskUserQuestion tool** with a single confirmation:
+
+   - "Archive N changes?" with options based on status
+   - Options might include:
+     - "Archive all N changes"
+     - "Archive only N ready changes (skip incomplete)"
+     - "Cancel"
+
+   If there are incomplete changes, make clear they'll be archived with warnings.
+
+8. **Execute archive for each confirmed change**
+
+   Process changes in the determined order (respecting conflict resolution):
+
+   a. **Sync specs** if delta specs exist:
+      - Use the openspec-sync-specs approach (agent-driven intelligent merge)
+      - For conflicts, apply in resolved order
+      - Track if sync was done
+
+   b. **Perform the archive**:
+      ```bash
+      mkdir -p openspec/changes/archive
+      mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+      ```
+
+   c. **Track outcome** for each change:
+      - Success: archived successfully
+      - Failed: error during archive (record error)
+      - Skipped: user chose not to archive (if applicable)
+
+9. **Display summary**
+
+   Show final results:
+
+   ```
+   ## Bulk Archive Complete
+
+   Archived 3 changes:
+   - schema-management-cli -> archive/2026-01-19-schema-management-cli/
+   - project-config -> archive/2026-01-19-project-config/
+   - add-oauth -> archive/2026-01-19-add-oauth/
+
+   Skipped 1 change:
+   - add-verify-skill (user chose not to archive incomplete)
+
+   Spec sync summary:
+   - 4 delta specs synced to main specs
+   - 1 conflict resolved (auth: applied both in chronological order)
+   ```
+
+   If any failures:
+   ```
+   Failed 1 change:
+   - some-change: Archive directory already exists
+   ```
+
+**Conflict Resolution Examples**
+
+Example 1: Only one implemented
+```
+Conflict: specs/auth/spec.md touched by [add-oauth, add-jwt]
+
+Checking add-oauth:
+- Delta adds "OAuth Provider Integration" requirement
+- Searching codebase... found src/auth/oauth.ts implementing OAuth flow
+
+Checking add-jwt:
+- Delta adds "JWT Token Handling" requirement
+- Searching codebase... no JWT implementation found
+
+Resolution: Only add-oauth is implemented. Will sync add-oauth specs only.
+```
+
+Example 2: Both implemented
+```
+Conflict: specs/api/spec.md touched by [add-rest-api, add-graphql]
+
+Checking add-rest-api (created 2026-01-10):
+- Delta adds "REST Endpoints" requirement
+- Searching codebase... found src/api/rest.ts
+
+Checking add-graphql (created 2026-01-15):
+- Delta adds "GraphQL Schema" requirement
+- Searching codebase... found src/api/graphql.ts
+
+Resolution: Both implemented. Will apply add-rest-api specs first,
+then add-graphql specs (chronological order, newer takes precedence).
+```
+
+**Output On Success**
+
+```
+## Bulk Archive Complete
+
+Archived N changes:
+- <change-1> -> archive/YYYY-MM-DD-<change-1>/
+- <change-2> -> archive/YYYY-MM-DD-<change-2>/
+
+Spec sync summary:
+- N delta specs synced to main specs
+- No conflicts (or: M conflicts resolved)
+```
+
+**Output On Partial Success**
+
+```
+## Bulk Archive Complete (partial)
+
+Archived N changes:
+- <change-1> -> archive/YYYY-MM-DD-<change-1>/
+
+Skipped M changes:
+- <change-2> (user chose not to archive incomplete)
+
+Failed K changes:
+- <change-3>: Archive directory already exists
+```
+
+**Output When No Changes**
+
+```
+## No Changes to Archive
+
+No active changes found. Use `/opsx:new` to create a new change.
+```
+
+**Guardrails**
+- Allow any number of changes (1+ is fine, 2+ is the typical use case)
+- Always prompt for selection, never auto-select
+- Detect spec conflicts early and resolve by checking codebase
+- When both changes are implemented, apply specs in chronological order
+- Skip spec sync only when implementation is missing (warn user)
+- Show clear per-change status before confirming
+- Use single confirmation for entire batch
+- Track and report all outcomes (success/skip/fail)
+- Preserve .openspec.yaml when moving to archive
+- Archive directory target uses current date: YYYY-MM-DD-<name>
+- If archive target exists, fail that change but continue with others

--- a/.claude/skills/openspec-continue-change/SKILL.md
+++ b/.claude/skills/openspec-continue-change/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: openspec-continue-change
+description: Continue working on an OpenSpec change by creating the next artifact. Use when the user wants to progress their change, create the next artifact, or continue their workflow.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.1.1"
+---
+
+Continue working on a change by creating the next artifact.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes sorted by most recently modified. Then use the **AskUserQuestion tool** to let the user select which change to work on.
+
+   Present the top 3-4 most recently modified changes as options, showing:
+   - Change name
+   - Schema (from `schema` field if present, otherwise "spec-driven")
+   - Status (e.g., "0/5 tasks", "complete", "no tasks")
+   - How recently it was modified (from `lastModified` field)
+
+   Mark the most recently modified change as "(Recommended)" since it's likely what the user wants to continue.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check current status**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand current state. The response includes:
+   - `schemaName`: The workflow schema being used (e.g., "spec-driven")
+   - `artifacts`: Array of artifacts with their status ("done", "ready", "blocked")
+   - `isComplete`: Boolean indicating if all artifacts are complete
+
+3. **Act based on status**:
+
+   ---
+
+   **If all artifacts are complete (`isComplete: true`)**:
+   - Congratulate the user
+   - Show final status including the schema used
+   - Suggest: "All artifacts created! You can now implement this change or archive it."
+   - STOP
+
+   ---
+
+   **If artifacts are ready to create** (status shows artifacts with `status: "ready"`):
+   - Pick the FIRST artifact with `status: "ready"` from the status output
+   - Get its instructions:
+     ```bash
+     openspec instructions <artifact-id> --change "<name>" --json
+     ```
+   - Parse the JSON. The key fields are:
+     - `context`: Project background (constraints for you - do NOT include in output)
+     - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+     - `template`: The structure to use for your output file
+     - `instruction`: Schema-specific guidance
+     - `outputPath`: Where to write the artifact
+     - `dependencies`: Completed artifacts to read for context
+   - **Create the artifact file**:
+     - Read any completed dependency files for context
+     - Use `template` as the structure - fill in its sections
+     - Apply `context` and `rules` as constraints when writing - but do NOT copy them into the file
+     - Write to the output path specified in instructions
+   - Show what was created and what's now unlocked
+   - STOP after creating ONE artifact
+
+   ---
+
+   **If no artifacts are ready (all blocked)**:
+   - This shouldn't happen with a valid schema
+   - Show status and suggest checking for issues
+
+4. **After creating an artifact, show progress**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After each invocation, show:
+- Which artifact was created
+- Schema workflow being used
+- Current progress (N/M complete)
+- What artifacts are now unlocked
+- Prompt: "Want to continue? Just ask me to continue or tell me what to do next."
+
+**Artifact Creation Guidelines**
+
+The artifact types and their purpose depend on the schema. Use the `instruction` field from the instructions output to understand what to create.
+
+Common artifact patterns:
+
+**spec-driven schema** (proposal → specs → design → tasks):
+- **proposal.md**: Ask user about the change if not clear. Fill in Why, What Changes, Capabilities, Impact.
+  - The Capabilities section is critical - each capability listed will need a spec file.
+- **specs/<capability>/spec.md**: Create one spec per capability listed in the proposal's Capabilities section (use the capability name, not the change name).
+- **design.md**: Document technical decisions, architecture, and implementation approach.
+- **tasks.md**: Break down implementation into checkboxed tasks.
+
+For other schemas, follow the `instruction` field from the CLI output.
+
+**Guardrails**
+- Create ONE artifact per invocation
+- Always read dependency artifacts before creating a new one
+- Never skip artifacts or create out of order
+- If context is unclear, ask the user before creating
+- Verify the artifact file exists after writing before marking progress
+- Use the schema's artifact sequence, don't assume specific artifact names
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output

--- a/.claude/skills/openspec-explore/SKILL.md
+++ b/.claude/skills/openspec-explore/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│   ┌────────┐         ┌────────┐        │
+│   │ State  │────────▶│ State  │        │
+│   │   A    │         │   B    │        │
+│   └────────┘         └────────┘        │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+   | Insight Type | Where to Capture |
+   |--------------|------------------|
+   | New requirement discovered | `specs/<capability>/spec.md` |
+   | Requirement changed | `specs/<capability>/spec.md` |
+   | Design decision made | `design.md` |
+   | Scope changed | `proposal.md` |
+   | New work identified | `tasks.md` |
+   | Assumption invalidated | Relevant artifact |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │         CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.claude/skills/openspec-ff-change/SKILL.md
+++ b/.claude/skills/openspec-ff-change/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: openspec-ff-change
+description: Fast-forward through OpenSpec artifact creation. Use when the user wants to quickly create all artifacts needed for implementation without stepping through each one individually.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.1.1"
+---
+
+Fast-forward through artifact creation - generate everything needed to start implementation in one go.
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "✓ Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, suggest continuing that change instead
+- Verify each artifact file exists after writing before proceeding to next

--- a/.claude/skills/openspec-new-change/SKILL.md
+++ b/.claude/skills/openspec-new-change/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: openspec-new-change
+description: Start a new OpenSpec change using the experimental artifact workflow. Use when the user wants to create a new feature, fix, or modification with a structured step-by-step approach.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.1.1"
+---
+
+Start a new change using the experimental artifact-driven approach.
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Determine the workflow schema**
+
+   Use the default schema (omit `--schema`) unless the user explicitly requests a different workflow.
+
+   **Use a different schema only if the user mentions:**
+   - A specific schema name → use `--schema <name>`
+   - "show workflows" or "what workflows" → run `openspec schemas --json` and let them choose
+
+   **Otherwise**: Omit `--schema` to use the default.
+
+3. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   Add `--schema <name>` only if the user requested a specific workflow.
+   This creates a scaffolded change at `openspec/changes/<name>/` with the selected schema.
+
+4. **Show the artifact status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+   This shows which artifacts need to be created and which are ready (dependencies satisfied).
+
+5. **Get instructions for the first artifact**
+   The first artifact depends on the schema (e.g., `proposal` for spec-driven).
+   Check the status output to find the first artifact with status "ready".
+   ```bash
+   openspec instructions <first-artifact-id> --change "<name>"
+   ```
+   This outputs the template and context for creating the first artifact.
+
+6. **STOP and wait for user direction**
+
+**Output**
+
+After completing the steps, summarize:
+- Change name and location
+- Schema/workflow being used and its artifact sequence
+- Current status (0/N artifacts complete)
+- The template for the first artifact
+- Prompt: "Ready to create the first artifact? Just describe what this change is about and I'll draft it, or ask me to continue."
+
+**Guardrails**
+- Do NOT create any artifacts yet - just show the instructions
+- Do NOT advance beyond showing the first artifact template
+- If the name is invalid (not kebab-case), ask for a valid name
+- If a change with that name already exists, suggest continuing that change instead
+- Pass --schema if using a non-default workflow

--- a/.claude/skills/openspec-onboard/SKILL.md
+++ b/.claude/skills/openspec-onboard/SKILL.md
@@ -1,0 +1,529 @@
+---
+name: openspec-onboard
+description: Guided onboarding for OpenSpec - walk through a complete workflow cycle with narration and real codebase work.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.1.1"
+---
+
+Guide the user through their first complete OpenSpec workflow cycle. This is a teaching experience—you'll do real work in their codebase while explaining each step.
+
+---
+
+## Preflight
+
+Before starting, check if OpenSpec is initialized:
+
+```bash
+openspec status --json 2>&1 || echo "NOT_INITIALIZED"
+```
+
+**If not initialized:**
+> OpenSpec isn't set up in this project yet. Run `openspec init` first, then come back to `/opsx:onboard`.
+
+Stop here if not initialized.
+
+---
+
+## Phase 1: Welcome
+
+Display:
+
+```
+## Welcome to OpenSpec!
+
+I'll walk you through a complete change cycle—from idea to implementation—using a real task in your codebase. Along the way, you'll learn the workflow by doing it.
+
+**What we'll do:**
+1. Pick a small, real task in your codebase
+2. Explore the problem briefly
+3. Create a change (the container for our work)
+4. Build the artifacts: proposal → specs → design → tasks
+5. Implement the tasks
+6. Archive the completed change
+
+**Time:** ~15-20 minutes
+
+Let's start by finding something to work on.
+```
+
+---
+
+## Phase 2: Task Selection
+
+### Codebase Analysis
+
+Scan the codebase for small improvement opportunities. Look for:
+
+1. **TODO/FIXME comments** - Search for `TODO`, `FIXME`, `HACK`, `XXX` in code files
+2. **Missing error handling** - `catch` blocks that swallow errors, risky operations without try-catch
+3. **Functions without tests** - Cross-reference `src/` with test directories
+4. **Type issues** - `any` types in TypeScript files (`: any`, `as any`)
+5. **Debug artifacts** - `console.log`, `console.debug`, `debugger` statements in non-debug code
+6. **Missing validation** - User input handlers without validation
+
+Also check recent git activity:
+```bash
+git log --oneline -10 2>/dev/null || echo "No git history"
+```
+
+### Present Suggestions
+
+From your analysis, present 3-4 specific suggestions:
+
+```
+## Task Suggestions
+
+Based on scanning your codebase, here are some good starter tasks:
+
+**1. [Most promising task]**
+   Location: `src/path/to/file.ts:42`
+   Scope: ~1-2 files, ~20-30 lines
+   Why it's good: [brief reason]
+
+**2. [Second task]**
+   Location: `src/another/file.ts`
+   Scope: ~1 file, ~15 lines
+   Why it's good: [brief reason]
+
+**3. [Third task]**
+   Location: [location]
+   Scope: [estimate]
+   Why it's good: [brief reason]
+
+**4. Something else?**
+   Tell me what you'd like to work on.
+
+Which task interests you? (Pick a number or describe your own)
+```
+
+**If nothing found:** Fall back to asking what the user wants to build:
+> I didn't find obvious quick wins in your codebase. What's something small you've been meaning to add or fix?
+
+### Scope Guardrail
+
+If the user picks or describes something too large (major feature, multi-day work):
+
+```
+That's a valuable task, but it's probably larger than ideal for your first OpenSpec run-through.
+
+For learning the workflow, smaller is better—it lets you see the full cycle without getting stuck in implementation details.
+
+**Options:**
+1. **Slice it smaller** - What's the smallest useful piece of [their task]? Maybe just [specific slice]?
+2. **Pick something else** - One of the other suggestions, or a different small task?
+3. **Do it anyway** - If you really want to tackle this, we can. Just know it'll take longer.
+
+What would you prefer?
+```
+
+Let the user override if they insist—this is a soft guardrail.
+
+---
+
+## Phase 3: Explore Demo
+
+Once a task is selected, briefly demonstrate explore mode:
+
+```
+Before we create a change, let me quickly show you **explore mode**—it's how you think through problems before committing to a direction.
+```
+
+Spend 1-2 minutes investigating the relevant code:
+- Read the file(s) involved
+- Draw a quick ASCII diagram if it helps
+- Note any considerations
+
+```
+## Quick Exploration
+
+[Your brief analysis—what you found, any considerations]
+
+┌─────────────────────────────────────────┐
+│   [Optional: ASCII diagram if helpful]  │
+└─────────────────────────────────────────┘
+
+Explore mode (`/opsx:explore`) is for this kind of thinking—investigating before implementing. You can use it anytime you need to think through a problem.
+
+Now let's create a change to hold our work.
+```
+
+**PAUSE** - Wait for user acknowledgment before proceeding.
+
+---
+
+## Phase 4: Create the Change
+
+**EXPLAIN:**
+```
+## Creating a Change
+
+A "change" in OpenSpec is a container for all the thinking and planning around a piece of work. It lives in `openspec/changes/<name>/` and holds your artifacts—proposal, specs, design, tasks.
+
+Let me create one for our task.
+```
+
+**DO:** Create the change with a derived kebab-case name:
+```bash
+openspec new change "<derived-name>"
+```
+
+**SHOW:**
+```
+Created: `openspec/changes/<name>/`
+
+The folder structure:
+```
+openspec/changes/<name>/
+├── proposal.md    ← Why we're doing this (empty, we'll fill it)
+├── design.md      ← How we'll build it (empty)
+├── specs/         ← Detailed requirements (empty)
+└── tasks.md       ← Implementation checklist (empty)
+```
+
+Now let's fill in the first artifact—the proposal.
+```
+
+---
+
+## Phase 5: Proposal
+
+**EXPLAIN:**
+```
+## The Proposal
+
+The proposal captures **why** we're making this change and **what** it involves at a high level. It's the "elevator pitch" for the work.
+
+I'll draft one based on our task.
+```
+
+**DO:** Draft the proposal content (don't save yet):
+
+```
+Here's a draft proposal:
+
+---
+
+## Why
+
+[1-2 sentences explaining the problem/opportunity]
+
+## What Changes
+
+[Bullet points of what will be different]
+
+## Capabilities
+
+### New Capabilities
+- `<capability-name>`: [brief description]
+
+### Modified Capabilities
+<!-- If modifying existing behavior -->
+
+## Impact
+
+- `src/path/to/file.ts`: [what changes]
+- [other files if applicable]
+
+---
+
+Does this capture the intent? I can adjust before we save it.
+```
+
+**PAUSE** - Wait for user approval/feedback.
+
+After approval, save the proposal:
+```bash
+openspec instructions proposal --change "<name>" --json
+```
+Then write the content to `openspec/changes/<name>/proposal.md`.
+
+```
+Proposal saved. This is your "why" document—you can always come back and refine it as understanding evolves.
+
+Next up: specs.
+```
+
+---
+
+## Phase 6: Specs
+
+**EXPLAIN:**
+```
+## Specs
+
+Specs define **what** we're building in precise, testable terms. They use a requirement/scenario format that makes expected behavior crystal clear.
+
+For a small task like this, we might only need one spec file.
+```
+
+**DO:** Create the spec file:
+```bash
+mkdir -p openspec/changes/<name>/specs/<capability-name>
+```
+
+Draft the spec content:
+
+```
+Here's the spec:
+
+---
+
+## ADDED Requirements
+
+### Requirement: <Name>
+
+<Description of what the system should do>
+
+#### Scenario: <Scenario name>
+
+- **WHEN** <trigger condition>
+- **THEN** <expected outcome>
+- **AND** <additional outcome if needed>
+
+---
+
+This format—WHEN/THEN/AND—makes requirements testable. You can literally read them as test cases.
+```
+
+Save to `openspec/changes/<name>/specs/<capability>/spec.md`.
+
+---
+
+## Phase 7: Design
+
+**EXPLAIN:**
+```
+## Design
+
+The design captures **how** we'll build it—technical decisions, tradeoffs, approach.
+
+For small changes, this might be brief. That's fine—not every change needs deep design discussion.
+```
+
+**DO:** Draft design.md:
+
+```
+Here's the design:
+
+---
+
+## Context
+
+[Brief context about the current state]
+
+## Goals / Non-Goals
+
+**Goals:**
+- [What we're trying to achieve]
+
+**Non-Goals:**
+- [What's explicitly out of scope]
+
+## Decisions
+
+### Decision 1: [Key decision]
+
+[Explanation of approach and rationale]
+
+---
+
+For a small task, this captures the key decisions without over-engineering.
+```
+
+Save to `openspec/changes/<name>/design.md`.
+
+---
+
+## Phase 8: Tasks
+
+**EXPLAIN:**
+```
+## Tasks
+
+Finally, we break the work into implementation tasks—checkboxes that drive the apply phase.
+
+These should be small, clear, and in logical order.
+```
+
+**DO:** Generate tasks based on specs and design:
+
+```
+Here are the implementation tasks:
+
+---
+
+## 1. [Category or file]
+
+- [ ] 1.1 [Specific task]
+- [ ] 1.2 [Specific task]
+
+## 2. Verify
+
+- [ ] 2.1 [Verification step]
+
+---
+
+Each checkbox becomes a unit of work in the apply phase. Ready to implement?
+```
+
+**PAUSE** - Wait for user to confirm they're ready to implement.
+
+Save to `openspec/changes/<name>/tasks.md`.
+
+---
+
+## Phase 9: Apply (Implementation)
+
+**EXPLAIN:**
+```
+## Implementation
+
+Now we implement each task, checking them off as we go. I'll announce each one and occasionally note how the specs/design informed the approach.
+```
+
+**DO:** For each task:
+
+1. Announce: "Working on task N: [description]"
+2. Implement the change in the codebase
+3. Reference specs/design naturally: "The spec says X, so I'm doing Y"
+4. Mark complete in tasks.md: `- [ ]` → `- [x]`
+5. Brief status: "✓ Task N complete"
+
+Keep narration light—don't over-explain every line of code.
+
+After all tasks:
+
+```
+## Implementation Complete
+
+All tasks done:
+- [x] Task 1
+- [x] Task 2
+- [x] ...
+
+The change is implemented! One more step—let's archive it.
+```
+
+---
+
+## Phase 10: Archive
+
+**EXPLAIN:**
+```
+## Archiving
+
+When a change is complete, we archive it. This moves it from `openspec/changes/` to `openspec/changes/archive/YYYY-MM-DD-<name>/`.
+
+Archived changes become your project's decision history—you can always find them later to understand why something was built a certain way.
+```
+
+**DO:**
+```bash
+openspec archive "<name>"
+```
+
+**SHOW:**
+```
+Archived to: `openspec/changes/archive/YYYY-MM-DD-<name>/`
+
+The change is now part of your project's history. The code is in your codebase, the decision record is preserved.
+```
+
+---
+
+## Phase 11: Recap & Next Steps
+
+```
+## Congratulations!
+
+You just completed a full OpenSpec cycle:
+
+1. **Explore** - Thought through the problem
+2. **New** - Created a change container
+3. **Proposal** - Captured WHY
+4. **Specs** - Defined WHAT in detail
+5. **Design** - Decided HOW
+6. **Tasks** - Broke it into steps
+7. **Apply** - Implemented the work
+8. **Archive** - Preserved the record
+
+This same rhythm works for any size change—a small fix or a major feature.
+
+---
+
+## Command Reference
+
+| Command | What it does |
+|---------|--------------|
+| `/opsx:explore` | Think through problems before/during work |
+| `/opsx:new` | Start a new change, step through artifacts |
+| `/opsx:ff` | Fast-forward: create all artifacts at once |
+| `/opsx:continue` | Continue working on an existing change |
+| `/opsx:apply` | Implement tasks from a change |
+| `/opsx:verify` | Verify implementation matches artifacts |
+| `/opsx:archive` | Archive a completed change |
+
+---
+
+## What's Next?
+
+Try `/opsx:new` or `/opsx:ff` on something you actually want to build. You've got the rhythm now!
+```
+
+---
+
+## Graceful Exit Handling
+
+### User wants to stop mid-way
+
+If the user says they need to stop, want to pause, or seem disengaged:
+
+```
+No problem! Your change is saved at `openspec/changes/<name>/`.
+
+To pick up where we left off later:
+- `/opsx:continue <name>` - Resume artifact creation
+- `/opsx:apply <name>` - Jump to implementation (if tasks exist)
+
+The work won't be lost. Come back whenever you're ready.
+```
+
+Exit gracefully without pressure.
+
+### User just wants command reference
+
+If the user says they just want to see the commands or skip the tutorial:
+
+```
+## OpenSpec Quick Reference
+
+| Command | What it does |
+|---------|--------------|
+| `/opsx:explore` | Think through problems (no code changes) |
+| `/opsx:new <name>` | Start a new change, step by step |
+| `/opsx:ff <name>` | Fast-forward: all artifacts at once |
+| `/opsx:continue <name>` | Continue an existing change |
+| `/opsx:apply <name>` | Implement tasks |
+| `/opsx:verify <name>` | Verify implementation |
+| `/opsx:archive <name>` | Archive when done |
+
+Try `/opsx:new` to start your first change, or `/opsx:ff` if you want to move fast.
+```
+
+Exit gracefully.
+
+---
+
+## Guardrails
+
+- **Follow the EXPLAIN → DO → SHOW → PAUSE pattern** at key transitions (after explore, after proposal draft, after tasks, after archive)
+- **Keep narration light** during implementation—teach without lecturing
+- **Don't skip phases** even if the change is small—the goal is teaching the workflow
+- **Pause for acknowledgment** at marked points, but don't over-pause
+- **Handle exits gracefully**—never pressure the user to continue
+- **Use real codebase tasks**—don't simulate or use fake examples
+- **Adjust scope gently**—guide toward smaller tasks but respect user choice

--- a/.claude/skills/openspec-propose/SKILL.md
+++ b/.claude/skills/openspec-propose/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.claude/skills/openspec-sync-specs/SKILL.md
+++ b/.claude/skills/openspec-sync-specs/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: openspec-sync-specs
+description: Sync delta specs from a change to main specs. Use when the user wants to update main specs with changes from a delta spec, without archiving the change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.1.1"
+---
+
+Sync delta specs from a change to main specs.
+
+This is an **agent-driven** operation - you will read delta specs and directly edit main specs to apply the changes. This allows intelligent merging (e.g., adding a scenario without copying the entire requirement).
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show changes that have delta specs (under `specs/` directory).
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Find delta specs**
+
+   Look for delta spec files in `openspec/changes/<name>/specs/*/spec.md`.
+
+   Each delta spec file contains sections like:
+   - `## ADDED Requirements` - New requirements to add
+   - `## MODIFIED Requirements` - Changes to existing requirements
+   - `## REMOVED Requirements` - Requirements to remove
+   - `## RENAMED Requirements` - Requirements to rename (FROM:/TO: format)
+
+   If no delta specs found, inform user and stop.
+
+3. **For each delta spec, apply changes to main specs**
+
+   For each capability with a delta spec at `openspec/changes/<name>/specs/<capability>/spec.md`:
+
+   a. **Read the delta spec** to understand the intended changes
+
+   b. **Read the main spec** at `openspec/specs/<capability>/spec.md` (may not exist yet)
+
+   c. **Apply changes intelligently**:
+
+      **ADDED Requirements:**
+      - If requirement doesn't exist in main spec → add it
+      - If requirement already exists → update it to match (treat as implicit MODIFIED)
+
+      **MODIFIED Requirements:**
+      - Find the requirement in main spec
+      - Apply the changes - this can be:
+        - Adding new scenarios (don't need to copy existing ones)
+        - Modifying existing scenarios
+        - Changing the requirement description
+      - Preserve scenarios/content not mentioned in the delta
+
+      **REMOVED Requirements:**
+      - Remove the entire requirement block from main spec
+
+      **RENAMED Requirements:**
+      - Find the FROM requirement, rename to TO
+
+   d. **Create new main spec** if capability doesn't exist yet:
+      - Create `openspec/specs/<capability>/spec.md`
+      - Add Purpose section (can be brief, mark as TBD)
+      - Add Requirements section with the ADDED requirements
+
+4. **Show summary**
+
+   After applying all changes, summarize:
+   - Which capabilities were updated
+   - What changes were made (requirements added/modified/removed/renamed)
+
+**Delta Spec Format Reference**
+
+```markdown
+## ADDED Requirements
+
+### Requirement: New Feature
+The system SHALL do something new.
+
+#### Scenario: Basic case
+- **WHEN** user does X
+- **THEN** system does Y
+
+## MODIFIED Requirements
+
+### Requirement: Existing Feature
+#### Scenario: New scenario to add
+- **WHEN** user does A
+- **THEN** system does B
+
+## REMOVED Requirements
+
+### Requirement: Deprecated Feature
+
+## RENAMED Requirements
+
+- FROM: `### Requirement: Old Name`
+- TO: `### Requirement: New Name`
+```
+
+**Key Principle: Intelligent Merging**
+
+Unlike programmatic merging, you can apply **partial updates**:
+- To add a scenario, just include that scenario under MODIFIED - don't copy existing scenarios
+- The delta represents *intent*, not a wholesale replacement
+- Use your judgment to merge changes sensibly
+
+**Output On Success**
+
+```
+## Specs Synced: <change-name>
+
+Updated main specs:
+
+**<capability-1>**:
+- Added requirement: "New Feature"
+- Modified requirement: "Existing Feature" (added 1 scenario)
+
+**<capability-2>**:
+- Created new spec file
+- Added requirement: "Another Feature"
+
+Main specs are now updated. The change remains active - archive when implementation is complete.
+```
+
+**Guardrails**
+- Read both delta and main specs before making changes
+- Preserve existing content not mentioned in delta
+- If something is unclear, ask for clarification
+- Show what you're changing as you go
+- The operation should be idempotent - running twice should give same result

--- a/.claude/skills/openspec-verify-change/SKILL.md
+++ b/.claude/skills/openspec-verify-change/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: openspec-verify-change
+description: Verify implementation matches change artifacts. Use when the user wants to validate that implementation is complete, correct, and coherent before archiving.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.1.1"
+---
+
+Verify that an implementation matches the change artifacts (specs, tasks, design).
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show changes that have implementation tasks (tasks artifact exists).
+   Include the schema used for each change if available.
+   Mark changes with incomplete tasks as "(In Progress)".
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifacts exist for this change
+
+3. **Get the change directory and load artifacts**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns the change directory and context files. Read all available artifacts from `contextFiles`.
+
+4. **Initialize verification report structure**
+
+   Create a report structure with three dimensions:
+   - **Completeness**: Track tasks and spec coverage
+   - **Correctness**: Track requirement implementation and scenario coverage
+   - **Coherence**: Track design adherence and pattern consistency
+
+   Each dimension can have CRITICAL, WARNING, or SUGGESTION issues.
+
+5. **Verify Completeness**
+
+   **Task Completion**:
+   - If tasks.md exists in contextFiles, read it
+   - Parse checkboxes: `- [ ]` (incomplete) vs `- [x]` (complete)
+   - Count complete vs total tasks
+   - If incomplete tasks exist:
+     - Add CRITICAL issue for each incomplete task
+     - Recommendation: "Complete task: <description>" or "Mark as done if already implemented"
+
+   **Spec Coverage**:
+   - If delta specs exist in `openspec/changes/<name>/specs/`:
+     - Extract all requirements (marked with "### Requirement:")
+     - For each requirement:
+       - Search codebase for keywords related to the requirement
+       - Assess if implementation likely exists
+     - If requirements appear unimplemented:
+       - Add CRITICAL issue: "Requirement not found: <requirement name>"
+       - Recommendation: "Implement requirement X: <description>"
+
+6. **Verify Correctness**
+
+   **Requirement Implementation Mapping**:
+   - For each requirement from delta specs:
+     - Search codebase for implementation evidence
+     - If found, note file paths and line ranges
+     - Assess if implementation matches requirement intent
+     - If divergence detected:
+       - Add WARNING: "Implementation may diverge from spec: <details>"
+       - Recommendation: "Review <file>:<lines> against requirement X"
+
+   **Scenario Coverage**:
+   - For each scenario in delta specs (marked with "#### Scenario:"):
+     - Check if conditions are handled in code
+     - Check if tests exist covering the scenario
+     - If scenario appears uncovered:
+       - Add WARNING: "Scenario not covered: <scenario name>"
+       - Recommendation: "Add test or implementation for scenario: <description>"
+
+7. **Verify Coherence**
+
+   **Design Adherence**:
+   - If design.md exists in contextFiles:
+     - Extract key decisions (look for sections like "Decision:", "Approach:", "Architecture:")
+     - Verify implementation follows those decisions
+     - If contradiction detected:
+       - Add WARNING: "Design decision not followed: <decision>"
+       - Recommendation: "Update implementation or revise design.md to match reality"
+   - If no design.md: Skip design adherence check, note "No design.md to verify against"
+
+   **Code Pattern Consistency**:
+   - Review new code for consistency with project patterns
+   - Check file naming, directory structure, coding style
+   - If significant deviations found:
+     - Add SUGGESTION: "Code pattern deviation: <details>"
+     - Recommendation: "Consider following project pattern: <example>"
+
+8. **Generate Verification Report**
+
+   **Summary Scorecard**:
+   ```
+   ## Verification Report: <change-name>
+
+   ### Summary
+   | Dimension    | Status           |
+   |--------------|------------------|
+   | Completeness | X/Y tasks, N reqs|
+   | Correctness  | M/N reqs covered |
+   | Coherence    | Followed/Issues  |
+   ```
+
+   **Issues by Priority**:
+
+   1. **CRITICAL** (Must fix before archive):
+      - Incomplete tasks
+      - Missing requirement implementations
+      - Each with specific, actionable recommendation
+
+   2. **WARNING** (Should fix):
+      - Spec/design divergences
+      - Missing scenario coverage
+      - Each with specific recommendation
+
+   3. **SUGGESTION** (Nice to fix):
+      - Pattern inconsistencies
+      - Minor improvements
+      - Each with specific recommendation
+
+   **Final Assessment**:
+   - If CRITICAL issues: "X critical issue(s) found. Fix before archiving."
+   - If only warnings: "No critical issues. Y warning(s) to consider. Ready for archive (with noted improvements)."
+   - If all clear: "All checks passed. Ready for archive."
+
+**Verification Heuristics**
+
+- **Completeness**: Focus on objective checklist items (checkboxes, requirements list)
+- **Correctness**: Use keyword search, file path analysis, reasonable inference - don't require perfect certainty
+- **Coherence**: Look for glaring inconsistencies, don't nitpick style
+- **False Positives**: When uncertain, prefer SUGGESTION over WARNING, WARNING over CRITICAL
+- **Actionability**: Every issue must have a specific recommendation with file/line references where applicable
+
+**Graceful Degradation**
+
+- If only tasks.md exists: verify task completion only, skip spec/design checks
+- If tasks + specs exist: verify completeness and correctness, skip design
+- If full artifacts: verify all three dimensions
+- Always note which checks were skipped and why
+
+**Output Format**
+
+Use clear markdown with:
+- Table for summary scorecard
+- Grouped lists for issues (CRITICAL/WARNING/SUGGESTION)
+- Code references in format: `file.ts:123`
+- Specific, actionable recommendations
+- No vague suggestions like "consider reviewing"

--- a/.github/prompts/opsx-apply.prompt.md
+++ b/.github/prompts/opsx-apply.prompt.md
@@ -1,0 +1,149 @@
+---
+description: Implement tasks from an OpenSpec change (Experimental)
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name (e.g., `/opsx:apply add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - Context file paths (varies by schema)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using `/opsx:continue`
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read the files listed in `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! You can archive this change with `/opsx:archive`.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.github/prompts/opsx-archive.prompt.md
+++ b/.github/prompts/opsx-archive.prompt.md
@@ -1,0 +1,154 @@
+---
+description: Archive a completed change in the experimental workflow
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name after `/opsx:archive` (e.g., `/opsx:archive add-auth`). If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Prompt user for confirmation to continue
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Spec sync status (synced / sync skipped / no delta specs)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success (No Delta Specs)**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** No delta specs
+
+All artifacts complete. All tasks complete.
+```
+
+**Output On Success With Warnings**
+
+```
+## Archive Complete (with warnings)
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** Sync skipped (user chose to skip)
+
+**Warnings:**
+- Archived with 2 incomplete artifacts
+- Archived with 3 incomplete tasks
+- Delta spec sync was skipped (user chose to skip)
+
+Review the archive if this was not intentional.
+```
+
+**Output On Error (Archive Exists)**
+
+```
+## Archive Failed
+
+**Change:** <change-name>
+**Target:** openspec/changes/archive/YYYY-MM-DD-<name>/
+
+Target archive directory already exists.
+
+**Options:**
+1. Rename the existing archive
+2. Delete the existing archive if it's a duplicate
+3. Wait until a different date to archive
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use the Skill tool to invoke `openspec-sync-specs` (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.github/prompts/opsx-explore.prompt.md
+++ b/.github/prompts/opsx-explore.prompt.md
@@ -1,0 +1,170 @@
+---
+description: Enter explore mode - think through ideas, investigate problems, clarify requirements
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+**Input**: The argument after `/opsx:explore` is whatever the user wants to think about. Could be:
+- A vague idea: "real-time collaboration"
+- A specific problem: "the auth system is getting unwieldy"
+- A change name: "add-dark-mode" (to explore in context of that change)
+- A comparison: "postgres vs sqlite for this"
+- Nothing (just enter explore mode)
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│   ┌────────┐         ┌────────┐        │
+│   │ State  │────────▶│ State  │        │
+│   │   A    │         │   B    │        │
+│   └────────┘         └────────┘        │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+If the user mentioned a specific change name, read its artifacts for context.
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+   | Insight Type | Where to Capture |
+   |--------------|------------------|
+   | New requirement discovered | `specs/<capability>/spec.md` |
+   | Requirement changed | `specs/<capability>/spec.md` |
+   | Design decision made | `design.md` |
+   | Scope changed | `proposal.md` |
+   | New work identified | `tasks.md` |
+   | Assumption invalidated | Relevant artifact |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When things crystallize, you might offer a summary - but it's optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.github/prompts/opsx-propose.prompt.md
+++ b/.github/prompts/opsx-propose.prompt.md
@@ -1,0 +1,103 @@
+---
+description: Propose a new change - create it and generate all artifacts in one step
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The argument after `/opsx:propose` is the change name (kebab-case), OR a description of what the user wants to build.
+
+**Steps**
+
+1. **If no input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` to start implementing."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/.github/skills/openspec-apply-change/SKILL.md
+++ b/.github/skills/openspec-apply-change/SKILL.md
@@ -1,0 +1,156 @@
+---
+name: openspec-apply-change
+description: Implement tasks from an OpenSpec change. Use when the user wants to start implementing, continue implementation, or work through tasks.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Implement tasks from an OpenSpec change.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **Select the change**
+
+   If a name is provided, use it. Otherwise:
+   - Infer from conversation context if the user mentioned a change
+   - Auto-select if only one active change exists
+   - If ambiguous, run `openspec list --json` to get available changes and use the **AskUserQuestion tool** to let the user select
+
+   Always announce: "Using change: <name>" and how to override (e.g., `/opsx:apply <other>`).
+
+2. **Check status to understand the schema**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used (e.g., "spec-driven")
+   - Which artifact contains the tasks (typically "tasks" for spec-driven, check status for others)
+
+3. **Get apply instructions**
+
+   ```bash
+   openspec instructions apply --change "<name>" --json
+   ```
+
+   This returns:
+   - Context file paths (varies by schema - could be proposal/specs/design/tasks or spec/tests/implementation/docs)
+   - Progress (total, complete, remaining)
+   - Task list with status
+   - Dynamic instruction based on current state
+
+   **Handle states:**
+   - If `state: "blocked"` (missing artifacts): show message, suggest using openspec-continue-change
+   - If `state: "all_done"`: congratulate, suggest archive
+   - Otherwise: proceed to implementation
+
+4. **Read context files**
+
+   Read the files listed in `contextFiles` from the apply instructions output.
+   The files depend on the schema being used:
+   - **spec-driven**: proposal, specs, design, tasks
+   - Other schemas: follow the contextFiles from CLI output
+
+5. **Show current progress**
+
+   Display:
+   - Schema being used
+   - Progress: "N/M tasks complete"
+   - Remaining tasks overview
+   - Dynamic instruction from CLI
+
+6. **Implement tasks (loop until done or blocked)**
+
+   For each pending task:
+   - Show which task is being worked on
+   - Make the code changes required
+   - Keep changes minimal and focused
+   - Mark task complete in the tasks file: `- [ ]` → `- [x]`
+   - Continue to next task
+
+   **Pause if:**
+   - Task is unclear → ask for clarification
+   - Implementation reveals a design issue → suggest updating artifacts
+   - Error or blocker encountered → report and wait for guidance
+   - User interrupts
+
+7. **On completion or pause, show status**
+
+   Display:
+   - Tasks completed this session
+   - Overall progress: "N/M tasks complete"
+   - If all done: suggest archive
+   - If paused: explain why and wait for guidance
+
+**Output During Implementation**
+
+```
+## Implementing: <change-name> (schema: <schema-name>)
+
+Working on task 3/7: <task description>
+[...implementation happening...]
+✓ Task complete
+
+Working on task 4/7: <task description>
+[...implementation happening...]
+✓ Task complete
+```
+
+**Output On Completion**
+
+```
+## Implementation Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 7/7 tasks complete ✓
+
+### Completed This Session
+- [x] Task 1
+- [x] Task 2
+...
+
+All tasks complete! Ready to archive this change.
+```
+
+**Output On Pause (Issue Encountered)**
+
+```
+## Implementation Paused
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Progress:** 4/7 tasks complete
+
+### Issue Encountered
+<description of the issue>
+
+**Options:**
+1. <option 1>
+2. <option 2>
+3. Other approach
+
+What would you like to do?
+```
+
+**Guardrails**
+- Keep going through tasks until done or blocked
+- Always read context files before starting (from the apply instructions output)
+- If task is ambiguous, pause and ask before implementing
+- If implementation reveals issues, pause and suggest artifact updates
+- Keep code changes minimal and scoped to each task
+- Update task checkbox immediately after completing each task
+- Pause on errors, blockers, or unclear requirements - don't guess
+- Use contextFiles from CLI output, don't assume specific file names
+
+**Fluid Workflow Integration**
+
+This skill supports the "actions on a change" model:
+
+- **Can be invoked anytime**: Before all artifacts are done (if tasks exist), after partial implementation, interleaved with other actions
+- **Allows artifact updates**: If implementation reveals design issues, suggest updating artifacts - not phase-locked, work fluidly

--- a/.github/skills/openspec-archive-change/SKILL.md
+++ b/.github/skills/openspec-archive-change/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: openspec-archive-change
+description: Archive a completed change in the experimental workflow. Use when the user wants to finalize and archive a change after implementation is complete.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Archive a completed change in the experimental workflow.
+
+**Input**: Optionally specify a change name. If omitted, check if it can be inferred from conversation context. If vague or ambiguous you MUST prompt for available changes.
+
+**Steps**
+
+1. **If no change name provided, prompt for selection**
+
+   Run `openspec list --json` to get available changes. Use the **AskUserQuestion tool** to let the user select.
+
+   Show only active changes (not already archived).
+   Include the schema used for each change if available.
+
+   **IMPORTANT**: Do NOT guess or auto-select a change. Always let the user choose.
+
+2. **Check artifact completion status**
+
+   Run `openspec status --change "<name>" --json` to check artifact completion.
+
+   Parse the JSON to understand:
+   - `schemaName`: The workflow being used
+   - `artifacts`: List of artifacts with their status (`done` or other)
+
+   **If any artifacts are not `done`:**
+   - Display warning listing incomplete artifacts
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+3. **Check task completion status**
+
+   Read the tasks file (typically `tasks.md`) to check for incomplete tasks.
+
+   Count tasks marked with `- [ ]` (incomplete) vs `- [x]` (complete).
+
+   **If incomplete tasks found:**
+   - Display warning showing count of incomplete tasks
+   - Use **AskUserQuestion tool** to confirm user wants to proceed
+   - Proceed if user confirms
+
+   **If no tasks file exists:** Proceed without task-related warning.
+
+4. **Assess delta spec sync state**
+
+   Check for delta specs at `openspec/changes/<name>/specs/`. If none exist, proceed without sync prompt.
+
+   **If delta specs exist:**
+   - Compare each delta spec with its corresponding main spec at `openspec/specs/<capability>/spec.md`
+   - Determine what changes would be applied (adds, modifications, removals, renames)
+   - Show a combined summary before prompting
+
+   **Prompt options:**
+   - If changes needed: "Sync now (recommended)", "Archive without syncing"
+   - If already synced: "Archive now", "Sync anyway", "Cancel"
+
+   If user chooses sync, use Task tool (subagent_type: "general-purpose", prompt: "Use Skill tool to invoke openspec-sync-specs for change '<name>'. Delta spec analysis: <include the analyzed delta spec summary>"). Proceed to archive regardless of choice.
+
+5. **Perform the archive**
+
+   Create the archive directory if it doesn't exist:
+   ```bash
+   mkdir -p openspec/changes/archive
+   ```
+
+   Generate target name using current date: `YYYY-MM-DD-<change-name>`
+
+   **Check if target already exists:**
+   - If yes: Fail with error, suggest renaming existing archive or using different date
+   - If no: Move the change directory to archive
+
+   ```bash
+   mv openspec/changes/<name> openspec/changes/archive/YYYY-MM-DD-<name>
+   ```
+
+6. **Display summary**
+
+   Show archive completion summary including:
+   - Change name
+   - Schema that was used
+   - Archive location
+   - Whether specs were synced (if applicable)
+   - Note about any warnings (incomplete artifacts/tasks)
+
+**Output On Success**
+
+```
+## Archive Complete
+
+**Change:** <change-name>
+**Schema:** <schema-name>
+**Archived to:** openspec/changes/archive/YYYY-MM-DD-<name>/
+**Specs:** ✓ Synced to main specs (or "No delta specs" or "Sync skipped")
+
+All artifacts complete. All tasks complete.
+```
+
+**Guardrails**
+- Always prompt for change selection if not provided
+- Use artifact graph (openspec status --json) for completion checking
+- Don't block archive on warnings - just inform and confirm
+- Preserve .openspec.yaml when moving to archive (it moves with the directory)
+- Show clear summary of what happened
+- If sync is requested, use openspec-sync-specs approach (agent-driven)
+- If delta specs exist, always run the sync assessment and show the combined summary before prompting

--- a/.github/skills/openspec-explore/SKILL.md
+++ b/.github/skills/openspec-explore/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: openspec-explore
+description: Enter explore mode - a thinking partner for exploring ideas, investigating problems, and clarifying requirements. Use when the user wants to think through something before or during a change.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Enter explore mode. Think deeply. Visualize freely. Follow the conversation wherever it goes.
+
+**IMPORTANT: Explore mode is for thinking, not implementing.** You may read files, search code, and investigate the codebase, but you must NEVER write code or implement features. If the user asks you to implement something, remind them to exit explore mode first and create a change proposal. You MAY create OpenSpec artifacts (proposals, designs, specs) if the user asks—that's capturing thinking, not implementing.
+
+**This is a stance, not a workflow.** There are no fixed steps, no required sequence, no mandatory outputs. You're a thinking partner helping the user explore.
+
+---
+
+## The Stance
+
+- **Curious, not prescriptive** - Ask questions that emerge naturally, don't follow a script
+- **Open threads, not interrogations** - Surface multiple interesting directions and let the user follow what resonates. Don't funnel them through a single path of questions.
+- **Visual** - Use ASCII diagrams liberally when they'd help clarify thinking
+- **Adaptive** - Follow interesting threads, pivot when new information emerges
+- **Patient** - Don't rush to conclusions, let the shape of the problem emerge
+- **Grounded** - Explore the actual codebase when relevant, don't just theorize
+
+---
+
+## What You Might Do
+
+Depending on what the user brings, you might:
+
+**Explore the problem space**
+- Ask clarifying questions that emerge from what they said
+- Challenge assumptions
+- Reframe the problem
+- Find analogies
+
+**Investigate the codebase**
+- Map existing architecture relevant to the discussion
+- Find integration points
+- Identify patterns already in use
+- Surface hidden complexity
+
+**Compare options**
+- Brainstorm multiple approaches
+- Build comparison tables
+- Sketch tradeoffs
+- Recommend a path (if asked)
+
+**Visualize**
+```
+┌─────────────────────────────────────────┐
+│     Use ASCII diagrams liberally        │
+├─────────────────────────────────────────┤
+│                                         │
+│   ┌────────┐         ┌────────┐        │
+│   │ State  │────────▶│ State  │        │
+│   │   A    │         │   B    │        │
+│   └────────┘         └────────┘        │
+│                                         │
+│   System diagrams, state machines,      │
+│   data flows, architecture sketches,    │
+│   dependency graphs, comparison tables  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+**Surface risks and unknowns**
+- Identify what could go wrong
+- Find gaps in understanding
+- Suggest spikes or investigations
+
+---
+
+## OpenSpec Awareness
+
+You have full context of the OpenSpec system. Use it naturally, don't force it.
+
+### Check for context
+
+At the start, quickly check what exists:
+```bash
+openspec list --json
+```
+
+This tells you:
+- If there are active changes
+- Their names, schemas, and status
+- What the user might be working on
+
+### When no change exists
+
+Think freely. When insights crystallize, you might offer:
+
+- "This feels solid enough to start a change. Want me to create a proposal?"
+- Or keep exploring - no pressure to formalize
+
+### When a change exists
+
+If the user mentions a change or you detect one is relevant:
+
+1. **Read existing artifacts for context**
+   - `openspec/changes/<name>/proposal.md`
+   - `openspec/changes/<name>/design.md`
+   - `openspec/changes/<name>/tasks.md`
+   - etc.
+
+2. **Reference them naturally in conversation**
+   - "Your design mentions using Redis, but we just realized SQLite fits better..."
+   - "The proposal scopes this to premium users, but we're now thinking everyone..."
+
+3. **Offer to capture when decisions are made**
+
+   | Insight Type | Where to Capture |
+   |--------------|------------------|
+   | New requirement discovered | `specs/<capability>/spec.md` |
+   | Requirement changed | `specs/<capability>/spec.md` |
+   | Design decision made | `design.md` |
+   | Scope changed | `proposal.md` |
+   | New work identified | `tasks.md` |
+   | Assumption invalidated | Relevant artifact |
+
+   Example offers:
+   - "That's a design decision. Capture it in design.md?"
+   - "This is a new requirement. Add it to specs?"
+   - "This changes scope. Update the proposal?"
+
+4. **The user decides** - Offer and move on. Don't pressure. Don't auto-capture.
+
+---
+
+## What You Don't Have To Do
+
+- Follow a script
+- Ask the same questions every time
+- Produce a specific artifact
+- Reach a conclusion
+- Stay on topic if a tangent is valuable
+- Be brief (this is thinking time)
+
+---
+
+## Handling Different Entry Points
+
+**User brings a vague idea:**
+```
+User: I'm thinking about adding real-time collaboration
+
+You: Real-time collab is a big space. Let me think about this...
+
+      COLLABORATION SPECTRUM
+      ════════════════════════════════════════════
+
+      Awareness          Coordination         Sync
+          │                   │                 │
+          ▼                   ▼                 ▼
+      ┌────────┐         ┌────────┐        ┌────────┐
+      │Presence│         │Cursors │        │  CRDT  │
+      │  "3    │         │ Multi  │        │Conflict│
+      │online" │         │ select │        │  free  │
+      └────────┘         └────────┘        └────────┘
+          │                   │                 │
+       trivial            moderate           complex
+
+      Where's your head at?
+```
+
+**User brings a specific problem:**
+```
+User: The auth system is a mess
+
+You: [reads codebase]
+
+     ┌─────────────────────────────────────────────┐
+     │              CURRENT AUTH FLOW              │
+     └─────────────────────────────────────────────┘
+                        │
+          ┌─────────────┼─────────────┐
+          ▼             ▼             ▼
+     ┌─────────┐  ┌─────────┐  ┌─────────┐
+     │ Google  │  │  GitHub │  │  Email  │
+     │  OAuth  │  │  OAuth  │  │  Magic  │
+     └────┬────┘  └────┬────┘  └────┬────┘
+          │             │             │
+          └─────────────┼─────────────┘
+                        ▼
+                  ┌───────────┐
+                  │  Session  │
+                  └─────┬─────┘
+                        │
+                        ▼
+                  ┌───────────┐
+                  │   Perms   │
+                  └───────────┘
+
+     I see three tangles. Which one's burning?
+```
+
+**User is stuck mid-implementation:**
+```
+User: /opsx:explore add-auth-system
+      The OAuth integration is more complex than expected
+
+You: [reads change artifacts]
+
+     You're on task 4: "Implement OAuth flow"
+
+     Let me trace what's involved...
+
+     [draws diagram, explores options, suggests paths]
+
+     Want to update the design to reflect this?
+     Or add a spike task to investigate?
+```
+
+**User wants to compare options:**
+```
+User: Should we use Postgres or SQLite?
+
+You: Generic answer is boring. What's the context?
+
+User: A CLI tool that tracks local dev environments
+
+You: That changes everything.
+
+     ┌─────────────────────────────────────────────────┐
+     │         CLI TOOL DATA STORAGE                  │
+     └─────────────────────────────────────────────────┘
+
+     Key constraints:
+     • No daemon running
+     • Must work offline
+     • Single user
+
+                  SQLite          Postgres
+     Deployment   embedded ✓      needs server ✗
+     Offline      yes ✓           no ✗
+     Single file  yes ✓           no ✗
+
+     SQLite. Not even close.
+
+     Unless... is there a sync component?
+```
+
+---
+
+## Ending Discovery
+
+There's no required ending. Discovery might:
+
+- **Flow into a proposal**: "Ready to start? I can create a change proposal."
+- **Result in artifact updates**: "Updated design.md with these decisions"
+- **Just provide clarity**: User has what they need, moves on
+- **Continue later**: "We can pick this up anytime"
+
+When it feels like things are crystallizing, you might summarize:
+
+```
+## What We Figured Out
+
+**The problem**: [crystallized understanding]
+
+**The approach**: [if one emerged]
+
+**Open questions**: [if any remain]
+
+**Next steps** (if ready):
+- Create a change proposal
+- Keep exploring: just keep talking
+```
+
+But this summary is optional. Sometimes the thinking IS the value.
+
+---
+
+## Guardrails
+
+- **Don't implement** - Never write code or implement features. Creating OpenSpec artifacts is fine, writing application code is not.
+- **Don't fake understanding** - If something is unclear, dig deeper
+- **Don't rush** - Discovery is thinking time, not task time
+- **Don't force structure** - Let patterns emerge naturally
+- **Don't auto-capture** - Offer to save insights, don't just do it
+- **Do visualize** - A good diagram is worth many paragraphs
+- **Do explore the codebase** - Ground discussions in reality
+- **Do question assumptions** - Including the user's and your own

--- a/.github/skills/openspec-propose/SKILL.md
+++ b/.github/skills/openspec-propose/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: openspec-propose
+description: Propose a new change with all artifacts generated in one step. Use when the user wants to quickly describe what they want to build and get a complete proposal with design, specs, and tasks ready for implementation.
+license: MIT
+compatibility: Requires openspec CLI.
+metadata:
+  author: openspec
+  version: "1.0"
+  generatedBy: "1.2.0"
+---
+
+Propose a new change - create the change and generate all artifacts in one step.
+
+I'll create a change with artifacts:
+- proposal.md (what & why)
+- design.md (how)
+- tasks.md (implementation steps)
+
+When ready to implement, run /opsx:apply
+
+---
+
+**Input**: The user's request should include a change name (kebab-case) OR a description of what they want to build.
+
+**Steps**
+
+1. **If no clear input provided, ask what they want to build**
+
+   Use the **AskUserQuestion tool** (open-ended, no preset options) to ask:
+   > "What change do you want to work on? Describe what you want to build or fix."
+
+   From their description, derive a kebab-case name (e.g., "add user authentication" → `add-user-auth`).
+
+   **IMPORTANT**: Do NOT proceed without understanding what the user wants to build.
+
+2. **Create the change directory**
+   ```bash
+   openspec new change "<name>"
+   ```
+   This creates a scaffolded change at `openspec/changes/<name>/` with `.openspec.yaml`.
+
+3. **Get the artifact build order**
+   ```bash
+   openspec status --change "<name>" --json
+   ```
+   Parse the JSON to get:
+   - `applyRequires`: array of artifact IDs needed before implementation (e.g., `["tasks"]`)
+   - `artifacts`: list of all artifacts with their status and dependencies
+
+4. **Create artifacts in sequence until apply-ready**
+
+   Use the **TodoWrite tool** to track progress through the artifacts.
+
+   Loop through artifacts in dependency order (artifacts with no pending dependencies first):
+
+   a. **For each artifact that is `ready` (dependencies satisfied)**:
+      - Get instructions:
+        ```bash
+        openspec instructions <artifact-id> --change "<name>" --json
+        ```
+      - The instructions JSON includes:
+        - `context`: Project background (constraints for you - do NOT include in output)
+        - `rules`: Artifact-specific rules (constraints for you - do NOT include in output)
+        - `template`: The structure to use for your output file
+        - `instruction`: Schema-specific guidance for this artifact type
+        - `outputPath`: Where to write the artifact
+        - `dependencies`: Completed artifacts to read for context
+      - Read any completed dependency files for context
+      - Create the artifact file using `template` as the structure
+      - Apply `context` and `rules` as constraints - but do NOT copy them into the file
+      - Show brief progress: "Created <artifact-id>"
+
+   b. **Continue until all `applyRequires` artifacts are complete**
+      - After creating each artifact, re-run `openspec status --change "<name>" --json`
+      - Check if every artifact ID in `applyRequires` has `status: "done"` in the artifacts array
+      - Stop when all `applyRequires` artifacts are done
+
+   c. **If an artifact requires user input** (unclear context):
+      - Use **AskUserQuestion tool** to clarify
+      - Then continue with creation
+
+5. **Show final status**
+   ```bash
+   openspec status --change "<name>"
+   ```
+
+**Output**
+
+After completing all artifacts, summarize:
+- Change name and location
+- List of artifacts created with brief descriptions
+- What's ready: "All artifacts created! Ready for implementation."
+- Prompt: "Run `/opsx:apply` or ask me to implement to start working on the tasks."
+
+**Artifact Creation Guidelines**
+
+- Follow the `instruction` field from `openspec instructions` for each artifact type
+- The schema defines what each artifact should contain - follow it
+- Read dependency artifacts for context before creating new ones
+- Use `template` as the structure for your output file - fill in its sections
+- **IMPORTANT**: `context` and `rules` are constraints for YOU, not content for the file
+  - Do NOT copy `<context>`, `<rules>`, `<project_context>` blocks into the artifact
+  - These guide what you write, but should never appear in the output
+
+**Guardrails**
+- Create ALL artifacts needed for implementation (as defined by schema's `apply.requires`)
+- Always read dependency artifacts before creating a new one
+- If context is critically unclear, ask the user - but prefer making reasonable decisions to keep momentum
+- If a change with that name already exists, ask if user wants to continue it or create a new one
+- Verify each artifact file exists after writing before proceeding to next

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -11,25 +11,36 @@ bulldoze priorities.
 
 ## NOW (v0.1.0-alpha shipping path)
 
-### 1. Bootstrap projects
+> **Active OpenSpec change:** `v0.1-locked-interpretations` — captures
+> the eight planning-interview decisions (see
+> `openspec/changes/v0.1-locked-interpretations/`). Archived on PR 1
+> merge.
 
-- [ ] Create `src/ShellSyntaxTree/ShellSyntaxTree.csproj` (library,
-      multi-target `netstandard2.0;net8.0`)
-- [ ] Create `tests/ShellSyntaxTree.Tests/ShellSyntaxTree.Tests.csproj`
+### 1. Bootstrap projects (PR 1, in progress)
+
+- [x] Create `src/ShellSyntaxTree/ShellSyntaxTree.csproj` (library,
+      multi-target `netstandard2.0;net8.0`, `IsAotCompatible=true`)
+- [x] Create `tests/ShellSyntaxTree.Tests/ShellSyntaxTree.Tests.csproj`
       (xunit, target `net10.0`)
-- [ ] Add both to `ShellSyntaxTree.slnx`
-- [ ] `dotnet build` clean, `dotnet test` clean (zero tests OK)
+- [x] Add both to `ShellSyntaxTree.slnx`
+- [x] `dotnet build -c Release` clean, `dotnet test -c Release` clean
+      (18 PublicApiSnapshotTests passing)
 
-### 2. Public API skeleton (lock surface first)
+### 2. Public API skeleton (lock surface first) — PR 1, in progress
 
-- [ ] Implement public types from `SPEC.md` §2 verbatim:
+- [x] Implement public types from `SPEC.md` §2/§3 verbatim:
       `IShellParser`, `BashParser`, `BashParserOptions`, `ParsedCommand`,
       `Clause`, `VerbChain`, `Arg`, `Redirect`, and the three enums
-- [ ] `BashParser.Parse` throws `NotImplementedException` for now
-- [ ] `Arg` includes `IsCwdAttribution` per SPEC §9
-- [ ] Public API snapshot test (a single test that asserts each public
-      member exists with the expected shape — fast feedback when the
-      surface drifts)
+- [x] `BashParser.Parse` throws `NotImplementedException`; `Parse(null)`
+      throws `ArgumentNullException`
+- [x] `Arg` includes `IsCwdAttribution` per SPEC §9 (locked interpretation #1)
+- [x] PublicApiSnapshotTests reflection-based `[Fact]`s assert the surface
+      shape with strict namespace closure
+- [x] Bootstrap OpenSpec scaffolding (config, root spec stub, change
+      proposal/design/tasks/specs delta for `v0.1-locked-interpretations`)
+- [x] Copy OpenSpec authoring skills into `.claude/skills/`
+- [x] Update SPEC.md §3 to enumerate `Arg.IsCwdAttribution`; cross-tfm
+      note on `VerbChain.Joined`
 
 ### 3. BashLexer (SPEC §5)
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -209,9 +209,14 @@ public sealed record VerbChain
     public IReadOnlyList<string> Tokens { get; init; } = [];
 
     /// <summary>Convenience: tokens joined with spaces.</summary>
-    public string Joined => string.Join(' ', Tokens);
+    public string Joined => string.Join(" ", Tokens);
 }
 ```
+
+> **Note:** The single-space form `string.Join(" ", …)` is used (not the
+> `char` overload `string.Join(' ', …)`) so the implementation compiles
+> on both `netstandard2.0` and `net8.0`. The `char` overload is net5+
+> only.
 
 ### `Arg`
 
@@ -246,6 +251,14 @@ public sealed record Arg
     /// don't reapply per-verb rules.
     /// </summary>
     public bool IsPath { get; init; }
+
+    /// <summary>
+    /// True when this Arg is a synthetic attribution arg representing
+    /// the working directory inherited from a preceding `cd`/`chdir`
+    /// clause in the same compound. Default false. See §9 for
+    /// propagation semantics.
+    /// </summary>
+    public bool IsCwdAttribution { get; init; }
 }
 
 public enum ArgKind

--- a/ShellSyntaxTree.slnx
+++ b/ShellSyntaxTree.slnx
@@ -15,4 +15,10 @@
     <File Path="IMPLEMENTATION_PLAN.md" />
     <File Path="SPEC.md" />
   </Folder>
+  <Folder Name="/src/">
+    <Project Path="src/ShellSyntaxTree/ShellSyntaxTree.csproj" />
+  </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/ShellSyntaxTree.Tests/ShellSyntaxTree.Tests.csproj" />
+  </Folder>
 </Solution>

--- a/TOOLING.md
+++ b/TOOLING.md
@@ -118,6 +118,26 @@ Available via the `Agent` tool:
 | `/security-review` | Targeted security review — relevant for this library |
 | `/generate-image` | HCTI-backed image generation; used to mint the NuGet package icon |
 
+### OpenSpec authoring skills
+
+Light Path-C OpenSpec adoption: change proposals capture decision
+rationale; specs decompose to per-capability files in v0.2 work. Skills
+copied from `petabridge/sdkbin` and refreshed by `openspec init`.
+
+| Skill | When to use |
+|---|---|
+| `/opsx:propose` | Create a new change with proposal + design + tasks + specs deltas in one pass |
+| `/opsx:explore` | Think-partner mode for investigating a problem before drafting a change |
+| `/opsx:apply` | Implement the tasks of an active change |
+| `/opsx:archive` | Archive a completed change (move to `openspec/changes/archive/<date>-<name>/`) |
+| `openspec-new-change`, `openspec-continue-change`, `openspec-ff-change`, `openspec-verify-change`, `openspec-bulk-archive-change`, `openspec-sync-specs`, `openspec-onboard` | Granular flows for the same workflow; `propose`/`apply`/`archive` are usually enough |
+
+OpenSpec CLI (`openspec init`, `openspec list`, `openspec validate
+<change>`, `openspec archive <change>`) is installed at the user level;
+verify with `openspec --version`. Skill drift between this repo and
+upstream sdkbin: acceptable in v0.1; tracked as a NEXT-bucket task
+(periodic sync or marketplace publication).
+
 ## Image Generation (HCTI)
 
 Used to mint the package icon. Output goes to `assets/icon.png` (or similar)

--- a/openspec/changes/v0.1-locked-interpretations/design.md
+++ b/openspec/changes/v0.1-locked-interpretations/design.md
@@ -1,0 +1,192 @@
+# Design — v0.1 locked interpretations
+
+## Context
+
+ShellSyntaxTree's v0.1 implementation has to make a handful of design
+choices that ripple through every PR in the shipping plan. This document
+captures the cross-cutting decisions so future agents (or this one in
+v0.2) don't re-derive them by guesswork.
+
+The constraints we're designing under:
+
+- **Public API is locked** by SPEC §2/§3. Any changes to the surface bump
+  the version per SPEC §15. Locked-interpretation #1 (`IsCwdAttribution`)
+  is the sole additive surface change in v0.1.0-alpha; everything else
+  in this change is internal or specification-text-only.
+- **Multi-shell ready.** `IShellParser` is the public seam. v0.2 brings
+  `PwshParser : IShellParser`; v0.3 may bring cmd. Internal abstractions
+  must scale without forcing a from-scratch rewrite.
+- **AOT / trim friendly.** No `Reflection.Emit`, no dynamic loading, no
+  source generators in v0.1, no native dependencies. `IsAotCompatible=true`
+  set on the library project so the compiler warns on drift.
+- **Single maintainer; autonomous PR loop.** Decisions need to be defensible
+  without a synchronous review channel.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Resolve the eight SPEC ambiguities so the implementation has crisp
+  answers every time the question recurs.
+- Establish the shared internal abstractions (resolver, opaque-region
+  scanner) in a way that v0.2 PowerShell can plug into without redesign.
+- Keep the public surface change in v0.1.0-alpha to one additive bool
+  field (`Arg.IsCwdAttribution`).
+
+**Non-Goals:**
+
+- Full capability-spec decomposition under `openspec/specs/`. Path C from
+  the planning interview defers that work until v0.2 forces it. v0.1 ships
+  with one root `shellsyntaxtree-v0.1` spec stub deferring to `SPEC.md`.
+- An `IShellGrammar` abstraction that decouples lexer/parser/tables. The
+  second implementation (PowerShell) is the right driver for that; abstract
+  prematurely and we'll get the seam wrong.
+- Source-mapping (line/column on AST nodes). SPEC §18 explicitly defers
+  this; not relevant for security gates.
+- Performance optimization beyond "fast enough" (~1ms typical). SPEC §1
+  defers this.
+
+## Decisions
+
+### Decision 1: `IsCwdAttribution` lives on `Arg`, not `Clause`
+
+The careless-consumer failure mode dictates this. Under "field on `Arg`,"
+the consumer naively iterating `clause.Args` looking for `IsPath = true`
+sees the synthetic cwd-attribution arg automatically. Worst case: prompts
+once extra. Under "side-channel `Clause.AttributedCwd`," the careless
+consumer forgets to read the side-channel and a `grep` running in `/etc`
+slips past a hard-deny. The asymmetry between "annoying" and "unsafe"
+picks the field-on-`Arg` design.
+
+### Decision 2: Tiered handling of "evaluate-something-else-first" constructs
+
+Bash has four such constructs and they don't all deserve the same
+treatment.
+
+| Construct | Decision | Why |
+|---|---|---|
+| `$(cmd)` | Token-level `DynamicSkip` | Common in agent output; surrounding clauses must stay parseable so hard-deny rules can fire on visible parts |
+| `` `cmd` `` | Token-level `DynamicSkip` | Same as above; older syntax for the same construct |
+| `$((expr))` | `ParsedCommand.IsUnparseable` | SPEC §1 explicit non-goal |
+| `${var//pat/repl}` | `ParsedCommand.IsUnparseable` | SPEC §1 explicit non-goal |
+
+The boundary tracking for `$()` and backticks goes in a shared
+`Internal/Lexing/OpaqueRegionScanner.cs` so PowerShell's `$( … )` (and
+`@( … )` for sub-expression evaluation) can reuse the same machinery in
+v0.2.
+
+### Decision 3: `ArgKind` carries directory-extraction strategy
+
+The locked interpretation for Glob vs DynamicSkip turns `ArgKind` from
+"what kind of token is this?" into "how does the consumer extract a
+directory from this arg?":
+
+| Kind | How consumer gets a directory |
+|---|---|
+| `Literal` | `Path.GetDirectoryName(arg.Resolved)` |
+| `Tilde` | `Path.GetDirectoryName(arg.Resolved)` (after `~` expansion) |
+| `EnvVar` | `Path.GetDirectoryName(arg.Resolved)` (only `$HOME` ever lands here) |
+| `Glob` | `Path.GetDirectoryName(arg.Raw)` (covering-directory heuristic) |
+| `DynamicSkip` | No directory available; consumer prompts |
+
+This is the consumer-facing semantics that explains why Glob and
+DynamicSkip can't be collapsed.
+
+### Decision 4: `ParsedCommand.IsUnparseable` is the only "give up" signal
+
+`Clause.IsUnparseable` is not added in v0.1. Failure cases that SPEC §10
+or §11 describe at "deepest clause" granularity get translated to the
+outer `ParsedCommand.IsUnparseable = true` with a precise reason. Clauses
+parsed up to the failure point may still appear in `Clauses` for diagnostic
+UI value, but consumers safe-fail on the outer flag.
+
+This keeps the surface minimal. If future use cases (e.g., partially-bad
+heredoc body, malformed redirect on one clause) want clause-level signals,
+add `Clause.IsUnparseable` then with concrete drivers.
+
+### Decision 5: Internal layout (pluggable grammar without full abstraction)
+
+```
+src/ShellSyntaxTree/
+├── *.cs                           ← public types (locked by SPEC §2/§3)
+├── Internal/
+│   ├── Lexing/                    ← shared (grammar-agnostic)
+│   │   └── OpaqueRegionScanner.cs ← used by Bash for $(...); pwsh later
+│   ├── Resolving/                 ← shared (grammar-agnostic)
+│   │   └── BashResolver.cs        ← (named "Bash" in v0.1; rename + share at v0.2)
+│   └── Bash/
+│       ├── Lexing/
+│       │   ├── BashLexer.cs
+│       │   ├── BashToken.cs
+│       │   └── BashTokenKind.cs
+│       ├── Parsing/
+│       │   ├── BashCommandParser.cs
+│       │   └── CdAttributionContext.cs
+│       └── Verbs/
+│           ├── BashVerbs.cs       ← BashArity, CwdVerbs, FileVerbs, FlagsWithValue
+│           └── BashPerVerbRules.cs
+└── Properties/
+    └── IsExternalInit.cs          ← internal polyfill for netstandard2.0
+```
+
+Rules:
+
+- Public types exported from `ShellSyntaxTree` namespace; everything else
+  is `internal`.
+- `Internal/Bash/` owns bash-specific code. `Internal/Pwsh/` will own
+  pwsh-specific code symmetrically in v0.2.
+- `Internal/Lexing/` and `Internal/Resolving/` host the shared
+  abstractions that v0.2 will lean on. In v0.1 they have one user (bash);
+  v0.2 adds a second user without renaming.
+- The public `BashParser : IShellParser` is a thin façade that wires
+  `BashLexer` + `BashCommandParser` + `BashResolver` together. v0.2's
+  `PwshParser` will be the symmetric thin façade.
+
+Resisted in v0.1: extracting an `IShellGrammar` interface that defines
+"what a grammar provides" (lexer, verb tables, per-verb rules). Premature
+without a second implementation. The folder discipline + locked AST is
+enough governance.
+
+### Decision 6: `pushd`/`popd` parse but don't propagate
+
+The directory-stack semantics needed to model `pushd`/`popd` correctly
+(option C in the planning interview) are real work — `~50–80 LOC of state
+tracking + subshell-aware push/pop + ~10 corpus entries`. For a construct
+that's *rare* in single-command LLM emissions, we accept the documented
+limitation in v0.1: `pushd /target` parses (its first non-flag arg is
+path-classified, hard-deny rules fire), but no synthetic IsCwdAttribution
+arg gets appended to subsequent clauses. The GitHub issue for the option-C
+upgrade tracks this as v0.1.x or v0.2.0 work.
+
+### Decision 7: `cd $VAR` propagates a DynamicSkip attribution arg
+
+Even when the cd target is dynamic, subsequent clauses get a synthetic
+`Arg{ IsCwdAttribution = true, Kind = DynamicSkip, IsPath = false }`. This
+preserves the "this clause's cwd context is unknown" signal that
+sophisticated consumers can elevate to user-prompt, while naive
+iterate-paths consumers see nothing different (since `IsPath = false`).
+
+The alternative — appending no arg at all — would make `cd $VAR && cmd`
+indistinguishable from `cmd` (no preceding cd) at the consumer level.
+Silent signal loss is exactly what the locked-interpretations table avoids.
+
+### Decision 8: `tar` and `docker -v` are documented v0.1 limitations
+
+Both fall through to the default rule (all non-flag positionals → paths
+for tar; single literal arg for `docker -v`). Real consumer pain probably
+forces an upgrade path within v0.1.x, but speculative work belongs in
+issues, not in the alpha.
+
+## Failure modes and recovery
+
+The locked interpretations all converge on the same recovery posture:
+
+- Anything we can't model cleanly → `DynamicSkip` arg or
+  `ParsedCommand.IsUnparseable = true`.
+- Consumers route safe-fail per SPEC §11 (prompt user; offer Once / Deny
+  only; no persistent grants on shapes the parser can't model).
+- The PII audit (SPEC §14, implemented in PR 6) is the safety net for the
+  corpus; the locked interpretations don't change its scope.
+
+No interpretation chooses a "best-effort guess" path. The constitution's
+discipline is preserved: when in doubt, mark and let the consumer decide.

--- a/openspec/changes/v0.1-locked-interpretations/proposal.md
+++ b/openspec/changes/v0.1-locked-interpretations/proposal.md
@@ -1,0 +1,251 @@
+# v0.1 locked interpretations
+
+## Why
+
+`SPEC.md` is the locked v0.1 contract for ShellSyntaxTree, but a 30-minute
+planning interview surfaced eight clauses where the SPEC was either silent,
+abbreviated, or internally contradictory. Resolving them in code without
+capturing the rationale would create unprovenanced "magic" that future
+agents (or this one, in v0.2) would have to re-derive.
+
+This change records the eight resolutions, the trade-offs considered, and
+the alternatives rejected. It also bootstraps the OpenSpec change-proposal
+workflow for ShellSyntaxTree at the lightest level (Path C — light adoption
+per the planning notes), aligning governance with netclaw's process without
+forcing a full capability-spec decomposition until v0.2 PowerShell drives
+that refactor.
+
+## What Changes
+
+### 1. `Arg.IsCwdAttribution` becomes part of the public API
+
+SPEC §9 mandates a flag on synthetic cwd-attribution args but §2's record
+enumeration didn't list it. Without the flag, consumers can't distinguish
+"a path the user typed" from "a path we inferred from a preceding `cd`."
+
+**Decision:** Add `public bool IsCwdAttribution { get; init; }` to `Arg`
+(default `false`). Additive to §2's locked surface; consumers ignore it by
+default.
+
+**Rejected alternatives:**
+
+- **Side-channel `Clause.AttributedCwd: string?`.** Cleaner separation, but
+  the safety failure mode is *under-restriction* (a careless consumer
+  forgets the side-channel and misses the cwd path). Choosing a default
+  that prompts-too-often beats one that silently allows.
+- **Both fields.** Doubles the source of truth without a clear winner.
+
+### 2. Command substitution + arithmetic + complex param expansion
+
+SPEC §1 lists arithmetic and `${var//pat/repl}` as non-goals. SPEC §11's
+`IsUnparseable` triggers do **not** include `$()` or backticks — that
+silence is either a deliberate gap or an oversight.
+
+**Decision:** Three rules, applied uniformly:
+
+- `$(cmd)` and backtick `` `cmd` `` → the substitution is collapsed into a
+  single `Arg{ Kind = DynamicSkip, IsPath = false }` token. The rest of the
+  clause parses normally so hard-deny rules can still fire on visible parts.
+- `$((expr))` → `ParsedCommand.IsUnparseable = true` (matches §1 non-goals).
+- `${var//pat/repl}` → `ParsedCommand.IsUnparseable = true` (matches §1).
+
+Boundary tracking for `$()` lives in a shared `OpaqueRegionScanner` so the
+same machinery serves PowerShell's `$( … )` in v0.2.
+
+**Rejected alternatives:**
+
+- **All four → `IsUnparseable`.** Simpler but routes routine LLM commands
+  (`cd $(git rev-parse --show-toplevel)`, `kill $(pgrep nginx)`) to user
+  prompt instead of letting hard-deny rules auto-decide on the surrounding
+  structure. Loses the `rm /etc/important && cmd $(echo extra)` case where
+  the dangerous clause is auto-denyable.
+- **Token-level skip for all four.** Pretends arithmetic and complex
+  param expansion are parseable when SPEC §1 explicitly says they aren't.
+
+### 3. Glob vs `DynamicSkip` precedence in path-arg slots
+
+SPEC §8 step 4 says glob tokens get `Kind = Glob, Resolved = null`. Step 6
+says tokens get `DynamicSkip` "when … contains glob metachars AND the
+resolver was asked for an absolute resolution." These read as overlapping.
+
+**Decision:** Different signals to the consumer.
+
+- Glob in a path-arg slot → `Kind = Glob, IsPath = true, Resolved = null`.
+  Consumer can apply the SPEC §8 covering-directory heuristic
+  (`Path.GetDirectoryName(arg.Raw)`) to extract `/tmp` from `/tmp/*.bak`.
+- Unresolved env var (other than `$HOME`) or resolver-throws →
+  `Kind = DynamicSkip, IsPath = false, Resolved = null`. No useful directory
+  signal; consumer routes to safe-fail prompt.
+
+Matches the `rm $UNRESOLVED/foo` example in SPEC §12 verbatim, and adds the
+symmetric rule for globs that the SPEC didn't write out.
+
+**Rejected alternatives:**
+
+- **Uniform `DynamicSkip`.** Simpler but loses the covering-directory
+  signal — the consumer can't auto-allow `rm /tmp/*.bak` even when `/tmp`
+  is in their allowlist.
+- **Glob with `IsPath = false`.** Hides globs from the default
+  iterate-paths loop; failure mode is "miss a `rm /etc/*` because the
+  iteration never saw the token." Unsafe by SPEC's safety bias.
+
+### 4. `bash -c` recursion overflow site
+
+SPEC §10 says "mark the deepest clause as `IsUnparseable = true`" but
+`Clause` has no `IsUnparseable` field — only `ParsedCommand` does.
+
+**Decision:** When `bash -c` nesting exceeds depth 5, set
+`ParsedCommand.IsUnparseable = true` with reason `"bash -c recursion depth
+exceeded (>5)"`. Clauses parsed up to depth 5 may still appear in `Clauses`
+for diagnostic value, but consumers safe-fail per §11. No
+`Clause.IsUnparseable` field added in v0.1.
+
+**Rejected alternatives:**
+
+- **Add `Clause.IsUnparseable`.** Would let parser surface partial
+  failures, but expands the public surface for one (rare, hostile-input)
+  use case. Defer until a real second use case asks for it.
+- **Silent truncation.** Drops information on hostile input — exactly what
+  safe-fail discipline is designed to prevent.
+
+### 5. `pushd` / `popd` attribution
+
+SPEC §6.2 lists `pushd` / `popd` as `CwdVerbs`; SPEC §9's attribution rules
+are written in terms of `cd`. The `pushd` / `popd` semantics genuinely need
+a directory stack to model correctly.
+
+**Decision:** Only `cd` and `chdir` propagate attribution in v0.1. `pushd`
+and `popd` parse as CwdVerbs (their first non-flag positional is
+path-classified, so a hard-deny on `/etc/*` still fires for `pushd /etc`)
+but they don't propagate. A subsequent clause after `pushd /target` gets
+no synthetic IsCwdAttribution arg.
+
+A GitHub issue is filed for the option-C upgrade ("model directory stack
+properly") — likely v0.1.x or v0.2.0 with PowerShell, where Push-Location
+is used heavily.
+
+**Rejected alternatives:**
+
+- **Treat `pushd` like `cd`; clear attribution on `popd`.** Handles the
+  single-level case but breaks on stacked use — `cmd2` after a balancing
+  `popd` should inherit the prior `pushd`'s target, but option-B clears
+  attribution. Worse than honest "no attribution" because option-B *claims*
+  to track state and gets it wrong.
+- **Model the stack now.** Correct but ~50–80 LOC of state tracking +
+  subshell-aware push/pop + ~10 corpus entries. Speculative work for a
+  rare-in-LLM-output construct. Deferred to v0.1.x once dogfood corpus
+  surfaces real `pushd` / `popd` usage, or to v0.2 when PowerShell's
+  Push-Location forces the issue.
+
+### 6. `cd $VAR && cmd` propagation
+
+SPEC §9 covers `cd /literal && cmd` cleanly but is silent on what happens
+when the cd target is `DynamicSkip`.
+
+**Decision:** Each subsequent clause gets a synthetic
+`Arg{ IsCwdAttribution = true, Kind = DynamicSkip, IsPath = false,
+Resolved = null }` appended. Naive consumers (iterating `IsPath = true`)
+don't see it; consumers that specifically check `IsCwdAttribution` can
+detect "this clause's cwd context is unknown" and elevate to
+user-prompt rather than treating it like a default-cwd command.
+
+This preserves the cwd-uncertainty signal that `cd $REPO_DIR &&
+rm -rf node_modules` is legitimately ambiguous about — `$REPO_DIR` could
+be `/etc` for all we statically know.
+
+**Rejected alternatives:**
+
+- **No attribution arg.** Subsequent clauses look identical to "no `cd`
+  in the compound" — the consumer can't distinguish them. Silent loss of
+  signal.
+- **Whole command `IsUnparseable`.** Too coarse; this idiom is
+  pervasive in agent output. Routes everything to user prompt and defeats
+  the gate's auto-decide purpose.
+
+### 7. Corpus location
+
+SPEC §13 prose says `tests/Corpus/bash/*.json`; the inline runner code
+example uses `AppContext.BaseDirectory` (which resolves to the test bin
+output). `CLAUDE.md` and `TOOLING.md` say `tests/ShellSyntaxTree.Tests/Corpus/bash/`.
+
+**Decision:** Canonical corpus location is
+`tests/ShellSyntaxTree.Tests/Corpus/bash/*.json`, with `<None Update
+CopyToOutputDirectory="PreserveNewest" />` so the runner reads from
+`AppContext.BaseDirectory` per the §13 example. Aligns with the
+constitution and existing runner code; SPEC §13 prose updated in PR 6 to
+match.
+
+**Rejected alternatives:**
+
+- **Top-level `tests/Corpus/bash/`** — would only matter if a second test
+  project ever consumes the same corpus. Overkill for v0.1.
+- **Embedded resources.** Harder to author and diff in PRs.
+
+### 8. `tar` and `docker -v` handling for v0.1
+
+SPEC §7 says tar's path roles depend on the action flag, and lists
+`docker -v` in `FlagsWithValue` without specifying how to treat the
+colon-joined volume mount.
+
+**Decision:** Default rule for both in v0.1.
+
+- `tar`: all non-flag positionals are paths (no action-flag awareness).
+  Most security gates check "is the archive going somewhere sensitive?"
+  and that question stays answerable.
+- `docker -v "/host:/container"`: a single literal arg with `IsPath = false`.
+  The colon-joined form is structurally different from a plain path and we
+  don't try to split it.
+
+GitHub issues filed for both (action-flag-aware `tar` paths, and `docker
+-v` colon-split with Windows drive-letter handling). Targets: v0.1.x.
+
+**Rejected alternatives:**
+
+- **Implement properly now.** Adds ~half a PR of work to PR 4. Not
+  speculative (real consumer pain), but waits for a corpus entry that
+  surfaces it.
+
+## Capabilities
+
+### New Capabilities
+
+- `shellsyntaxtree-v0.1`: bootstrap capability spec for the v0.1 contract.
+  Initially a stub deferring to root `SPEC.md`; full decomposition into
+  per-section capability specs (`bash-lexer`, `path-resolver`,
+  `verb-tables`, etc.) deferred until v0.2 PowerShell work drives it.
+
+### Modified Capabilities
+
+None. v0.1.0-alpha is the first release.
+
+## Impact
+
+- `src/ShellSyntaxTree/Arg.cs`: new public field `IsCwdAttribution`.
+- `src/ShellSyntaxTree/`: full public API surface bootstrapped to lock
+  SPEC §2/§3 in PR 1 of the v0.1.0-alpha implementation plan.
+- `tests/ShellSyntaxTree.Tests/PublicApiSnapshotTests.cs`: reflection-based
+  snapshot of the locked surface; fails loud on any drift.
+- `SPEC.md` §2/§3 (PR 1), §10 (PR 5), §13 (PR 6), §1/§5/§8/§11 (PRs 2–4):
+  edits applied in same PR as the matching implementation.
+- `openspec/`: scaffolded; this change records v0.1 decisions; subsequent
+  spec edits go through new change proposals.
+- `.claude/skills/openspec-*`: copied from sdkbin so the change-proposal
+  workflow has tooling support.
+
+## Security and operational impact
+
+- **Security defaults bias preserved.** Every interpretation favors the
+  failure mode of "prompt the user when we could allow" over "silently
+  allow." The asymmetry between option A and B in interpretation 3 (Glob
+  vs DynamicSkip) was decided on this exact basis.
+- **No public-API surface mutation beyond the `IsCwdAttribution`
+  addition.** That field is additive and defaults to `false`; consumers
+  ignore it by default.
+- **No native dependencies introduced.** AOT/trim friendliness preserved;
+  `IsAotCompatible=true` set on the library project.
+- **No execution semantics changes** — the parser remains pure analysis.
+  No new code paths touch the filesystem, run subprocesses, or call out to
+  external services.
+- **PII audit unchanged.** Any future corpus entries seeded from dogfood
+  logs still go through the SPEC §14 sanitization workflow, gated by the
+  `[Fact]`-level audit (added in PR 6).

--- a/openspec/changes/v0.1-locked-interpretations/specs/shellsyntaxtree-v0.1/spec.md
+++ b/openspec/changes/v0.1-locked-interpretations/specs/shellsyntaxtree-v0.1/spec.md
@@ -1,0 +1,224 @@
+# shellsyntaxtree-v0.1 — spec delta
+
+## ADDED Requirements
+
+### Requirement: Public API surface mirrors SPEC.md §2 / §3
+
+The library SHALL expose only the public types enumerated in `SPEC.md` §2
+and §3, plus the additive `Arg.IsCwdAttribution: bool` field per locked
+interpretation #1. All other types in the `ShellSyntaxTree` assembly SHALL
+be `internal`. The library SHALL multi-target `netstandard2.0;net8.0` and
+SHALL set `<IsAotCompatible>true</IsAotCompatible>` on the net8.0
+configuration. SourceLink and SymbolPackageFormat=snupkg SHALL be enabled.
+
+#### Scenario: Public API snapshot matches SPEC
+
+- **GIVEN** a freshly built `ShellSyntaxTree.dll`
+- **WHEN** reflection enumerates all `public` types in the assembly
+- **THEN** the set is exactly: `IShellParser`, `BashParser`,
+  `BashParserOptions`, `ParsedCommand`, `Clause`, `VerbChain`, `Arg`,
+  `Redirect`, `ArgKind`, `RedirectDirection`, `CompoundOperator`
+- **AND** every record in that set is `sealed`
+- **AND** every record property uses `init`-only setters
+- **AND** the `Arg` record has the additional `IsCwdAttribution: bool`
+  property (default `false`) beyond the SPEC §2 enumeration
+
+#### Scenario: BashParser.Parse(null) throws ArgumentNullException
+
+- **GIVEN** a `BashParser` instance
+- **WHEN** `Parse(null)` is called
+- **THEN** the call throws `ArgumentNullException`
+
+#### Scenario: BashParser.Parse stub throws NotImplementedException in v0.1.0-alpha
+
+- **GIVEN** a `BashParser` instance and any non-null command string
+- **WHEN** `Parse(command)` is called before PRs 2–5 wire up the lexer,
+  parser, and resolver
+- **THEN** the call throws `NotImplementedException`
+- **AND** the message references the v0.1 implementation plan
+
+### Requirement: Synthetic cwd attribution arg distinguishes inferred paths
+
+The parser SHALL append a synthetic `Arg` with `IsCwdAttribution = true`
+to each clause that follows a `cd` or `chdir` clause within the same
+compound. When the cd target is statically known, the synthetic arg SHALL
+have `Kind = Literal`, `IsPath = true`, and `Resolved` equal to the
+resolved cwd. When the cd target is `Kind = DynamicSkip` (an unresolved env
+var, command substitution, or other dynamic content), the synthetic arg
+SHALL have `Kind = DynamicSkip`, `IsPath = false`, and `Resolved = null`.
+
+#### Scenario: Literal cd propagates resolvable attribution
+
+- **GIVEN** the input `cd /target && cmd`
+- **WHEN** the parser produces the AST
+- **THEN** the second clause's `Args` ends with `Arg{ Raw = "/target",
+  Resolved = "/target", Kind = Literal, IsPath = true,
+  IsCwdAttribution = true }`
+
+#### Scenario: Dynamic cd propagates DynamicSkip attribution
+
+- **GIVEN** the input `cd $REPO_DIR && rm -rf node_modules`
+- **WHEN** the parser produces the AST
+- **THEN** the rm clause's `Args` includes `Arg{ IsCwdAttribution = true,
+  Kind = DynamicSkip, IsPath = false, Resolved = null }`
+- **AND** a naive consumer iterating `arg.IsPath` does not see this synth
+  arg
+- **AND** a consumer specifically checking `arg.IsCwdAttribution` can
+  detect "this clause's cwd context is unknown"
+
+#### Scenario: pushd does not propagate attribution in v0.1
+
+- **GIVEN** the input `pushd /target && cmd`
+- **WHEN** the parser produces the AST
+- **THEN** the cmd clause has no synthetic `IsCwdAttribution` arg
+- **AND** the pushd clause's first non-flag arg is still classified as a
+  path (`/target` has `IsPath = true`) so hard-deny rules can fire on it
+
+### Requirement: Command substitution becomes opaque token; arithmetic and complex param expansion become unparseable
+
+Command substitution `$(cmd)` and backtick `` `cmd` `` SHALL be collapsed
+into a single `Arg` token with `Kind = DynamicSkip`, `IsPath = false`,
+`Resolved = null`. The surrounding clause SHALL parse normally. Boundary
+detection SHALL handle nested quotes, nested substitutions, and escape
+sequences via a shared opaque-region scanner.
+
+Arithmetic expansion `$((expr))` and complex parameter expansion
+`${var//pattern/replacement}` SHALL cause `ParsedCommand.IsUnparseable =
+true` with a reason naming the construct (per SPEC §1 non-goals).
+
+#### Scenario: $() collapses to DynamicSkip arg
+
+- **GIVEN** the input `rm $(find /tmp -name "*.bak")`
+- **WHEN** the parser produces the AST
+- **THEN** the rm clause's args include `Arg{ Raw = "$(find /tmp -name
+  \"*.bak\")", Kind = DynamicSkip, IsPath = false, Resolved = null }`
+- **AND** the rest of the clause (verb, redirects, other args) parses
+  normally
+
+#### Scenario: Backticks behave like $()
+
+- **GIVEN** the input `kill `pgrep nginx``
+- **WHEN** the parser produces the AST
+- **THEN** the kill clause has one `Arg` with `Kind = DynamicSkip`
+  containing the backtick substitution
+
+#### Scenario: $((expr)) marks unparseable
+
+- **GIVEN** the input `echo $((1 + 2))`
+- **WHEN** the parser produces the AST
+- **THEN** `ParsedCommand.IsUnparseable = true`
+- **AND** `ParsedCommand.UnparseableReason` references "arithmetic
+  expansion"
+
+#### Scenario: ${var//pat/repl} marks unparseable
+
+- **GIVEN** the input `echo ${PATH//:/\n}`
+- **WHEN** the parser produces the AST
+- **THEN** `ParsedCommand.IsUnparseable = true`
+- **AND** `ParsedCommand.UnparseableReason` references "complex parameter
+  expansion"
+
+#### Scenario: Compound with a substitution still routes hard-deny on visible clauses
+
+- **GIVEN** the input `cd /repo && rm /etc/important && cmd $(echo extra)`
+- **WHEN** the parser produces the AST
+- **THEN** all three clauses are parseable
+- **AND** the rm clause's `Args` includes `Arg{ Raw = "/etc/important",
+  Resolved = "/etc/important", Kind = Literal, IsPath = true }`
+- **AND** the cmd clause's `Args` includes `Arg{ Kind = DynamicSkip,
+  IsPath = false }` for the `$(echo extra)` portion
+
+### Requirement: Glob and DynamicSkip carry distinct directory-extraction signals
+
+The parser SHALL classify tokens with glob metacharacters (`*`, `?`, `[`)
+in a path-arg slot as `Kind = Glob`, `IsPath = true`, `Resolved = null`.
+The parser SHALL classify tokens with unresolved env-var references
+(other than `$HOME`) or resolver throws in a path-arg slot as
+`Kind = DynamicSkip`, `IsPath = false`, `Resolved = null`.
+
+#### Scenario: Glob carries IsPath=true so consumers see the covering directory
+
+- **GIVEN** the input `rm /tmp/*.bak`
+- **WHEN** the parser produces the AST
+- **THEN** the rm clause has `Arg{ Raw = "/tmp/*.bak", Kind = Glob,
+  IsPath = true, Resolved = null }`
+- **AND** consumers can apply `Path.GetDirectoryName(arg.Raw)` to obtain
+  `/tmp`
+
+#### Scenario: Unresolved env var carries IsPath=false so consumers prompt
+
+- **GIVEN** the input `rm $UNRESOLVED/foo`
+- **WHEN** the parser produces the AST
+- **THEN** the rm clause has `Arg{ Raw = "$UNRESOLVED/foo", Kind =
+  DynamicSkip, IsPath = false, Resolved = null }` (matching SPEC §12 example)
+- **AND** consumers iterating `arg.IsPath` see no path
+- **AND** route to safe-fail prompt
+
+### Requirement: bash -c recursion overflow signals via outer ParsedCommand.IsUnparseable
+
+When `bash -c` (or `sh -c`) chains nest deeper than 5, the parser SHALL
+set the outer `ParsedCommand.IsUnparseable = true` with a reason naming
+"bash -c recursion depth exceeded (>5)". Clauses parsed up to depth 5 MAY
+appear in `Clauses` for diagnostic value. The `Clause` record SHALL NOT
+carry an `IsUnparseable` field in v0.1.
+
+#### Scenario: 6-level bash -c nesting marks outer unparseable
+
+- **GIVEN** an input with `bash -c` chained 6 levels deep
+- **WHEN** the parser produces the AST
+- **THEN** `ParsedCommand.IsUnparseable = true`
+- **AND** `ParsedCommand.UnparseableReason` matches `"bash -c recursion
+  depth exceeded (>5)"`
+- **AND** consumers route safe-fail per SPEC §11
+
+### Requirement: Corpus location is the test-project subdirectory
+
+The canonical corpus location SHALL be
+`tests/ShellSyntaxTree.Tests/Corpus/bash/*.json`, with `<None Update
+CopyToOutputDirectory="PreserveNewest" />` so the corpus runner reads
+from `AppContext.BaseDirectory` per SPEC §13's runner code example. The
+PII audit SHALL operate on this same directory.
+
+#### Scenario: CorpusRunnerTests reads from the test bin output
+
+- **GIVEN** corpus JSONs under `tests/ShellSyntaxTree.Tests/Corpus/bash/`
+- **WHEN** the test project is built
+- **THEN** the JSONs appear under `tests/ShellSyntaxTree.Tests/bin/Release/net10.0/Corpus/bash/`
+- **AND** `CorpusRunnerTests` enumerates them via
+  `Path.Combine(AppContext.BaseDirectory, "Corpus", "bash")`
+
+### Requirement: tar and docker -v fall through to default rule in v0.1
+
+In v0.1.0-alpha, `tar` SHALL use the default per-verb rule (all non-flag
+positionals classified as paths; no action-flag awareness). The
+`docker -v "/host:/container"` argument SHALL be treated as a single
+literal arg with `IsPath = false`. v0.1.x or later MAY upgrade these via
+new OpenSpec changes; the limitation is documented in `SPEC.md` §7 and
+tracked in GitHub issues.
+
+#### Scenario: tar defaults to all-positionals-are-paths
+
+- **GIVEN** the input `tar -xf archive.tar.gz /target`
+- **WHEN** the parser produces the AST
+- **THEN** both `archive.tar.gz` and `/target` have `IsPath = true`
+- **AND** the SPEC §7 entry for `tar` documents this v0.1 limitation
+  and references the GitHub issue for action-flag awareness
+
+#### Scenario: docker -v keeps the colon-joined value as a single literal
+
+- **GIVEN** the input `docker run -v /host/data:/container/data nginx`
+- **WHEN** the parser produces the AST
+- **THEN** the value `/host/data:/container/data` appears as one `Arg`
+- **AND** that `Arg` has `IsPath = false`
+- **AND** the SPEC §7 entry for `docker` documents this v0.1 limitation
+  and references the GitHub issue for colon-split handling
+
+## Notes
+
+- **Spec stub.** This change populates the initial `shellsyntaxtree-v0.1`
+  capability spec. Path C light adoption: the spec deliberately stays at
+  one root document until v0.2 PowerShell decomposition. Root `SPEC.md`
+  remains the canonical human-readable contract.
+- **Future decompositions.** `bash-lexer`, `path-resolver`, `verb-tables`,
+  `cd-attribution`, `subshells-and-bash-c`, `parser-anomalies`, and
+  `corpus-contract` are reserved capability names for v0.2 split.

--- a/openspec/changes/v0.1-locked-interpretations/tasks.md
+++ b/openspec/changes/v0.1-locked-interpretations/tasks.md
@@ -1,0 +1,132 @@
+# Tasks — v0.1 locked interpretations
+
+The eight interpretations land across PRs 1–6 of the v0.1.0-alpha shipping
+plan (`/home/petabridge/.claude/plans/okay-are-you-ready-wise-emerson.md`).
+This task list maps each interpretation to its implementing PR(s) and to
+the SPEC.md sections that get updated alongside the implementation.
+
+## 1. PR 1 — Public API surface and OpenSpec scaffolding
+
+- [x] 1.1 Bootstrap `src/ShellSyntaxTree/ShellSyntaxTree.csproj`
+      (multi-target `netstandard2.0;net8.0`, `IsAotCompatible=true` for
+      net8.0)
+- [x] 1.2 Implement public types per SPEC §2/§3 verbatim
+- [x] 1.3 Add `Arg.IsCwdAttribution: bool` (default `false`) per
+      interpretation #1
+- [x] 1.4 Bootstrap `tests/ShellSyntaxTree.Tests/ShellSyntaxTree.Tests.csproj`
+- [x] 1.5 Author `PublicApiSnapshotTests.cs` — reflection-based snapshot
+      of the locked surface (18 facts asserting type kinds, properties,
+      enum members, ctor behavior, default values)
+- [x] 1.6 Add both projects to `ShellSyntaxTree.slnx`
+- [x] 1.7 Bootstrap OpenSpec scaffolding (`openspec/`, change directories,
+      this proposal/design/tasks/specs delta)
+- [ ] 1.8 Update `SPEC.md` §2/§3 to enumerate `Arg.IsCwdAttribution`;
+      annotate `VerbChain.Joined` to use `string.Join(" ", Tokens)` for
+      cross-tfm compatibility (was `string.Join(' ', …)`, char overload
+      missing on netstandard2.0)
+- [ ] 1.9 Update `IMPLEMENTATION_PLAN.md` — mark PR 1 in-progress;
+      reference this OpenSpec change
+- [ ] 1.10 Update `TOOLING.md` to list installed OpenSpec skills under
+       Helper Skills
+- [ ] 1.11 Run `pwsh ./scripts/Add-FileHeaders.ps1`; verify with `-Verify`
+- [ ] 1.12 `dotnet build -c Release` clean; `dotnet test -c Release`
+       all-green
+- [ ] 1.13 Commit (signed) and push `pr1-bootstrap`; open PR with
+       `gh pr merge --auto --squash` against `dev`
+- [ ] 1.14 On merge: archive this OpenSpec change to
+       `openspec/changes/archive/2026-05-10-v0.1-locked-interpretations/`
+
+## 2. PR 2 — Lexer + opaque-region scanner (interpretation #2)
+
+- [ ] 2.1 Implement `Internal/Lexing/OpaqueRegionScanner.cs` — finds
+      balanced delimiters with quote-aware nesting; configurable open/close
+- [ ] 2.2 Implement `Internal/Bash/Lexing/BashLexer.cs` per SPEC §5
+- [ ] 2.3 Recognize `$(...)` and `` ` `` regions via the scanner; emit
+      `OpaqueSubstitution` token
+- [ ] 2.4 Recognize `$((` and `${var//` openers; emit `IsUnparseable`
+      sentinel
+- [ ] 2.5 Update `SPEC.md` §1 (note that command substitution is marked
+      DynamicSkip), §5 (lex rules for opaque regions), §11 (add arithmetic
+      and complex-param-expansion to IsUnparseable triggers)
+- [ ] 2.6 Open OpenSpec change `bash-lexer-opaque-regions` capturing the
+      §1/§5/§11 deltas in their final form
+
+## 3. PR 3 — Verb tables + parser core
+
+- [ ] 3.1 `Internal/Bash/Verbs/BashVerbs.cs` — `BashArity`, `CwdVerbs`,
+      `FileVerbs`, `FlagsWithValue` from SPEC §6
+- [ ] 3.2 `Internal/Bash/Parsing/BashCommandParser.cs` per SPEC §4
+- [ ] 3.3 Compound splitting; verb chain longest-prefix probe; flag/positional
+- [ ] 3.4 Heredoc skip (`<<DELIM` / `<<-DELIM`)
+- [ ] 3.5 Anomaly safe-fail per SPEC §11
+- [ ] 3.6 Wire opaque-substitution tokens into `Arg{ Kind=DynamicSkip }`
+      per interpretation #2
+- [ ] 3.7 Wire arithmetic/complex-param sentinels into
+      `ParsedCommand.IsUnparseable` per interpretation #2
+
+## 4. PR 4 — Resolver + per-verb rules (interpretations #3 + #8)
+
+- [ ] 4.1 `Internal/Resolving/BashResolver.cs` per SPEC §8
+- [ ] 4.2 Tilde + `$HOME`; other env vars → `DynamicSkip, IsPath=false`
+- [ ] 4.3 `filesystem::/path` strip; glob detection per interpretation #3
+      (`Kind=Glob, IsPath=true (in path slot), Resolved=null`)
+- [ ] 4.4 Relative-path joining against `WorkingDirectory`; `LooksLikePath`
+      heuristic
+- [ ] 4.5 `Internal/Bash/Verbs/BashPerVerbRules.cs` per SPEC §7 with
+      interpretation #8 fallback for tar (default rule) and docker -v
+      (single literal arg, IsPath=false)
+- [ ] 4.6 Update `SPEC.md` §7 (note v0.1 limitations + reference issues),
+      §8 (rewrite steps 4 & 6 to remove the overlap; explicit IsPath
+      asymmetry per interpretation #3)
+- [ ] 4.7 File 2 GitHub issues: tar action-flag awareness; docker -v
+      colon-split + Windows drive-letter handling
+- [ ] 4.8 Open OpenSpec change `path-resolver-rules` for the §7/§8 deltas
+
+## 5. PR 5 — cd attribution + subshells + bash -c (interpretations #4, #5, #6)
+
+- [ ] 5.1 `Internal/Bash/Parsing/CdAttributionContext.cs` (parser-internal
+      mutable; output AST stays immutable)
+- [ ] 5.2 Only `cd`/`chdir` propagate (interpretation #5); pushd/popd
+      parse but don't propagate
+- [ ] 5.3 Synthetic `Arg{ IsCwdAttribution=true, … }` appended to
+      subsequent clauses; `Kind=DynamicSkip` when cd target is dynamic
+      (interpretation #6)
+- [ ] 5.4 Subshell `(...)` parsing with attribution stack push/pop
+- [ ] 5.5 `bash -c "..."` / `sh -c "..."` recursion (cap at 5)
+- [ ] 5.6 Recursion overflow → outer `ParsedCommand.IsUnparseable=true`
+      (interpretation #4)
+- [ ] 5.7 Update `SPEC.md` §9 (clarify which CwdVerbs propagate; add
+      dynamic-cd attribution subsection); §10 (replace "mark the deepest
+      clause" wording with "set ParsedCommand.IsUnparseable=true")
+- [ ] 5.8 File GitHub issue: "Model pushd/popd directory stack semantics"
+- [ ] 5.9 Open OpenSpec change `cd-attribution-clarifications` for the
+      §9/§10 deltas
+
+## 6. PR 6 — Corpus completeness + PII audit (interpretation #7)
+
+- [ ] 6.1 Audit corpus categories from SPEC §13; fill to ≥105 entries
+- [ ] 6.2 `tests/.../Corpus/AstAssert.cs` — structural equality with
+      diffable failures
+- [ ] 6.3 `tests/.../Corpus/PiiAuditTests.cs` — `[Fact]` regex scan over
+      corpus JSON for SPEC §14 forbidden patterns
+- [ ] 6.4 Verify pr_validation runs both via `dotnet test`
+- [ ] 6.5 Confirm green on Linux + Windows (path separators)
+- [ ] 6.6 Update `SPEC.md` §13 (replace abbreviated path with canonical
+      `tests/ShellSyntaxTree.Tests/Corpus/bash/*.json`)
+- [ ] 6.7 Open OpenSpec change `corpus-location` for the §13 delta
+
+## 7. Verify
+
+- [ ] 7.1 After all PRs land: `dotnet build -c Release` and `dotnet test
+      -c Release` clean on Linux + Windows
+- [ ] 7.2 `PublicApiSnapshotTests` still green — no public surface drift
+      beyond the locked `IsCwdAttribution` addition
+- [ ] 7.3 PII audit passes
+- [ ] 7.4 SPEC.md edits consistent with implementations across all PRs
+
+## Status conventions
+
+- `- [ ]` pending
+- `- [x]` done
+- Subtasks left as `[ ]` while the parent PR is in flight; flipped to
+  `[x]` only when the PR merges.

--- a/src/ShellSyntaxTree/Arg.cs
+++ b/src/ShellSyntaxTree/Arg.cs
@@ -1,0 +1,47 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="Arg.cs" company="Aaron Stannard">
+//      Copyright (C) 2026 - 2026 Aaron Stannard <https://github.com/Aaronontheweb>
+// </copyright>
+// -----------------------------------------------------------------------
+namespace ShellSyntaxTree;
+
+/// <summary>
+/// One argument token after the verb chain. Includes resolution state.
+/// </summary>
+public sealed record Arg
+{
+    /// <summary>Verbatim token from the source.</summary>
+    public string Raw { get; init; } = "";
+
+    /// <summary>
+    /// Resolved value for path tokens — tilde expanded, env vars
+    /// substituted, normalized to absolute path against
+    /// BashParserOptions.WorkingDirectory. Null when Kind is not a path
+    /// (Literal non-path / Glob / DynamicSkip).
+    /// </summary>
+    public string? Resolved { get; init; }
+
+    /// <summary>Token kind. See <see cref="ArgKind"/>.</summary>
+    public ArgKind Kind { get; init; }
+
+    /// <summary>
+    /// True when this token starts with '-' or '--' (a flag, not a
+    /// positional arg).
+    /// </summary>
+    // netstandard2.0 lacks string.StartsWith(char); use indexer for cross-tfm parity.
+    public bool IsFlag => Raw.Length > 0 && Raw[0] == '-';
+
+    /// <summary>
+    /// True when this token is a path the clause operates on (per the
+    /// per-verb pathArgs table; see SPEC §7). Set during parsing so
+    /// consumers don't reapply per-verb rules.
+    /// </summary>
+    public bool IsPath { get; init; }
+
+    /// <summary>
+    /// True when this Arg is a synthetic attribution arg representing the
+    /// working directory inherited from a preceding <c>cd</c>/<c>chdir</c>
+    /// clause in the same compound. Default false. See SPEC §9.
+    /// </summary>
+    public bool IsCwdAttribution { get; init; }
+}

--- a/src/ShellSyntaxTree/ArgKind.cs
+++ b/src/ShellSyntaxTree/ArgKind.cs
@@ -1,0 +1,31 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="ArgKind.cs" company="Aaron Stannard">
+//      Copyright (C) 2026 - 2026 Aaron Stannard <https://github.com/Aaronontheweb>
+// </copyright>
+// -----------------------------------------------------------------------
+namespace ShellSyntaxTree;
+
+/// <summary>
+/// Classification for an argument token after parsing.
+/// </summary>
+public enum ArgKind
+{
+    /// <summary>Literal value (string, number, flag).</summary>
+    Literal,
+
+    /// <summary>Token containing an unresolved env var reference.</summary>
+    EnvVar,
+
+    /// <summary>Token containing glob metachars (* ? [).</summary>
+    Glob,
+
+    /// <summary>Token starting with ~ (tilde).</summary>
+    Tilde,
+
+    /// <summary>
+    /// Token whose value cannot be safely resolved (unresolved env var,
+    /// unexpandable glob). Consumers SHALL treat as "no value extracted"
+    /// rather than using Raw as a literal path.
+    /// </summary>
+    DynamicSkip
+}

--- a/src/ShellSyntaxTree/BashParser.cs
+++ b/src/ShellSyntaxTree/BashParser.cs
@@ -1,0 +1,52 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="BashParser.cs" company="Aaron Stannard">
+//      Copyright (C) 2026 - 2026 Aaron Stannard <https://github.com/Aaronontheweb>
+// </copyright>
+// -----------------------------------------------------------------------
+using System;
+
+namespace ShellSyntaxTree;
+
+/// <summary>Bash implementation of <see cref="IShellParser"/>.</summary>
+public sealed class BashParser : IShellParser
+{
+    // Stored for use by the lexer/parser passes landing in PRs 2-5; the v0.1.0-alpha
+    // skeleton only locks the public API surface — see SPEC §17 acceptance criteria.
+#pragma warning disable IDE0052, CA1823 // intentionally retained until PR 2 wires this in
+    private readonly BashParserOptions _options;
+#pragma warning restore IDE0052, CA1823
+
+    /// <summary>
+    /// Create a parser with default options.
+    /// </summary>
+    public BashParser() : this(new BashParserOptions())
+    {
+    }
+
+    /// <summary>
+    /// Create a parser with the supplied options.
+    /// </summary>
+    /// <param name="options">Resolver knobs (home / working directory).</param>
+    public BashParser(BashParserOptions options)
+    {
+        if (options is null)
+        {
+            throw new ArgumentNullException(nameof(options));
+        }
+
+        _options = options;
+    }
+
+    /// <inheritdoc />
+    public ParsedCommand Parse(string command)
+    {
+        // Cross-tfm null-check: ArgumentNullException.ThrowIfNull is net6+ only.
+        if (command is null)
+        {
+            throw new ArgumentNullException(nameof(command));
+        }
+
+        throw new NotImplementedException(
+            "BashParser.Parse will be implemented in PR 2-5; this stub locks the public API surface.");
+    }
+}

--- a/src/ShellSyntaxTree/BashParserOptions.cs
+++ b/src/ShellSyntaxTree/BashParserOptions.cs
@@ -1,0 +1,23 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="BashParserOptions.cs" company="Aaron Stannard">
+//      Copyright (C) 2026 - 2026 Aaron Stannard <https://github.com/Aaronontheweb>
+// </copyright>
+// -----------------------------------------------------------------------
+namespace ShellSyntaxTree;
+
+/// <summary>Configuration knobs for <see cref="BashParser"/>.</summary>
+public sealed record BashParserOptions
+{
+    /// <summary>
+    /// User home directory used to expand <c>~</c> and <c>$HOME</c> tokens
+    /// during resolution. Defaults to
+    /// <see cref="System.Environment.SpecialFolder.UserProfile"/>.
+    /// </summary>
+    public string? HomeDirectory { get; init; }
+
+    /// <summary>
+    /// Working directory used to resolve relative path tokens during
+    /// resolution. Defaults to the daemon-process cwd.
+    /// </summary>
+    public string? WorkingDirectory { get; init; }
+}

--- a/src/ShellSyntaxTree/Clause.cs
+++ b/src/ShellSyntaxTree/Clause.cs
@@ -1,0 +1,54 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="Clause.cs" company="Aaron Stannard">
+//      Copyright (C) 2026 - 2026 Aaron Stannard <https://github.com/Aaronontheweb>
+// </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+
+namespace ShellSyntaxTree;
+
+/// <summary>
+/// One logical command within a compound. Each clause has its own verb
+/// chain, args, redirects, and the operator that joined it to the previous
+/// clause.
+/// </summary>
+public sealed record Clause
+{
+    /// <summary>
+    /// The operator joining this clause to the previous one. The first
+    /// clause in a ParsedCommand has Operator=None. Subsequent clauses
+    /// carry the operator that preceded them in the source
+    /// (e.g. <c>a &amp;&amp; b</c> produces clauses [{None,a}, {AndIf,b}]).
+    /// </summary>
+    public CompoundOperator Operator { get; init; }
+
+    /// <summary>The verb chain (see SPEC §3.3 and §6).</summary>
+    public VerbChain Verb { get; init; } = new();
+
+    /// <summary>
+    /// All argument tokens after the verb chain, in source order. Includes
+    /// flags and positional args. See <see cref="Arg.Kind"/> for token kind.
+    /// </summary>
+    public IReadOnlyList<Arg> Args { get; init; } = Array.Empty<Arg>();
+
+    /// <summary>
+    /// Redirect operators on this clause (<c>&gt;</c>, <c>&gt;&gt;</c>,
+    /// <c>&lt;</c>, <c>2&gt;</c>, <c>2&gt;&gt;</c>). Each entry includes
+    /// direction and target path.
+    /// </summary>
+    public IReadOnlyList<Redirect> Redirects { get; init; } = Array.Empty<Redirect>();
+
+    /// <summary>
+    /// True when this clause is wrapped in a subshell (parens). Subshells
+    /// isolate cd state — see SPEC §9.
+    /// </summary>
+    public bool IsSubshell { get; init; }
+
+    /// <summary>
+    /// True when this clause is the result of recursing into a
+    /// <c>bash -c</c> or <c>sh -c</c> wrapper. Useful for consumers that
+    /// want to surface "this came from a wrapped invocation" in UI.
+    /// </summary>
+    public bool IsBashCWrapped { get; init; }
+}

--- a/src/ShellSyntaxTree/CompoundOperator.cs
+++ b/src/ShellSyntaxTree/CompoundOperator.cs
@@ -1,0 +1,27 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="CompoundOperator.cs" company="Aaron Stannard">
+//      Copyright (C) 2026 - 2026 Aaron Stannard <https://github.com/Aaronontheweb>
+// </copyright>
+// -----------------------------------------------------------------------
+namespace ShellSyntaxTree;
+
+/// <summary>
+/// Operator joining a clause to its predecessor in a compound command.
+/// </summary>
+public enum CompoundOperator
+{
+    /// <summary>First clause; no prior operator.</summary>
+    None,
+
+    /// <summary><c>&amp;&amp;</c> — short-circuit AND.</summary>
+    AndIf,
+
+    /// <summary><c>||</c> — short-circuit OR.</summary>
+    OrIf,
+
+    /// <summary><c>;</c> — sequence.</summary>
+    Sequence,
+
+    /// <summary><c>|</c> — pipe.</summary>
+    Pipe
+}

--- a/src/ShellSyntaxTree/IShellParser.cs
+++ b/src/ShellSyntaxTree/IShellParser.cs
@@ -1,0 +1,20 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="IShellParser.cs" company="Aaron Stannard">
+//      Copyright (C) 2026 - 2026 Aaron Stannard <https://github.com/Aaronontheweb>
+// </copyright>
+// -----------------------------------------------------------------------
+namespace ShellSyntaxTree;
+
+/// <summary>
+/// Parses shell command strings into structured ASTs.
+/// </summary>
+public interface IShellParser
+{
+    /// <summary>
+    /// Parse the command. Always returns a ParsedCommand; sets
+    /// <see cref="ParsedCommand.IsUnparseable"/> when the input cannot
+    /// be tokenized (unbalanced quotes, etc.). Never throws on
+    /// well-formed strings; throws ArgumentNullException on null input.
+    /// </summary>
+    ParsedCommand Parse(string command);
+}

--- a/src/ShellSyntaxTree/ParsedCommand.cs
+++ b/src/ShellSyntaxTree/ParsedCommand.cs
@@ -1,0 +1,37 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="ParsedCommand.cs" company="Aaron Stannard">
+//      Copyright (C) 2026 - 2026 Aaron Stannard <https://github.com/Aaronontheweb>
+// </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+
+namespace ShellSyntaxTree;
+
+/// <summary>
+/// The top-level result of parsing. Always returned (never null).
+/// </summary>
+public sealed record ParsedCommand
+{
+    /// <summary>The original input string, verbatim.</summary>
+    public string Source { get; init; } = "";
+
+    /// <summary>
+    /// Top-level clauses, split on compound operators
+    /// (<c>&amp;&amp;</c>, <c>||</c>, <c>;</c>, <c>|</c>). For a simple
+    /// command, exactly one clause with Operator=None.
+    /// </summary>
+    public IReadOnlyList<Clause> Clauses { get; init; } = Array.Empty<Clause>();
+
+    /// <summary>
+    /// True when the parser could not produce a clean AST (unbalanced
+    /// quotes, unparseable construct). When true, Clauses MAY be partial
+    /// or empty. Consumers should route to safe-fail.
+    /// </summary>
+    public bool IsUnparseable { get; init; }
+
+    /// <summary>
+    /// Human-readable diagnostic when IsUnparseable=true; null otherwise.
+    /// </summary>
+    public string? UnparseableReason { get; init; }
+}

--- a/src/ShellSyntaxTree/Properties/IsExternalInit.cs
+++ b/src/ShellSyntaxTree/Properties/IsExternalInit.cs
@@ -1,0 +1,21 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="IsExternalInit.cs" company="Aaron Stannard">
+//      Copyright (C) 2026 - 2026 Aaron Stannard <https://github.com/Aaronontheweb>
+// </copyright>
+// -----------------------------------------------------------------------
+// Polyfill for `init` accessors on netstandard2.0. The C# compiler emits a
+// reference to System.Runtime.CompilerServices.IsExternalInit for any
+// init-only setter; that type ships in net5.0+ but is absent from
+// netstandard2.0. Declaring it internally is the standard workaround and
+// is bit-compatible with the framework type — the runtime never inspects
+// it, only the compiler does at the call site.
+#if NETSTANDARD2_0
+namespace System.Runtime.CompilerServices;
+
+using System.ComponentModel;
+
+[EditorBrowsable(EditorBrowsableState.Never)]
+internal static class IsExternalInit
+{
+}
+#endif

--- a/src/ShellSyntaxTree/Redirect.cs
+++ b/src/ShellSyntaxTree/Redirect.cs
@@ -1,0 +1,23 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="Redirect.cs" company="Aaron Stannard">
+//      Copyright (C) 2026 - 2026 Aaron Stannard <https://github.com/Aaronontheweb>
+// </copyright>
+// -----------------------------------------------------------------------
+using System;
+
+namespace ShellSyntaxTree;
+
+/// <summary>
+/// One redirect operator on a clause (e.g. <c>&gt; out.txt</c>, <c>2&gt;&amp;1</c>).
+/// </summary>
+public sealed record Redirect
+{
+    /// <summary>Direction of the redirect.</summary>
+    public RedirectDirection Direction { get; init; }
+
+    /// <summary>Target path (resolved per Arg conventions).</summary>
+    public string Target { get; init; } = "";
+
+    /// <summary>True when target is a dynamic token (skip).</summary>
+    public bool IsDynamicSkip { get; init; }
+}

--- a/src/ShellSyntaxTree/RedirectDirection.cs
+++ b/src/ShellSyntaxTree/RedirectDirection.cs
@@ -1,0 +1,27 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="RedirectDirection.cs" company="Aaron Stannard">
+//      Copyright (C) 2026 - 2026 Aaron Stannard <https://github.com/Aaronontheweb>
+// </copyright>
+// -----------------------------------------------------------------------
+namespace ShellSyntaxTree;
+
+/// <summary>
+/// Direction of a clause redirect operator.
+/// </summary>
+public enum RedirectDirection
+{
+    /// <summary><c>&lt;</c> — input redirect.</summary>
+    In,
+
+    /// <summary><c>&gt;</c> — stdout redirect (truncate).</summary>
+    Out,
+
+    /// <summary><c>&gt;&gt;</c> — stdout append.</summary>
+    Append,
+
+    /// <summary><c>2&gt;</c> — stderr redirect (truncate).</summary>
+    ErrOut,
+
+    /// <summary><c>2&gt;&gt;</c> — stderr append.</summary>
+    ErrAppend
+}

--- a/src/ShellSyntaxTree/ShellSyntaxTree.csproj
+++ b/src/ShellSyntaxTree/ShellSyntaxTree.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>$(NetStandardLibVersion);$(NetLibVersion)</TargetFrameworks>
+    <RootNamespace>ShellSyntaxTree</RootNamespace>
+    <Description>Bash command parser that emits a structured AST for security gate evaluators.</Description>
+    <PackageDescription>Bash command parser that emits a structured AST for security gate evaluators.</PackageDescription>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == '$(NetLibVersion)'">
+    <IsAotCompatible>true</IsAotCompatible>
+  </PropertyGroup>
+
+</Project>

--- a/src/ShellSyntaxTree/VerbChain.cs
+++ b/src/ShellSyntaxTree/VerbChain.cs
@@ -1,0 +1,26 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="VerbChain.cs" company="Aaron Stannard">
+//      Copyright (C) 2026 - 2026 Aaron Stannard <https://github.com/Aaronontheweb>
+// </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+
+namespace ShellSyntaxTree;
+
+/// <summary>
+/// The verb of a clause. Multi-token to handle commands like
+/// <c>git push</c>, <c>docker compose up</c>, <c>bun run</c>,
+/// <c>dotnet test</c>. Length determined by the BashArity table (see SPEC §6).
+/// </summary>
+public sealed record VerbChain
+{
+    /// <summary>
+    /// Verb tokens in source order. Empty when the clause has no verb
+    /// (e.g. clause is just a redirect or an empty fragment).
+    /// </summary>
+    public IReadOnlyList<string> Tokens { get; init; } = Array.Empty<string>();
+
+    /// <summary>Convenience: tokens joined with spaces.</summary>
+    public string Joined => string.Join(" ", Tokens);
+}

--- a/tests/ShellSyntaxTree.Tests/PublicApiSnapshotTests.cs
+++ b/tests/ShellSyntaxTree.Tests/PublicApiSnapshotTests.cs
@@ -1,0 +1,379 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="PublicApiSnapshotTests.cs" company="Aaron Stannard">
+//      Copyright (C) 2026 - 2026 Aaron Stannard <https://github.com/Aaronontheweb>
+// </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace ShellSyntaxTree.Tests;
+
+/// <summary>
+/// Locks the public API surface for v0.1.0-alpha. Any drift here means
+/// either SPEC.md §2/§3 was bumped (deliberate version change) or a
+/// regression — both are blockers until reconciled.
+/// </summary>
+public class PublicApiSnapshotTests
+{
+    private static readonly Assembly LibAssembly = typeof(BashParser).Assembly;
+
+    // -------- IShellParser --------
+
+    [Fact]
+    public void IShellParser_has_expected_shape()
+    {
+        var t = typeof(IShellParser);
+        Assert.True(t.IsInterface);
+        Assert.True(t.IsPublic);
+        Assert.Equal("ShellSyntaxTree", t.Namespace);
+
+        var methods = t.GetMethods();
+        var parse = Assert.Single(methods, m => m.Name == "Parse");
+        Assert.Equal(typeof(ParsedCommand), parse.ReturnType);
+        var parameters = parse.GetParameters();
+        Assert.Single(parameters);
+        Assert.Equal(typeof(string), parameters[0].ParameterType);
+    }
+
+    // -------- BashParser --------
+
+    [Fact]
+    public void BashParser_has_expected_shape()
+    {
+        var t = typeof(BashParser);
+        Assert.True(t.IsPublic);
+        Assert.True(t.IsSealed);
+        Assert.True(t.IsClass);
+        Assert.Contains(typeof(IShellParser), t.GetInterfaces());
+
+        var ctors = t.GetConstructors().OrderBy(c => c.GetParameters().Length).ToArray();
+        Assert.Equal(2, ctors.Length);
+
+        Assert.Empty(ctors[0].GetParameters());
+
+        var withOptions = ctors[1].GetParameters();
+        Assert.Single(withOptions);
+        Assert.Equal(typeof(BashParserOptions), withOptions[0].ParameterType);
+
+        var parse = t.GetMethod(nameof(BashParser.Parse), new[] { typeof(string) });
+        Assert.NotNull(parse);
+        Assert.Equal(typeof(ParsedCommand), parse!.ReturnType);
+    }
+
+    [Fact]
+    public void BashParser_Parse_throws_ArgumentNullException_on_null()
+    {
+        var parser = new BashParser();
+        Assert.Throws<ArgumentNullException>(() => parser.Parse(null!));
+    }
+
+    [Fact]
+    public void BashParser_Parse_throws_NotImplementedException_in_v0_1_alpha()
+    {
+        var parser = new BashParser();
+        Assert.Throws<NotImplementedException>(() => parser.Parse("ls"));
+    }
+
+    [Fact]
+    public void BashParser_default_ctor_constructs_with_default_options()
+    {
+        // Smoke test: parameterless ctor doesn't throw.
+        var parser = new BashParser();
+        Assert.NotNull(parser);
+    }
+
+    [Fact]
+    public void BashParser_options_ctor_constructs_with_supplied_options()
+    {
+        var parser = new BashParser(new BashParserOptions
+        {
+            HomeDirectory = "/home/test",
+            WorkingDirectory = "/tmp",
+        });
+        Assert.NotNull(parser);
+    }
+
+    // -------- BashParserOptions --------
+
+    [Fact]
+    public void BashParserOptions_has_expected_shape()
+    {
+        var t = typeof(BashParserOptions);
+        Assert.True(t.IsPublic);
+        Assert.True(t.IsSealed);
+        AssertIsRecord(t);
+
+        AssertInitProperty(t, "HomeDirectory", typeof(string), nullable: true);
+        AssertInitProperty(t, "WorkingDirectory", typeof(string), nullable: true);
+
+        var declaredProps = DeclaredInstanceProps(t)
+            .Where(p => p.Name != "EqualityContract")
+            .Select(p => p.Name)
+            .OrderBy(n => n)
+            .ToArray();
+        Assert.Equal(new[] { "HomeDirectory", "WorkingDirectory" }, declaredProps);
+    }
+
+    // -------- ParsedCommand --------
+
+    [Fact]
+    public void ParsedCommand_has_expected_shape()
+    {
+        var t = typeof(ParsedCommand);
+        Assert.True(t.IsPublic);
+        Assert.True(t.IsSealed);
+        AssertIsRecord(t);
+
+        AssertInitProperty(t, "Source", typeof(string));
+        AssertInitProperty(t, "Clauses", typeof(IReadOnlyList<Clause>));
+        AssertInitProperty(t, "IsUnparseable", typeof(bool));
+        AssertInitProperty(t, "UnparseableReason", typeof(string), nullable: true);
+
+        var instance = new ParsedCommand();
+        Assert.Equal("", instance.Source);
+        Assert.Empty(instance.Clauses);
+        Assert.False(instance.IsUnparseable);
+        Assert.Null(instance.UnparseableReason);
+    }
+
+    // -------- Clause --------
+
+    [Fact]
+    public void Clause_has_expected_shape()
+    {
+        var t = typeof(Clause);
+        Assert.True(t.IsPublic);
+        Assert.True(t.IsSealed);
+        AssertIsRecord(t);
+
+        AssertInitProperty(t, "Operator", typeof(CompoundOperator));
+        AssertInitProperty(t, "Verb", typeof(VerbChain));
+        AssertInitProperty(t, "Args", typeof(IReadOnlyList<Arg>));
+        AssertInitProperty(t, "Redirects", typeof(IReadOnlyList<Redirect>));
+        AssertInitProperty(t, "IsSubshell", typeof(bool));
+        AssertInitProperty(t, "IsBashCWrapped", typeof(bool));
+
+        var instance = new Clause();
+        Assert.Equal(CompoundOperator.None, instance.Operator);
+        Assert.NotNull(instance.Verb);
+        Assert.Empty(instance.Verb.Tokens);
+        Assert.Empty(instance.Args);
+        Assert.Empty(instance.Redirects);
+        Assert.False(instance.IsSubshell);
+        Assert.False(instance.IsBashCWrapped);
+    }
+
+    // -------- VerbChain --------
+
+    [Fact]
+    public void VerbChain_has_expected_shape()
+    {
+        var t = typeof(VerbChain);
+        Assert.True(t.IsPublic);
+        Assert.True(t.IsSealed);
+        AssertIsRecord(t);
+
+        AssertInitProperty(t, "Tokens", typeof(IReadOnlyList<string>));
+
+        // Joined is a computed (get-only) property, no setter.
+        var joined = t.GetProperty("Joined");
+        Assert.NotNull(joined);
+        Assert.Equal(typeof(string), joined!.PropertyType);
+        Assert.True(joined.CanRead);
+        Assert.False(joined.CanWrite);
+
+        var instance = new VerbChain { Tokens = new[] { "git", "push" } };
+        Assert.Equal("git push", instance.Joined);
+
+        var empty = new VerbChain();
+        Assert.Empty(empty.Tokens);
+        Assert.Equal("", empty.Joined);
+    }
+
+    // -------- Arg --------
+
+    [Fact]
+    public void Arg_has_expected_shape()
+    {
+        var t = typeof(Arg);
+        Assert.True(t.IsPublic);
+        Assert.True(t.IsSealed);
+        AssertIsRecord(t);
+
+        AssertInitProperty(t, "Raw", typeof(string));
+        AssertInitProperty(t, "Resolved", typeof(string), nullable: true);
+        AssertInitProperty(t, "Kind", typeof(ArgKind));
+        AssertInitProperty(t, "IsPath", typeof(bool));
+        AssertInitProperty(t, "IsCwdAttribution", typeof(bool));
+
+        // IsFlag is a computed property with no setter.
+        var isFlag = t.GetProperty("IsFlag");
+        Assert.NotNull(isFlag);
+        Assert.Equal(typeof(bool), isFlag!.PropertyType);
+        Assert.True(isFlag.CanRead);
+        Assert.False(isFlag.CanWrite);
+
+        Assert.True(new Arg { Raw = "-f" }.IsFlag);
+        Assert.True(new Arg { Raw = "--force" }.IsFlag);
+        Assert.False(new Arg { Raw = "foo" }.IsFlag);
+        Assert.False(new Arg { Raw = "" }.IsFlag);
+    }
+
+    [Fact]
+    public void Arg_IsCwdAttribution_defaults_to_false()
+    {
+        var instance = new Arg();
+        Assert.False(instance.IsCwdAttribution);
+        Assert.Equal("", instance.Raw);
+        Assert.Null(instance.Resolved);
+        Assert.Equal(ArgKind.Literal, instance.Kind);
+        Assert.False(instance.IsPath);
+    }
+
+    // -------- Redirect --------
+
+    [Fact]
+    public void Redirect_has_expected_shape()
+    {
+        var t = typeof(Redirect);
+        Assert.True(t.IsPublic);
+        Assert.True(t.IsSealed);
+        AssertIsRecord(t);
+
+        AssertInitProperty(t, "Direction", typeof(RedirectDirection));
+        AssertInitProperty(t, "Target", typeof(string));
+        AssertInitProperty(t, "IsDynamicSkip", typeof(bool));
+
+        var instance = new Redirect();
+        Assert.Equal(RedirectDirection.In, instance.Direction);
+        Assert.Equal("", instance.Target);
+        Assert.False(instance.IsDynamicSkip);
+    }
+
+    // -------- enums --------
+
+    [Fact]
+    public void ArgKind_has_expected_members()
+    {
+        Assert.Equal(
+            new[] { "Literal", "EnvVar", "Glob", "Tilde", "DynamicSkip" },
+            Enum.GetNames(typeof(ArgKind)));
+
+        // Underlying values follow declaration order (0..4).
+        Assert.Equal(0, (int)ArgKind.Literal);
+        Assert.Equal(1, (int)ArgKind.EnvVar);
+        Assert.Equal(2, (int)ArgKind.Glob);
+        Assert.Equal(3, (int)ArgKind.Tilde);
+        Assert.Equal(4, (int)ArgKind.DynamicSkip);
+    }
+
+    [Fact]
+    public void RedirectDirection_has_expected_members()
+    {
+        Assert.Equal(
+            new[] { "In", "Out", "Append", "ErrOut", "ErrAppend" },
+            Enum.GetNames(typeof(RedirectDirection)));
+
+        Assert.Equal(0, (int)RedirectDirection.In);
+        Assert.Equal(1, (int)RedirectDirection.Out);
+        Assert.Equal(2, (int)RedirectDirection.Append);
+        Assert.Equal(3, (int)RedirectDirection.ErrOut);
+        Assert.Equal(4, (int)RedirectDirection.ErrAppend);
+    }
+
+    [Fact]
+    public void CompoundOperator_has_expected_members()
+    {
+        Assert.Equal(
+            new[] { "None", "AndIf", "OrIf", "Sequence", "Pipe" },
+            Enum.GetNames(typeof(CompoundOperator)));
+
+        Assert.Equal(0, (int)CompoundOperator.None);
+        Assert.Equal(1, (int)CompoundOperator.AndIf);
+        Assert.Equal(2, (int)CompoundOperator.OrIf);
+        Assert.Equal(3, (int)CompoundOperator.Sequence);
+        Assert.Equal(4, (int)CompoundOperator.Pipe);
+    }
+
+    // -------- closure --------
+
+    [Fact]
+    public void Public_namespace_contains_only_expected_types()
+    {
+        var actual = LibAssembly
+            .GetExportedTypes()
+            .Where(t => t.Namespace == "ShellSyntaxTree")
+            .Select(t => t.Name)
+            .OrderBy(n => n)
+            .ToArray();
+
+        var expected = new[]
+        {
+            nameof(Arg),
+            nameof(ArgKind),
+            nameof(BashParser),
+            nameof(BashParserOptions),
+            nameof(Clause),
+            nameof(CompoundOperator),
+            nameof(IShellParser),
+            nameof(ParsedCommand),
+            nameof(Redirect),
+            nameof(RedirectDirection),
+            nameof(VerbChain),
+        };
+
+        Assert.Equal(expected, actual);
+    }
+
+    [Fact]
+    public void Library_assembly_exports_no_other_namespaces()
+    {
+        var namespaces = LibAssembly
+            .GetExportedTypes()
+            .Select(t => t.Namespace)
+            .Where(n => n is not null)
+            .Distinct()
+            .ToArray();
+
+        Assert.Equal(new[] { "ShellSyntaxTree" }, namespaces);
+    }
+
+    // -------- helpers --------
+
+    private static IEnumerable<PropertyInfo> DeclaredInstanceProps(Type t) =>
+        t.GetProperties(BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+
+    private static void AssertIsRecord(Type t)
+    {
+        // Records emit a compiler-generated <Clone>$ method and an EqualityContract property.
+        var clone = t.GetMethod("<Clone>$", BindingFlags.Public | BindingFlags.Instance);
+        Assert.NotNull(clone);
+
+        var equalityContract = t.GetProperty(
+            "EqualityContract",
+            BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.Public);
+        Assert.NotNull(equalityContract);
+    }
+
+    private static void AssertInitProperty(Type t, string name, Type expectedType, bool nullable = false)
+    {
+        var prop = t.GetProperty(name);
+        Assert.NotNull(prop);
+        Assert.True(prop!.CanRead, $"{t.Name}.{name} must be readable");
+        Assert.True(prop.CanWrite, $"{t.Name}.{name} must be writable (init-only)");
+        Assert.Equal(expectedType, prop.PropertyType);
+
+        // init-only setter has the IsExternalInit modreq baked into its return type.
+        var setter = prop.SetMethod;
+        Assert.NotNull(setter);
+        var modreqs = setter!.ReturnParameter.GetRequiredCustomModifiers();
+        Assert.Contains(modreqs, m => m.FullName == "System.Runtime.CompilerServices.IsExternalInit");
+
+        // Suppress unused-parameter warning; nullability metadata isn't queried at runtime
+        // without NullabilityInfoContext (net6+) and our purpose here is shape, not nullability.
+        _ = nullable;
+    }
+}

--- a/tests/ShellSyntaxTree.Tests/ShellSyntaxTree.Tests.csproj
+++ b/tests/ShellSyntaxTree.Tests/ShellSyntaxTree.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(NetCoreTestVersion)</TargetFramework>
+    <RootNamespace>ShellSyntaxTree.Tests</RootNamespace>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\ShellSyntaxTree\ShellSyntaxTree.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="coverlet.collector">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary

PR 1 of the v0.1.0-alpha shipping plan. Bootstraps the library + tests projects, locks the public API surface per `SPEC.md` §2/§3, and scaffolds OpenSpec governance with the `v0.1-locked-interpretations` change recording the eight planning-interview decisions.

`BashParser.Parse` stubs to `NotImplementedException` — PRs 2-5 wire up the lexer/parser/resolver behind the locked surface.

## What landed

- **`src/ShellSyntaxTree/`** — multi-target `netstandard2.0;net8.0`, `IsAotCompatible=true` on net8.0. Eleven public types per SPEC §2/§3 verbatim. `Arg.IsCwdAttribution: bool` added per locked interpretation #1.
- **`tests/ShellSyntaxTree.Tests/`** — net10.0 xunit project. `PublicApiSnapshotTests` ships 18 reflection-based `[Fact]`s asserting type kinds, properties, enum members, ctor behavior, default values, namespace closure. Fails loud on any future drift.
- **`openspec/`** — Path C light adoption. `v0.1-locked-interpretations` change records all 8 SPEC ambiguity resolutions (proposal + design + tasks + spec deltas). Archived on this PR's merge per the plan.
- **`.claude/skills/openspec-*`** — authoring skills copied from `petabridge/sdkbin`; refreshed by `openspec init`.
- **`SPEC.md` §3** — enumerates `Arg.IsCwdAttribution`; cross-tfm note on `VerbChain.Joined` (string overload, not char).

## SPEC interpretations locked in this change

| # | Decision |
|---|---|
| 1 | `Arg.IsCwdAttribution: bool` (default false) added to public surface |
| 2 | `$()`, backticks → token-level DynamicSkip; `$((expr))`, `${var//pat/repl}` → IsUnparseable |
| 3 | Glob → `Kind=Glob, IsPath=true, Resolved=null`; DynamicSkip → `IsPath=false` |
| 4 | bash -c overflow → outer `ParsedCommand.IsUnparseable=true` (no Clause field) |
| 5 | Only `cd`/`chdir` propagate; `pushd`/`popd` parse but don't (issue tracked) |
| 6 | `cd $VAR && cmd` propagates synthetic `IsCwdAttribution=true, Kind=DynamicSkip` arg |
| 7 | Corpus location: `tests/ShellSyntaxTree.Tests/Corpus/bash/*.json` |
| 8 | tar / docker -v fall through to default rule in v0.1; issues tracked |

See `openspec/changes/v0.1-locked-interpretations/proposal.md` for full rationale per decision.

## Verification

- ✅ `dotnet build -c Release` — clean (0 warnings, 0 errors with `TreatWarningsAsErrors=true`)
- ✅ `dotnet test -c Release` — 18/18 passing
- ✅ `pwsh ./scripts/Add-FileHeaders.ps1 -Verify` — all files have headers
- ✅ `openspec validate v0.1-locked-interpretations --strict` — passes
- ✅ Commit signed (GPG key C468D63CF33112D4DD885B20468D23829D6C09E8)

## Test plan

- [ ] CI passes on `Test-ubuntu-latest`
- [ ] CI passes on `Test-windows-latest`
- [ ] Public API surface matches SPEC §2/§3 (PublicApiSnapshotTests)
- [ ] No drift in copyright headers (PowerShell verify in CI)

## Next

PR 2 implements `BashLexer` + `OpaqueRegionScanner` per SPEC §5 + locked interpretation #2 (boundary tracking for `$()` substitutions).