### PR TITLE
PR 3: verb tables + BashCommandParser core

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"d3ab9a93-4c60-44b4-ab9e-a1d76ffbe40c","pid":895750,"procStart":"102434345","acquiredAt":1778436639709}

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -63,22 +63,33 @@ bulldoze priorities.
 - [x] OpenSpec change `v0.1-locked-interpretations` tasks.md updated
       (Phase 2 marked [x])
 
-### 4. Verb tables (SPEC §6, data only)
+### 4. Verb tables (SPEC §6, data only) — PR 3, complete
 
-- [ ] `BashArity` (multi-token verbs)
-- [ ] `CwdVerbs` (`cd`, `chdir`, `popd`, `pushd`, ...)
-- [ ] `FileVerbs` (cat, grep, find, ls, ...)
-- [ ] `FlagsWithValue` (per-verb flags that consume the next token)
-- [ ] Probe order: longest-match-first when joining 1, 2, 3 tokens
+- [x] `BashArity` (multi-token verbs) per SPEC §6.1
+- [x] `CwdVerbs` (`cd`, `chdir`, `popd`, `pushd`, `push-location`,
+      `set-location`)
+- [x] `FileVerbs` (full SPEC §6.3 list)
+- [x] `FlagsWithValue` (`git`, `curl`, `wget`, `docker`, `tar`)
+- [x] `ControlFlowKeywords` (for IsUnparseable detection)
+- [x] Probe order: longest-match-first (3-token, then 2-token, then
+      1-token); SPEC note added that flag-with-value-aware probing
+      arrives in PR 4
 
-### 5. BashParser core (SPEC §4)
+### 5. BashParser core (SPEC §4) — PR 3, complete
 
-- [ ] Compound splitting on `&&`, `||`, `;`, `|`
-- [ ] Verb chain extraction using `BashArity`
-- [ ] Args + redirects per clause
-- [ ] Subshell `( ... )` handling
-- [ ] `bash -c "..."` recursion (capped at depth 5)
-- [ ] Anomaly safe-fail (SPEC §11): never throw on well-formed input
+- [x] Compound splitting on `&&`, `||`, `;`, `|`
+- [x] Verb chain extraction using `BashArity` (PR 4 will refine for
+      flag-with-value pairs)
+- [x] Args + redirects per clause (literal-only mode; path classification
+      arrives in PR 4)
+- [x] Subshell `( ... )` framework (inner clauses parse inline;
+      `IsSubshell` flag stays false until PR 5)
+- [x] `bash -c "..."` framework (single-clause mode in PR 3; PR 5 wires
+      recursion + `IsBashCWrapped`)
+- [x] Anomaly safe-fail (SPEC §11): never throw on well-formed input;
+      strict empty-Clauses on anomaly (PR 6 may relax to partial recovery)
+- [x] CorpusRunnerTests skeleton + 50 corpus entries
+- [x] `BashParser.Parse` delegates to `BashCommandParser.Parse`
 
 ### 6. Resolver (SPEC §8)
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -568,8 +568,8 @@ Some flags take values (`-o file`, `-C /repo`, `--output=file`). The parser
 must know which flags consume the next token as a value. Curated table:
 
 ```csharp
-internal static readonly IReadOnlyDictionary<string, IReadOnlySet<string>>
-    FlagsWithValue = new Dictionary<string, IReadOnlySet<string>>(
+internal static readonly IReadOnlyDictionary<string, HashSet<string>>
+    FlagsWithValue = new Dictionary<string, HashSet<string>>(
         StringComparer.OrdinalIgnoreCase)
 {
     ["git"]   = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "-C", "--git-dir", "--work-tree" },
@@ -580,6 +580,16 @@ internal static readonly IReadOnlyDictionary<string, IReadOnlySet<string>>
     // Add as corpus surfaces real cases.
 };
 ```
+
+> **Note:** the value type is `HashSet<string>` (not `IReadOnlySet<string>`)
+> because `IReadOnlySet<string>` is .NET 5+ only and the library
+> multi-targets `netstandard2.0`. Internal-only — no public-API impact.
+
+> **Note (PR 3 → PR 4 follow-up):** the verb-chain probe must run *after*
+> the flag-with-value pair is consumed for invocations like
+> `git -C /repo log`. PR 3 ships the probe at token zero (the simpler
+> shape); PR 4 lands the flag-with-value-aware probe so `git -C /repo log`
+> produces `Verb.Tokens = ["git", "log"]` per SPEC §12's example.
 
 When a flag-with-value consumes the next token, the consumed token's
 `IsPath` flag is set if the value is path-shaped (per the resolver in §8).

--- a/openspec/changes/v0.1-locked-interpretations/tasks.md
+++ b/openspec/changes/v0.1-locked-interpretations/tasks.md
@@ -63,16 +63,46 @@ the SPEC.md sections that get updated alongside the implementation.
 
 ## 3. PR 3 — Verb tables + parser core
 
-- [ ] 3.1 `Internal/Bash/Verbs/BashVerbs.cs` — `BashArity`, `CwdVerbs`,
-      `FileVerbs`, `FlagsWithValue` from SPEC §6
-- [ ] 3.2 `Internal/Bash/Parsing/BashCommandParser.cs` per SPEC §4
-- [ ] 3.3 Compound splitting; verb chain longest-prefix probe; flag/positional
-- [ ] 3.4 Heredoc skip (`<<DELIM` / `<<-DELIM`)
-- [ ] 3.5 Anomaly safe-fail per SPEC §11
-- [ ] 3.6 Wire opaque-substitution tokens into `Arg{ Kind=DynamicSkip }`
-      per interpretation #2
-- [ ] 3.7 Wire arithmetic/complex-param sentinels into
-      `ParsedCommand.IsUnparseable` per interpretation #2
+- [x] 3.1 `Internal/Bash/Verbs/BashVerbs.cs` — `BashArity`, `CwdVerbs`,
+      `FileVerbs`, `FlagsWithValue`, `ControlFlowKeywords` from SPEC §6
+- [x] 3.2 `Internal/Bash/Parsing/BashCommandParser.cs` per SPEC §4
+- [x] 3.3 Compound splitting on `&&`, `||`, `;`, `|`; verb chain
+      longest-prefix probe; flag/positional walking
+- [x] 3.4 Heredoc operator framework (lexer body-skip already in PR 2;
+      parser emits placeholder Redirect)
+- [x] 3.5 Anomaly safe-fail per SPEC §11 (control-flow keyword,
+      function definition, process substitution, unbalanced parens)
+- [x] 3.6 Wire `OpaqueSubstitution` tokens into
+      `Arg{ Kind=DynamicSkip, IsPath=false }` per interpretation #2
+- [x] 3.7 Wire `UnparseableSentinel` tokens into
+      `ParsedCommand.IsUnparseable=true` per interpretation #2
+- [x] 3.8 `BashParser.Parse` delegates to `BashCommandParser.Parse`;
+      placeholder `NotImplementedException` removed
+- [x] 3.9 `CorpusRunnerTests` skeleton (`[Theory] [MemberData]` over
+      `tests/.../Corpus/bash/*.json` with field-by-field comparison;
+      polished AstAssert lands in PR 6)
+- [x] 3.10 Test project copies `Corpus/bash/*.json` to bin output via
+       `<None Update CopyToOutputDirectory="PreserveNewest" />`
+- [x] 3.11 Authored 50 corpus entries: 10 simple-verb + 10 multi-token-verb
+       + 15 compound + 10 redirect + 5 unparseable. PR 4-5 will refine
+       expectations once path classification + cd-attribution land.
+- [x] 3.12 SPEC §7 updated: `FlagsWithValue` value type is `HashSet<string>`
+       (not `IReadOnlySet<string>`) for netstandard2.0 compat; PR 4
+       follow-up note on flag-with-value-aware verb-chain probing
+- [x] 3.13 53 parser unit tests + 50 corpus runner cases. With PR 1+2:
+       **199/199 passing**.
+
+### PR 3 follow-ups (tracked for PR 4)
+
+- Flag-with-value-aware verb-chain probe (`git -C /repo log` →
+  `Verb.Tokens = ["git", "log"]`); currently probe stops at the leading
+  flag and uses `["git"]`. SPEC §12 example expects the post-probe
+  shape, so PR 4 must move the probe to run after flag-with-value
+  consumption.
+- Per-verb path-arg rules + path-shape classification to populate
+  `IsPath`. Corpus entries currently have all literal args at
+  `IsPath=false`; PR 4 will update the corpus to reflect the new
+  classification.
 
 ## 4. PR 4 — Resolver + per-verb rules (interpretations #3 + #8)
 

--- a/src/ShellSyntaxTree/BashParser.cs
+++ b/src/ShellSyntaxTree/BashParser.cs
@@ -10,11 +10,7 @@ namespace ShellSyntaxTree;
 /// <summary>Bash implementation of <see cref="IShellParser"/>.</summary>
 public sealed class BashParser : IShellParser
 {
-    // Stored for use by the lexer/parser passes landing in PRs 2-5; the v0.1.0-alpha
-    // skeleton only locks the public API surface — see SPEC §17 acceptance criteria.
-#pragma warning disable IDE0052, CA1823 // intentionally retained until PR 2 wires this in
     private readonly BashParserOptions _options;
-#pragma warning restore IDE0052, CA1823
 
     /// <summary>
     /// Create a parser with default options.
@@ -46,7 +42,6 @@ public sealed class BashParser : IShellParser
             throw new ArgumentNullException(nameof(command));
         }
 
-        throw new NotImplementedException(
-            "BashParser.Parse will be implemented in PR 2-5; this stub locks the public API surface.");
+        return Internal.Bash.Parsing.BashCommandParser.Parse(command, _options);
     }
 }

--- a/src/ShellSyntaxTree/Internal/Bash/Parsing/BashCommandParser.cs
+++ b/src/ShellSyntaxTree/Internal/Bash/Parsing/BashCommandParser.cs
@@ -1,0 +1,797 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="BashCommandParser.cs" company="Aaron Stannard">
+//      Copyright (C) 2026 - 2026 Aaron Stannard <https://github.com/Aaronontheweb>
+// </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using ShellSyntaxTree.Internal.Bash.Lexing;
+using ShellSyntaxTree.Internal.Bash.Verbs;
+
+namespace ShellSyntaxTree.Internal.Bash.Parsing;
+
+/// <summary>
+/// Translates a <see cref="BashLexer"/> token stream into the public
+/// <see cref="ParsedCommand"/> AST. The parser is intentionally narrow:
+/// PR 3 wires verb chains, args, redirects, compound splitting, and the
+/// safe-fail anomaly behavior in SPEC §11. It does <em>not</em> apply
+/// per-verb path classification or path resolution (PR 4) and stops short
+/// of the full subshell / <c>bash -c</c> recursion treatment described in
+/// SPEC §10 (PR 5 lands that surface flattening + IsBashCWrapped /
+/// IsSubshell attribution + cd-in-compound propagation).
+/// </summary>
+/// <remarks>
+/// PR 3 scope: subshell + <c>bash -c</c> framework only — see comments
+/// next to <see cref="ParseClauseSegment"/> and the segment splitter for
+/// where PR 5 will land real attribution and inner-string flattening.
+/// </remarks>
+internal static class BashCommandParser
+{
+    /// <summary>
+    /// Parse the input string into a <see cref="ParsedCommand"/>. Never
+    /// throws on well-formed input; safe-fails to <c>IsUnparseable=true</c>
+    /// for SPEC §11 anomalies.
+    /// </summary>
+    internal static ParsedCommand Parse(string source, BashParserOptions options)
+    {
+        if (source is null)
+        {
+            throw new ArgumentNullException(nameof(source));
+        }
+
+        // options is currently unused by PR 3 — the resolver lands in PR 4
+        // and consumes HomeDirectory / WorkingDirectory. Discarding here
+        // keeps the call sites stable for the full pipeline.
+        _ = options;
+
+        if (source.Length == 0)
+        {
+            return new ParsedCommand
+            {
+                Source = source,
+                Clauses = Array.Empty<Clause>(),
+                IsUnparseable = false,
+            };
+        }
+
+        var tokens = BashLexer.Tokenize(source);
+
+        // Step 1: lift any UnparseableSentinel to the outer ParsedCommand.
+        // SPEC §11 step 3 says we may also return whatever clauses were
+        // parsed up to that point — for PR 3 we keep it strictly safe-fail
+        // (empty Clauses) so consumers don't get a half-built AST whose
+        // shape changes when PR 5 wires recursion. The reason text comes
+        // straight from the lexer.
+        for (var i = 0; i < tokens.Count; i++)
+        {
+            var t = tokens[i];
+            if (t.Kind == BashTokenKind.UnparseableSentinel)
+            {
+                return new ParsedCommand
+                {
+                    Source = source,
+                    Clauses = Array.Empty<Clause>(),
+                    IsUnparseable = true,
+                    UnparseableReason = t.UnparseableReason,
+                };
+            }
+        }
+
+        // Step 2: split the (filtered, non-whitespace) token stream into
+        // clause segments at top-level &&, ||, ;, and |. Subshell and
+        // bash -c boundaries are recognized as framework only — see
+        // SplitIntoSegments.
+        var significant = FilterSignificant(tokens);
+
+        // Step 3: detect anomalies that map straight to outer IsUnparseable.
+        if (TryDetectAnomaly(significant, out var anomalyReason))
+        {
+            return new ParsedCommand
+            {
+                Source = source,
+                Clauses = Array.Empty<Clause>(),
+                IsUnparseable = true,
+                UnparseableReason = anomalyReason,
+            };
+        }
+
+        var segments = SplitIntoSegments(significant, source, out var splitError);
+        if (splitError is not null)
+        {
+            return new ParsedCommand
+            {
+                Source = source,
+                Clauses = Array.Empty<Clause>(),
+                IsUnparseable = true,
+                UnparseableReason = splitError,
+            };
+        }
+
+        // Step 4: parse each segment into a Clause. Any per-clause anomaly
+        // (control-flow keyword as the verb, function definition shape,
+        // process substitution) flips the outer IsUnparseable.
+        var clauses = new List<Clause>(segments.Count);
+        foreach (var segment in segments)
+        {
+            var clauseOrError = ParseClauseSegment(segment, source);
+            if (clauseOrError.Error is not null)
+            {
+                return new ParsedCommand
+                {
+                    Source = source,
+                    Clauses = Array.Empty<Clause>(),
+                    IsUnparseable = true,
+                    UnparseableReason = clauseOrError.Error,
+                };
+            }
+
+            // ParseClauseSegment produces a list because subshell framework
+            // emits one Clause per inner segment; see comments inside.
+            foreach (var clause in clauseOrError.Clauses)
+            {
+                clauses.Add(clause);
+            }
+        }
+
+        return new ParsedCommand
+        {
+            Source = source,
+            Clauses = clauses,
+            IsUnparseable = false,
+        };
+    }
+
+    // ---------------------------------------------------------------- token filtering
+
+    private static List<BashToken> FilterSignificant(IReadOnlyList<BashToken> tokens)
+    {
+        // Whitespace and Continuation are source-fidelity tokens — irrelevant
+        // for parser logic. Drop them. The remaining list is what every
+        // subsequent step walks.
+        var filtered = new List<BashToken>(tokens.Count);
+        foreach (var t in tokens)
+        {
+            if (t.Kind == BashTokenKind.Whitespace || t.Kind == BashTokenKind.Continuation)
+            {
+                continue;
+            }
+
+            filtered.Add(t);
+        }
+
+        return filtered;
+    }
+
+    // ---------------------------------------------------------------- anomaly detection
+
+    private static bool TryDetectAnomaly(IReadOnlyList<BashToken> tokens, out string? reason)
+    {
+        // Function definition: `name() { ... }`. Trigger = a Word followed
+        // by an immediately-adjacent `(` and `)`. SPEC §11 + locked
+        // interpretation: outer IsUnparseable.
+        for (var i = 0; i + 2 < tokens.Count; i++)
+        {
+            var a = tokens[i];
+            var b = tokens[i + 1];
+            var c = tokens[i + 2];
+            if (a.Kind == BashTokenKind.Word
+                && b.Kind == BashTokenKind.Operator && b.OperatorText == "("
+                && c.Kind == BashTokenKind.Operator && c.OperatorText == ")"
+                && b.SourceStart == a.SourceStart + a.SourceLength
+                && c.SourceStart == b.SourceStart + b.SourceLength)
+            {
+                reason = "function definition is not supported in v0.1";
+                return true;
+            }
+        }
+
+        // Process substitution: `<(cmd)` or `>(cmd)`. The lexer doesn't
+        // emit a dedicated token for these; they show up as `<` or `>`
+        // operators followed *immediately* by `(` (no whitespace between).
+        for (var i = 0; i + 1 < tokens.Count; i++)
+        {
+            var a = tokens[i];
+            var b = tokens[i + 1];
+            if (a.Kind == BashTokenKind.Operator
+                && (a.OperatorText == "<" || a.OperatorText == ">")
+                && b.Kind == BashTokenKind.Operator && b.OperatorText == "("
+                && b.SourceStart == a.SourceStart + a.SourceLength)
+            {
+                reason = "process substitution is not supported in v0.1";
+                return true;
+            }
+        }
+
+        reason = null;
+        return false;
+    }
+
+    // ---------------------------------------------------------------- segment split
+
+    /// <summary>
+    /// One contiguous piece of significant tokens that becomes a single
+    /// <see cref="Clause"/>. Carries the operator that <em>preceded</em>
+    /// the segment in the source, plus a flag for the subshell-framework
+    /// pass-through (see <see cref="ParseClauseSegment"/>).
+    /// </summary>
+    private sealed class Segment
+    {
+        public CompoundOperator PrecedingOperator { get; init; }
+
+        public List<BashToken> Tokens { get; init; } = new();
+
+        /// <summary>
+        /// True when this segment came from inside a subshell <c>(...)</c>
+        /// region. PR 3 surfaces inner clauses without setting
+        /// <c>IsSubshell</c> per the explicit note in the task — that's
+        /// PR 5's job. The flag lives on the segment for forward-compat.
+        /// </summary>
+        public bool FromSubshell { get; init; }
+    }
+
+    /// <summary>
+    /// Walk the significant token list and split on top-level compound
+    /// operators. Tracks paren depth so operators inside a subshell stay
+    /// part of the inner segments. PR 3: subshell inner clauses surface
+    /// inline (no IsSubshell flag); PR 5 will land real attribution +
+    /// IsBashCWrapped / IsSubshell flag flipping + bash -c recursion.
+    /// </summary>
+    private static List<Segment> SplitIntoSegments(
+        IReadOnlyList<BashToken> tokens,
+        string source,
+        out string? error)
+    {
+        var segments = new List<Segment>();
+        var current = new Segment { PrecedingOperator = CompoundOperator.None };
+
+        var depth = 0;
+        // SubshellRegion stack tracks "we entered a subshell" to mark inner
+        // segments' FromSubshell. Empty when at top level.
+        var subshellDepthStack = new Stack<int>();
+
+        for (var i = 0; i < tokens.Count; i++)
+        {
+            var t = tokens[i];
+
+            if (t.Kind == BashTokenKind.Operator)
+            {
+                var op = t.OperatorText;
+
+                if (op == "(")
+                {
+                    // Open subshell: flush current segment if it has content,
+                    // then mark the new context as "inside a subshell."
+                    if (current.Tokens.Count > 0)
+                    {
+                        segments.Add(current);
+                        current = new Segment { PrecedingOperator = CompoundOperator.Sequence, FromSubshell = subshellDepthStack.Count > 0 };
+                    }
+                    else
+                    {
+                        // Inherit FromSubshell from the new (deeper) context.
+                        current = new Segment { PrecedingOperator = current.PrecedingOperator, FromSubshell = true };
+                    }
+
+                    subshellDepthStack.Push(depth);
+                    depth++;
+                    // The opening paren itself is not part of any clause's
+                    // tokens. Continue.
+                    continue;
+                }
+
+                if (op == ")")
+                {
+                    if (depth == 0)
+                    {
+                        error = $"unbalanced parens at position {t.SourceStart}";
+                        return segments;
+                    }
+
+                    depth--;
+                    if (subshellDepthStack.Count > 0)
+                    {
+                        subshellDepthStack.Pop();
+                    }
+
+                    // Flush the inner segment and start a new top-level (or
+                    // deeper-but-still-subshell) segment.
+                    if (current.Tokens.Count > 0)
+                    {
+                        segments.Add(current);
+                    }
+
+                    // After the close paren, the next operator/token decides
+                    // the next segment's preceding operator. We default to
+                    // None and let the operator dispatch below overwrite it.
+                    current = new Segment
+                    {
+                        PrecedingOperator = CompoundOperator.None,
+                        FromSubshell = subshellDepthStack.Count > 0,
+                    };
+                    continue;
+                }
+
+                // Compound operators only split when at top level relative to
+                // the current "shell" — a subshell is its own scope, but its
+                // operators still split the inner segments. Concretely: any
+                // depth (including inside subshells) treats &&/||/;/| as a
+                // splitter for the segment they live in.
+                if (op == "&&" || op == "||" || op == ";" || op == "|")
+                {
+                    if (current.Tokens.Count == 0 && current.PrecedingOperator != CompoundOperator.None)
+                    {
+                        // Two operators in a row, e.g. `&& &&`. Treat as
+                        // unparseable.
+                        error = $"unexpected operator '{op}' at position {t.SourceStart}";
+                        return segments;
+                    }
+
+                    if (current.Tokens.Count > 0)
+                    {
+                        segments.Add(current);
+                    }
+
+                    current = new Segment
+                    {
+                        PrecedingOperator = MapOperator(op),
+                        FromSubshell = subshellDepthStack.Count > 0,
+                    };
+                    continue;
+                }
+
+                // Redirect operators stay inside the current segment.
+                current.Tokens.Add(t);
+                continue;
+            }
+
+            current.Tokens.Add(t);
+        }
+
+        if (depth != 0)
+        {
+            // Find the position of the unmatched '(' for a useful diagnostic.
+            // We don't track it precisely; use the source length as a fallback.
+            error = $"unbalanced parens at position {source.Length}";
+            return segments;
+        }
+
+        if (current.Tokens.Count > 0)
+        {
+            segments.Add(current);
+        }
+
+        error = null;
+        return segments;
+    }
+
+    private static CompoundOperator MapOperator(string? op) => op switch
+    {
+        "&&" => CompoundOperator.AndIf,
+        "||" => CompoundOperator.OrIf,
+        ";" => CompoundOperator.Sequence,
+        "|" => CompoundOperator.Pipe,
+        _ => CompoundOperator.None,
+    };
+
+    // ---------------------------------------------------------------- clause parse
+
+    /// <summary>
+    /// Either a list of clauses (success) or an error reason (failure).
+    /// Multi-clause results are reserved for the subshell framework — a
+    /// single segment can produce one clause for non-subshell input.
+    /// </summary>
+    private readonly struct ClauseResult
+    {
+        public IReadOnlyList<Clause> Clauses { get; }
+
+        public string? Error { get; }
+
+        public ClauseResult(IReadOnlyList<Clause> clauses, string? error)
+        {
+            Clauses = clauses;
+            Error = error;
+        }
+
+        public static ClauseResult Empty() => new(Array.Empty<Clause>(), null);
+
+        public static ClauseResult Ok(Clause c) => new(new[] { c }, null);
+
+        public static ClauseResult Fail(string reason) => new(Array.Empty<Clause>(), reason);
+    }
+
+    private static ClauseResult ParseClauseSegment(Segment segment, string source)
+    {
+        // Empty segment (e.g. trailing `;`): just drop it. We materialize
+        // an empty clause only when the segment carries a preceding
+        // operator AND tokens; the splitter already prevents the "operator
+        // with no tokens" case via the `unexpected operator` error.
+        if (segment.Tokens.Count == 0)
+        {
+            return ClauseResult.Empty();
+        }
+
+        // Verb chain extraction. Probe the first 1–3 verb-eligible tokens
+        // against BashVerbs.BashArity. PR 3 keeps things simple: only
+        // consecutive Word/QuotedString/OpaqueSubstitution tokens at the
+        // very start qualify as verb candidates. Redirect operators or any
+        // other operator immediately end the verb chain.
+        var verbCandidateValues = new List<string>(3);
+        var verbCandidateIndices = new List<int>(3);
+        for (var i = 0; i < segment.Tokens.Count && verbCandidateValues.Count < 3; i++)
+        {
+            var t = segment.Tokens[i];
+            if (t.Kind == BashTokenKind.Word || t.Kind == BashTokenKind.QuotedString)
+            {
+                // A flag-like word stops verb-chain probing — flags belong
+                // to args, never to verbs.
+                if (IsFlagWord(t))
+                {
+                    break;
+                }
+
+                verbCandidateValues.Add(t.Value);
+                verbCandidateIndices.Add(i);
+                continue;
+            }
+
+            break;
+        }
+
+        if (verbCandidateValues.Count == 0)
+        {
+            // No verb tokens at all. Could be a redirect-only clause
+            // (`> /tmp/out` is rare but technically valid bash). Return an
+            // empty-verb clause; consumers can detect this with
+            // `Verb.Tokens.Count == 0`.
+            var redirectsOnly = ExtractRedirectsAndArgs(
+                segment.Tokens, 0, source, out var emptyArgs, out var emptyRedirects, out var redirectError);
+            if (redirectError is not null)
+            {
+                return ClauseResult.Fail(redirectError);
+            }
+
+            _ = redirectsOnly;
+            return ClauseResult.Ok(new Clause
+            {
+                Operator = segment.PrecedingOperator,
+                Verb = new VerbChain(),
+                Args = emptyArgs,
+                Redirects = emptyRedirects,
+                IsSubshell = false, // PR 5 will set this for FromSubshell segments.
+                IsBashCWrapped = false, // PR 5.
+            });
+        }
+
+        // Anomaly: control-flow keyword as the leading verb.
+        var firstVerb = verbCandidateValues[0];
+        if (BashVerbs.ControlFlowKeywords.Contains(firstVerb))
+        {
+            return ClauseResult.Fail(
+                $"control-flow keyword '{firstVerb}' is not supported in v0.1");
+        }
+
+        var arity = BashVerbs.ProbeArity(verbCandidateValues, 0);
+        if (arity <= 0)
+        {
+            arity = 1;
+        }
+
+        // Build the verb chain.
+        var verbTokens = new List<string>(arity);
+        for (var k = 0; k < arity; k++)
+        {
+            verbTokens.Add(verbCandidateValues[k]);
+        }
+
+        // Position in segment.Tokens immediately after the verb chain.
+        var argStart = verbCandidateIndices[arity - 1] + 1;
+
+        // Determine the verb name we use to drive flag-with-value lookups.
+        // SPEC §7's table is keyed on the *first* token (`git`, `docker`,
+        // `tar`, ...). Multi-token verbs share the first-token's table.
+        var verbKeyForFlags = verbTokens[0];
+
+        var argsAndRedirects = ExtractRedirectsAndArgs(
+            segment.Tokens,
+            argStart,
+            source,
+            out var args,
+            out var redirects,
+            out var argError);
+        if (argError is not null)
+        {
+            return ClauseResult.Fail(argError);
+        }
+
+        _ = argsAndRedirects;
+
+        // Apply flag-with-value pairing. Per SPEC §7 the *value* arg's
+        // IsPath classification lands in PR 4; for PR 3 both flag and
+        // value remain in Args with default-literal kind.
+        args = ApplyFlagsWithValue(verbKeyForFlags, args);
+
+        var clause = new Clause
+        {
+            Operator = segment.PrecedingOperator,
+            Verb = new VerbChain { Tokens = verbTokens },
+            Args = args,
+            Redirects = redirects,
+            IsSubshell = false, // PR 3: framework only; PR 5 sets this for FromSubshell segments.
+            IsBashCWrapped = false, // PR 3: framework only; PR 5 lands real bash -c recursion.
+        };
+
+        return ClauseResult.Ok(clause);
+    }
+
+    private static bool IsFlagWord(BashToken token)
+    {
+        // A leading '-' marks a flag. QuotedString tokens are never flags
+        // — quoting a leading dash is the user's signal "treat as literal."
+        if (token.Kind != BashTokenKind.Word)
+        {
+            return false;
+        }
+
+        return token.Value.Length > 0 && token.Value[0] == '-';
+    }
+
+    // ---------------------------------------------------------------- args + redirects
+
+    private static int ExtractRedirectsAndArgs(
+        IReadOnlyList<BashToken> segmentTokens,
+        int start,
+        string source,
+        out IReadOnlyList<Arg> args,
+        out IReadOnlyList<Redirect> redirects,
+        out string? error)
+    {
+        var argList = new List<Arg>();
+        var redirectList = new List<Redirect>();
+        var i = start;
+        while (i < segmentTokens.Count)
+        {
+            var t = segmentTokens[i];
+            if (t.Kind == BashTokenKind.Operator)
+            {
+                if (TryMapRedirect(t.OperatorText, out var dir))
+                {
+                    // Heredoc operators come through as a redirect operator
+                    // followed by a Word delimiter. PR 3 emits the redirect
+                    // as Direction=In, Target=<delim> with no special flag —
+                    // sufficient to keep clause boundaries while we ship
+                    // the rest of the parser.
+                    if (i + 1 >= segmentTokens.Count)
+                    {
+                        error = $"redirect operator '{t.OperatorText}' missing target at position {t.SourceStart}";
+                        args = argList;
+                        redirects = redirectList;
+                        return i;
+                    }
+
+                    var target = segmentTokens[i + 1];
+                    if (target.Kind == BashTokenKind.Operator)
+                    {
+                        error = $"redirect operator '{t.OperatorText}' missing target at position {t.SourceStart}";
+                        args = argList;
+                        redirects = redirectList;
+                        return i;
+                    }
+
+                    var isDynamic = target.Kind == BashTokenKind.OpaqueSubstitution;
+                    var redirectTarget = target.Kind == BashTokenKind.OpaqueSubstitution
+                        ? target.Value
+                        : SourceSlice(source, target);
+
+                    redirectList.Add(new Redirect
+                    {
+                        Direction = dir,
+                        Target = redirectTarget,
+                        IsDynamicSkip = isDynamic,
+                    });
+
+                    i += 2;
+                    continue;
+                }
+
+                // Heredoc operators show up as `<<` / `<<-` from the lexer.
+                // PR 3 treats them like the In redirect for the purpose of
+                // pinning a placeholder; the body is already dropped by the
+                // lexer so the next token is the delimiter Word.
+                if (t.OperatorText == "<<" || t.OperatorText == "<<-")
+                {
+                    if (i + 1 >= segmentTokens.Count)
+                    {
+                        error = $"heredoc operator '{t.OperatorText}' missing delimiter at position {t.SourceStart}";
+                        args = argList;
+                        redirects = redirectList;
+                        return i;
+                    }
+
+                    var delim = segmentTokens[i + 1];
+                    redirectList.Add(new Redirect
+                    {
+                        Direction = RedirectDirection.In,
+                        Target = "<<" + delim.Value + ">",
+                        IsDynamicSkip = false,
+                    });
+
+                    i += 2;
+                    continue;
+                }
+
+                // Any other operator inside a clause segment is unexpected.
+                error = $"unexpected operator '{t.OperatorText}' at position {t.SourceStart}";
+                args = argList;
+                redirects = redirectList;
+                return i;
+            }
+
+            // Args.
+            switch (t.Kind)
+            {
+                case BashTokenKind.Word:
+                {
+                    // Equals-form flag-with-value: `--output=file` splits on
+                    // the first `=`. Both halves enter Args. The path-shape
+                    // classification lives in PR 4.
+                    var raw = SourceSlice(source, t);
+                    if (TrySplitEqualsFlag(t.Value, out var flagPart, out var valuePart))
+                    {
+                        argList.Add(new Arg
+                        {
+                            Raw = flagPart,
+                            Resolved = null,
+                            Kind = ArgKind.Literal,
+                            IsPath = false,
+                        });
+                        argList.Add(new Arg
+                        {
+                            Raw = valuePart,
+                            Resolved = null,
+                            Kind = ArgKind.Literal,
+                            IsPath = false,
+                        });
+                    }
+                    else
+                    {
+                        argList.Add(new Arg
+                        {
+                            Raw = raw,
+                            Resolved = null,
+                            Kind = ArgKind.Literal,
+                            IsPath = false,
+                        });
+                    }
+
+                    break;
+                }
+
+                case BashTokenKind.QuotedString:
+                {
+                    argList.Add(new Arg
+                    {
+                        Raw = SourceSlice(source, t),
+                        Resolved = null,
+                        Kind = ArgKind.Literal,
+                        IsPath = false,
+                    });
+                    break;
+                }
+
+                case BashTokenKind.OpaqueSubstitution:
+                {
+                    // Locked interpretation #2: opaque region collapses to
+                    // a single DynamicSkip arg; the surrounding clause
+                    // continues to parse normally.
+                    argList.Add(new Arg
+                    {
+                        Raw = t.Value,
+                        Resolved = null,
+                        Kind = ArgKind.DynamicSkip,
+                        IsPath = false,
+                    });
+                    break;
+                }
+
+                default:
+                    // UnparseableSentinel is filtered earlier; Whitespace /
+                    // Continuation are filtered in FilterSignificant. Any
+                    // other kind would be a parser bug, but stay quiet —
+                    // dropping unknown kinds is safer than crashing.
+                    break;
+            }
+
+            i++;
+        }
+
+        args = argList;
+        redirects = redirectList;
+        error = null;
+        return i;
+    }
+
+    private static bool TryMapRedirect(string? op, out RedirectDirection direction)
+    {
+        switch (op)
+        {
+            case ">":
+                direction = RedirectDirection.Out;
+                return true;
+            case ">>":
+                direction = RedirectDirection.Append;
+                return true;
+            case "<":
+                direction = RedirectDirection.In;
+                return true;
+            case "2>":
+                direction = RedirectDirection.ErrOut;
+                return true;
+            case "2>>":
+                direction = RedirectDirection.ErrAppend;
+                return true;
+            default:
+                direction = default;
+                return false;
+        }
+    }
+
+    private static bool TrySplitEqualsFlag(string raw, out string flagPart, out string valuePart)
+    {
+        // Only split when the leading character is '-' (so `KEY=value`
+        // stays a single arg, but `--output=file` becomes two). The split
+        // happens at the *first* '=' to preserve values that contain '='.
+        if (raw.Length < 2 || raw[0] != '-')
+        {
+            flagPart = "";
+            valuePart = "";
+            return false;
+        }
+
+        var eq = raw.IndexOf('=');
+        if (eq <= 0 || eq == raw.Length - 1)
+        {
+            // No '=' or trailing '=' (no value to split off).
+            flagPart = "";
+            valuePart = "";
+            return false;
+        }
+
+        flagPart = raw.Substring(0, eq);
+        valuePart = raw.Substring(eq + 1);
+        return true;
+    }
+
+    private static IReadOnlyList<Arg> ApplyFlagsWithValue(string verbKey, IReadOnlyList<Arg> args)
+    {
+        if (!BashVerbs.FlagsWithValue.TryGetValue(verbKey, out var flagsWithValue))
+        {
+            return args;
+        }
+
+        // PR 3 doesn't change Arg shape based on the pairing — both flag
+        // and value remain in Args with default-literal kind. The pairing
+        // matters in PR 4 for IsPath classification. We still walk the
+        // list so the structural shape stays identical with what PR 4 will
+        // produce; the assignment is currently a no-op but locks the loop
+        // in place.
+        var unused = flagsWithValue;
+        _ = unused;
+        return args;
+    }
+
+    private static string SourceSlice(string source, BashToken token)
+    {
+        if (token.SourceStart < 0 || token.SourceStart >= source.Length)
+        {
+            return token.Value;
+        }
+
+        var len = token.SourceLength;
+        if (token.SourceStart + len > source.Length)
+        {
+            len = source.Length - token.SourceStart;
+        }
+
+        return source.Substring(token.SourceStart, len);
+    }
+}

--- a/src/ShellSyntaxTree/Internal/Bash/Verbs/BashVerbs.cs
+++ b/src/ShellSyntaxTree/Internal/Bash/Verbs/BashVerbs.cs
@@ -1,0 +1,239 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="BashVerbs.cs" company="Aaron Stannard">
+//      Copyright (C) 2026 - 2026 Aaron Stannard <https://github.com/Aaronontheweb>
+// </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+
+namespace ShellSyntaxTree.Internal.Bash.Verbs;
+
+/// <summary>
+/// Static, case-insensitive verb data per SPEC §6 / §7. These are *data*,
+/// not logic — the parser probes them and applies the rules described in
+/// the SPEC. Centralizing the tables here keeps the parser readable and
+/// keeps reviewers' eyes on a single file when curating verb knowledge.
+/// </summary>
+internal static class BashVerbs
+{
+    /// <summary>
+    /// How many tokens form the verb chain for known commands. Defaults to
+    /// 1 when not in the table. SPEC §6.1.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Per the SPEC §6.1 implementation note, the parser must look up
+    /// multi-token verbs by joining the first 1, 2, then 3 tokens and
+    /// probing the table from <em>longest to shortest</em>. So
+    /// <c>docker compose up nginx</c> first probes <c>docker compose up</c>
+    /// (not in table), then <c>docker compose</c> (arity 3 — match). The
+    /// matched key's value <em>is</em> the verb chain length, so e.g.
+    /// <c>docker compose</c>'s value of 3 means "consume three source
+    /// tokens as the verb chain."
+    /// </para>
+    /// <para>
+    /// The table is non-exhaustive. Verbs not listed default to a 1-token
+    /// chain. Add entries as the corpus surfaces real commands.
+    /// </para>
+    /// </remarks>
+    internal static readonly IReadOnlyDictionary<string, int> BashArity =
+        new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase)
+        {
+            // Two-token verbs.
+            ["git"] = 2,
+            ["dotnet"] = 2,
+            ["npm"] = 2,
+            ["yarn"] = 2,
+            ["pnpm"] = 2,
+            ["cargo"] = 2,
+            ["go"] = 2,
+            ["kubectl"] = 2,
+            ["helm"] = 2,
+            ["systemctl"] = 2,
+            ["service"] = 2,
+            ["pip"] = 2,
+            ["pip3"] = 2,
+            ["brew"] = 2,
+            ["apt"] = 2,
+            ["apt-get"] = 2,
+            ["yum"] = 2,
+            ["dnf"] = 2,
+            ["pacman"] = 2,
+            ["aws"] = 2,
+            ["gcloud"] = 2,
+            ["az"] = 2,
+            ["docker"] = 2,
+            ["docker-compose"] = 2,
+            ["bun"] = 2,
+            ["nuget"] = 2,
+
+            // Three-token verbs.
+            ["docker compose"] = 3,
+            ["bun run"] = 3,
+        };
+
+    /// <summary>
+    /// Verbs whose first non-flag positional arg becomes the cwd for
+    /// subsequent clauses in the same compound. SPEC §6.2.
+    /// </summary>
+    /// <remarks>
+    /// <c>push-location</c> / <c>set-location</c> are PowerShell idioms
+    /// listed for forward-compat; v0.1 only emits attribution for
+    /// <c>cd</c> / <c>chdir</c> per locked interpretation #5.
+    /// </remarks>
+    internal static readonly HashSet<string> CwdVerbs =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            "cd",
+            "chdir",
+            "popd",
+            "pushd",
+            "push-location",
+            "set-location",
+        };
+
+    /// <summary>
+    /// Verbs whose positional args are paths. The default extraction rule
+    /// is "all non-flag positional args after the verb chain are paths,"
+    /// modulo per-verb overrides in SPEC §7. SPEC §6.3.
+    /// </summary>
+    /// <remarks>
+    /// CWD verbs are also FILE verbs (their target is a path), included
+    /// here for closure so a single membership check suffices.
+    /// </remarks>
+    internal static readonly HashSet<string> FileVerbs =
+        new(StringComparer.OrdinalIgnoreCase)
+        {
+            // CWD verbs (also file verbs).
+            "cd", "chdir", "popd", "pushd", "push-location", "set-location",
+
+            // File mutation.
+            "rm", "cp", "mv", "mkdir", "rmdir", "touch", "ln",
+            "chmod", "chown", "chgrp", "stat", "test",
+
+            // Read.
+            "cat", "less", "more", "head", "tail", "grep", "rg",
+            "find", "fd", "locate", "wc", "file",
+
+            // Editors / text tools.
+            "sed", "awk", "vi", "vim", "nano", "emacs", "ed",
+
+            // Compression.
+            "tar", "zip", "unzip", "gzip", "gunzip", "bzip2", "xz",
+
+            // Network with file targets.
+            "curl", "wget", "scp", "rsync", "sftp",
+
+            // Shell / interpreter loaders.
+            "bash", "sh", "zsh", "fish",
+            "python", "python3", "node", "ruby", "perl", "php",
+
+            // Diff / patch.
+            "diff", "patch", "cmp",
+
+            // Listing.
+            "ls", "dir", "tree",
+        };
+
+    /// <summary>
+    /// Per-verb table of flags whose <em>next</em> token is consumed as the
+    /// flag's value. Per SPEC §7, the equals form
+    /// (<c>--output=file</c>) is the same logical case but realized
+    /// differently in the lexer; the parser splits on <c>=</c> and emits
+    /// two args.
+    /// </summary>
+    /// <remarks>
+    /// Value type is <see cref="HashSet{T}"/> rather than
+    /// <c>IReadOnlySet&lt;string&gt;</c> for netstandard2.0 parity —
+    /// <c>IReadOnlySet&lt;T&gt;</c> ships in net5+ only. Internally the
+    /// shape is identical (case-insensitive set lookup).
+    /// </remarks>
+    internal static readonly IReadOnlyDictionary<string, HashSet<string>>
+        FlagsWithValue = new Dictionary<string, HashSet<string>>(
+            StringComparer.OrdinalIgnoreCase)
+        {
+            ["git"] = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "-C", "--git-dir", "--work-tree",
+            },
+            ["curl"] = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "-o", "--output", "-d", "--data",
+            },
+            ["wget"] = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "-O", "--output-document",
+            },
+            ["docker"] = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "-v", "--volume", "-f", "--file",
+            },
+            ["tar"] = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+            {
+                "-f", "--file", "-C", "--directory",
+            },
+        };
+
+    /// <summary>
+    /// Resolve the verb-chain length for a token sequence at <paramref name="start"/>.
+    /// Implements the longest-prefix probe from SPEC §6.1: try the first 3
+    /// tokens, then 2, then 1, returning the matching arity.
+    /// </summary>
+    /// <param name="tokens">Source-order list of verb-candidate tokens.</param>
+    /// <param name="start">Index into <paramref name="tokens"/> where the verb chain begins.</param>
+    /// <returns>
+    /// 1, 2, or 3 — the number of tokens that form the verb chain.
+    /// Defaults to 1 when no match is found (per SPEC §6.1) or when fewer
+    /// than the probed-prefix length tokens remain.
+    /// </returns>
+    internal static int ProbeArity(IReadOnlyList<string> tokens, int start)
+    {
+        var available = tokens.Count - start;
+        if (available <= 0)
+        {
+            return 0;
+        }
+
+        // Three-token probe.
+        if (available >= 3)
+        {
+            var key3 = tokens[start] + " " + tokens[start + 1] + " " + tokens[start + 2];
+            if (BashArity.TryGetValue(key3, out var arity3) && arity3 == 3)
+            {
+                return 3;
+            }
+        }
+
+        // Two-token probe.
+        if (available >= 2)
+        {
+            var key2 = tokens[start] + " " + tokens[start + 1];
+            if (BashArity.TryGetValue(key2, out var arity2))
+            {
+                return Math.Min(arity2, available);
+            }
+        }
+
+        // Single-token probe (default arity 1).
+        if (BashArity.TryGetValue(tokens[start], out var arity1))
+        {
+            return Math.Min(arity1, available);
+        }
+
+        return 1;
+    }
+
+    /// <summary>
+    /// Control-flow keywords that v0.1 explicitly does not parse. Per SPEC
+    /// §11, encountering one as a clause's verb sets
+    /// <c>ParsedCommand.IsUnparseable = true</c>.
+    /// </summary>
+    internal static readonly HashSet<string> ControlFlowKeywords =
+        new(StringComparer.Ordinal)
+        {
+            "for", "while", "until", "do", "done",
+            "if", "then", "elif", "else", "fi",
+            "case", "esac", "select", "in",
+            "function",
+        };
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/CorpusRunnerTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Corpus/CorpusRunnerTests.cs
@@ -1,0 +1,256 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="CorpusRunnerTests.cs" company="Aaron Stannard">
+//      Copyright (C) 2026 - 2026 Aaron Stannard <https://github.com/Aaronontheweb>
+// </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Xunit;
+
+namespace ShellSyntaxTree.Tests.Corpus;
+
+/// <summary>
+/// Drives the JSON corpus under <c>tests/ShellSyntaxTree.Tests/Corpus/bash/</c>.
+/// Each entry pairs an <c>input</c> string with an <c>expected</c>
+/// <see cref="ParsedCommand"/> shape; the runner parses the input and
+/// compares the result field-by-field. PR 3 ships a basic comparison
+/// helper; PR 6 will polish to <c>AstAssert.Equal</c> with rich diffs.
+/// </summary>
+public class CorpusRunnerTests
+{
+    [Theory]
+    [MemberData(nameof(CorpusEntries))]
+    public void Corpus_entry_parses_to_expected_ast(string fileName, CorpusEntry entry)
+    {
+        Assert.NotNull(entry);
+        Assert.False(string.IsNullOrEmpty(entry.Name), $"Corpus entry {fileName} has no name.");
+        Assert.NotNull(entry.Expected);
+
+        var parser = new BashParser();
+        var actual = parser.Parse(entry.Input);
+
+        AssertParsedCommandEqual(entry.Expected!, actual, fileName);
+    }
+
+    public static IEnumerable<object[]> CorpusEntries()
+    {
+        var dir = Path.Combine(AppContext.BaseDirectory, "Corpus", "bash");
+        if (!Directory.Exists(dir))
+        {
+            // Empty corpus is a valid state until entries arrive.
+            yield break;
+        }
+
+        var files = Directory.GetFiles(dir, "*.json").OrderBy(f => f).ToArray();
+        foreach (var file in files)
+        {
+            CorpusEntry? entry;
+            try
+            {
+                entry = JsonSerializer.Deserialize<CorpusEntry>(
+                    File.ReadAllText(file),
+                    JsonOptions);
+            }
+            catch (JsonException ex)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to deserialize corpus entry {Path.GetFileName(file)}: {ex.Message}", ex);
+            }
+
+            if (entry is null)
+            {
+                throw new InvalidOperationException(
+                    $"Corpus entry {Path.GetFileName(file)} deserialized to null.");
+            }
+
+            yield return new object[] { Path.GetFileName(file), entry };
+        }
+    }
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        ReadCommentHandling = JsonCommentHandling.Skip,
+        AllowTrailingCommas = true,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    // -------- structural assertion (rough; PR 6 polishes) --------
+
+    private static void AssertParsedCommandEqual(
+        ExpectedParsedCommand expected, ParsedCommand actual, string fileName)
+    {
+        var diffPrefix = $"[{fileName}] ";
+
+        Assert.True(
+            expected.IsUnparseable == actual.IsUnparseable,
+            diffPrefix + $"IsUnparseable mismatch. expected={expected.IsUnparseable}, actual={actual.IsUnparseable}; reason={actual.UnparseableReason}");
+
+        if (expected.IsUnparseable)
+        {
+            // PR 3: don't pin the exact reason text — it's an implementation
+            // detail. The corpus author can include `unparseableReasonContains`
+            // for a substring contract.
+            if (!string.IsNullOrEmpty(expected.UnparseableReasonContains))
+            {
+                Assert.True(
+                    actual.UnparseableReason is not null
+                    && actual.UnparseableReason.Contains(expected.UnparseableReasonContains, StringComparison.Ordinal),
+                    diffPrefix + $"UnparseableReason should contain '{expected.UnparseableReasonContains}', got: '{actual.UnparseableReason}'");
+            }
+
+            return;
+        }
+
+        var expectedClauses = expected.Clauses ?? new List<ExpectedClause>();
+        Assert.True(
+            expectedClauses.Count == actual.Clauses.Count,
+            diffPrefix + $"Clause count mismatch. expected={expectedClauses.Count}, actual={actual.Clauses.Count}\n"
+            + DumpActual(actual));
+
+        for (var i = 0; i < expectedClauses.Count; i++)
+        {
+            AssertClauseEqual(expectedClauses[i], actual.Clauses[i], diffPrefix + $"clause[{i}]: ");
+        }
+    }
+
+    private static void AssertClauseEqual(ExpectedClause expected, Clause actual, string diffPrefix)
+    {
+        Assert.True(
+            expected.Operator == actual.Operator,
+            diffPrefix + $"Operator mismatch. expected={expected.Operator}, actual={actual.Operator}");
+
+        var expectedVerb = expected.Verb ?? new List<string>();
+        Assert.True(
+            expectedVerb.SequenceEqual(actual.Verb.Tokens),
+            diffPrefix + $"Verb mismatch. expected=[{string.Join(",", expectedVerb)}], actual=[{string.Join(",", actual.Verb.Tokens)}]");
+
+        var expectedArgs = expected.Args ?? new List<ExpectedArg>();
+        Assert.True(
+            expectedArgs.Count == actual.Args.Count,
+            diffPrefix + $"Args count mismatch. expected={expectedArgs.Count}, actual={actual.Args.Count}\n"
+            + " actual args: " + string.Join(", ", actual.Args.Select(a => $"({a.Raw}, kind={a.Kind})")));
+
+        for (var i = 0; i < expectedArgs.Count; i++)
+        {
+            AssertArgEqual(expectedArgs[i], actual.Args[i], diffPrefix + $"arg[{i}]: ");
+        }
+
+        var expectedRedirects = expected.Redirects ?? new List<ExpectedRedirect>();
+        Assert.True(
+            expectedRedirects.Count == actual.Redirects.Count,
+            diffPrefix + $"Redirects count mismatch. expected={expectedRedirects.Count}, actual={actual.Redirects.Count}");
+
+        for (var i = 0; i < expectedRedirects.Count; i++)
+        {
+            AssertRedirectEqual(expectedRedirects[i], actual.Redirects[i], diffPrefix + $"redirect[{i}]: ");
+        }
+
+        Assert.True(
+            expected.IsSubshell == actual.IsSubshell,
+            diffPrefix + $"IsSubshell mismatch. expected={expected.IsSubshell}, actual={actual.IsSubshell}");
+        Assert.True(
+            expected.IsBashCWrapped == actual.IsBashCWrapped,
+            diffPrefix + $"IsBashCWrapped mismatch. expected={expected.IsBashCWrapped}, actual={actual.IsBashCWrapped}");
+    }
+
+    private static void AssertArgEqual(ExpectedArg expected, Arg actual, string diffPrefix)
+    {
+        Assert.True(expected.Raw == actual.Raw, diffPrefix + $"Raw mismatch. expected='{expected.Raw}', actual='{actual.Raw}'");
+        Assert.True(expected.Kind == actual.Kind, diffPrefix + $"Kind mismatch. expected={expected.Kind}, actual={actual.Kind}");
+        Assert.True(expected.IsPath == actual.IsPath, diffPrefix + $"IsPath mismatch. expected={expected.IsPath}, actual={actual.IsPath}");
+        // isFlag is computed; assert when present so corpus can document it.
+        if (expected.IsFlag.HasValue)
+        {
+            Assert.True(expected.IsFlag.Value == actual.IsFlag, diffPrefix + $"IsFlag mismatch. expected={expected.IsFlag}, actual={actual.IsFlag}");
+        }
+    }
+
+    private static void AssertRedirectEqual(ExpectedRedirect expected, Redirect actual, string diffPrefix)
+    {
+        Assert.True(expected.Direction == actual.Direction, diffPrefix + $"Direction mismatch. expected={expected.Direction}, actual={actual.Direction}");
+        Assert.True(expected.Target == actual.Target, diffPrefix + $"Target mismatch. expected='{expected.Target}', actual='{actual.Target}'");
+        if (expected.IsDynamicSkip.HasValue)
+        {
+            Assert.True(expected.IsDynamicSkip.Value == actual.IsDynamicSkip, diffPrefix + $"IsDynamicSkip mismatch. expected={expected.IsDynamicSkip}, actual={actual.IsDynamicSkip}");
+        }
+    }
+
+    private static string DumpActual(ParsedCommand actual) =>
+        JsonSerializer.Serialize(new
+        {
+            actual.Source,
+            actual.IsUnparseable,
+            actual.UnparseableReason,
+            Clauses = actual.Clauses.Select(c => new
+            {
+                Operator = c.Operator.ToString(),
+                Verb = c.Verb.Tokens,
+                Args = c.Args.Select(a => new { a.Raw, Kind = a.Kind.ToString(), a.IsPath, a.IsFlag }),
+                Redirects = c.Redirects.Select(r => new { Direction = r.Direction.ToString(), r.Target, r.IsDynamicSkip }),
+                c.IsSubshell,
+                c.IsBashCWrapped,
+            }),
+        }, new JsonSerializerOptions { WriteIndented = true });
+}
+
+// -------- corpus DTOs (JSON shape; PR 6 may move into a shared file) --------
+
+public sealed record CorpusEntry
+{
+    public string Name { get; init; } = "";
+
+    public string Input { get; init; } = "";
+
+    public ExpectedParsedCommand? Expected { get; init; }
+
+    public string? Notes { get; init; }
+}
+
+public sealed record ExpectedParsedCommand
+{
+    public bool IsUnparseable { get; init; }
+
+    public string? UnparseableReasonContains { get; init; }
+
+    public List<ExpectedClause>? Clauses { get; init; }
+}
+
+public sealed record ExpectedClause
+{
+    public CompoundOperator Operator { get; init; }
+
+    public List<string>? Verb { get; init; }
+
+    public List<ExpectedArg>? Args { get; init; }
+
+    public List<ExpectedRedirect>? Redirects { get; init; }
+
+    public bool IsSubshell { get; init; }
+
+    public bool IsBashCWrapped { get; init; }
+}
+
+public sealed record ExpectedArg
+{
+    public string Raw { get; init; } = "";
+
+    public ArgKind Kind { get; init; } = ArgKind.Literal;
+
+    public bool IsPath { get; init; }
+
+    public bool? IsFlag { get; init; }
+}
+
+public sealed record ExpectedRedirect
+{
+    public RedirectDirection Direction { get; init; }
+
+    public string Target { get; init; } = "";
+
+    public bool? IsDynamicSkip { get; init; }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/01_simple_ls.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/01_simple_ls.json
@@ -1,0 +1,18 @@
+{
+  "name": "Simple verb: ls",
+  "input": "ls",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["ls"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  },
+  "notes": "Default arity 1; no args."
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/02_ls_la_tmp.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/02_ls_la_tmp.json
@@ -1,0 +1,21 @@
+{
+  "name": "ls with flag and path arg",
+  "input": "ls -la /tmp",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["ls"],
+        "args": [
+          { "raw": "-la", "kind": "Literal", "isPath": false, "isFlag": true },
+          { "raw": "/tmp", "kind": "Literal", "isPath": false, "isFlag": false }
+        ],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  },
+  "notes": "PR 3 keeps isPath=false; path classification arrives in PR 4."
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/03_simple_pwd.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/03_simple_pwd.json
@@ -1,0 +1,17 @@
+{
+  "name": "Simple verb: pwd",
+  "input": "pwd",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["pwd"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/04_echo_hello.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/04_echo_hello.json
@@ -1,0 +1,19 @@
+{
+  "name": "Simple verb: echo hello",
+  "input": "echo hello",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["echo"],
+        "args": [
+          { "raw": "hello", "kind": "Literal", "isPath": false }
+        ],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/05_cat_etc_hostname.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/05_cat_etc_hostname.json
@@ -1,0 +1,20 @@
+{
+  "name": "Simple verb: cat /etc/hostname",
+  "input": "cat /etc/hostname",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["cat"],
+        "args": [
+          { "raw": "/etc/hostname", "kind": "Literal", "isPath": false }
+        ],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  },
+  "notes": "isPath=false in PR 3; PR 4 will mark as path."
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/06_mkdir_tmp_foo.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/06_mkdir_tmp_foo.json
@@ -1,0 +1,19 @@
+{
+  "name": "Simple verb: mkdir /tmp/foo",
+  "input": "mkdir /tmp/foo",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["mkdir"],
+        "args": [
+          { "raw": "/tmp/foo", "kind": "Literal", "isPath": false }
+        ],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/07_rm_tmp_foo.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/07_rm_tmp_foo.json
@@ -1,0 +1,19 @@
+{
+  "name": "Simple verb: rm /tmp/foo",
+  "input": "rm /tmp/foo",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["rm"],
+        "args": [
+          { "raw": "/tmp/foo", "kind": "Literal", "isPath": false }
+        ],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/08_touch_file.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/08_touch_file.json
@@ -1,0 +1,19 @@
+{
+  "name": "Simple verb: touch file",
+  "input": "touch file",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["touch"],
+        "args": [
+          { "raw": "file", "kind": "Literal", "isPath": false }
+        ],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/09_whoami.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/09_whoami.json
@@ -1,0 +1,17 @@
+{
+  "name": "Simple verb: whoami",
+  "input": "whoami",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["whoami"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/10_date.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/10_date.json
@@ -1,0 +1,17 @@
+{
+  "name": "Simple verb: date",
+  "input": "date",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["date"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/11_git_push_origin_main.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/11_git_push_origin_main.json
@@ -1,0 +1,21 @@
+{
+  "name": "Multi-token verb: git push origin main",
+  "input": "git push origin main",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["git", "push"],
+        "args": [
+          { "raw": "origin", "kind": "Literal", "isPath": false },
+          { "raw": "main", "kind": "Literal", "isPath": false }
+        ],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  },
+  "notes": "git arity=2 → first two source tokens become the verb chain."
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/12_git_log_oneline.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/12_git_log_oneline.json
@@ -1,0 +1,19 @@
+{
+  "name": "Multi-token verb: git log --oneline",
+  "input": "git log --oneline",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["git", "log"],
+        "args": [
+          { "raw": "--oneline", "kind": "Literal", "isPath": false, "isFlag": true }
+        ],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/13_git_checkout_dev.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/13_git_checkout_dev.json
@@ -1,0 +1,19 @@
+{
+  "name": "Multi-token verb: git checkout dev",
+  "input": "git checkout dev",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["git", "checkout"],
+        "args": [
+          { "raw": "dev", "kind": "Literal", "isPath": false }
+        ],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/14_dotnet_build.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/14_dotnet_build.json
@@ -1,0 +1,17 @@
+{
+  "name": "Multi-token verb: dotnet build",
+  "input": "dotnet build",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["dotnet", "build"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/15_dotnet_test.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/15_dotnet_test.json
@@ -1,0 +1,17 @@
+{
+  "name": "Multi-token verb: dotnet test",
+  "input": "dotnet test",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["dotnet", "test"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/16_npm_install.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/16_npm_install.json
@@ -1,0 +1,17 @@
+{
+  "name": "Multi-token verb: npm install",
+  "input": "npm install",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["npm", "install"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/17_docker_run_nginx.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/17_docker_run_nginx.json
@@ -1,0 +1,19 @@
+{
+  "name": "Multi-token verb: docker run nginx",
+  "input": "docker run nginx",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["docker", "run"],
+        "args": [
+          { "raw": "nginx", "kind": "Literal", "isPath": false }
+        ],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/18_docker_compose_up.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/18_docker_compose_up.json
@@ -1,0 +1,18 @@
+{
+  "name": "Three-token verb: docker compose up",
+  "input": "docker compose up",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["docker", "compose", "up"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  },
+  "notes": "Three-token probe: longest-prefix lookup matches 'docker compose' → arity 3."
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/19_docker_compose_down_v.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/19_docker_compose_down_v.json
@@ -1,0 +1,19 @@
+{
+  "name": "Three-token verb with flag: docker compose down -v",
+  "input": "docker compose down -v",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["docker", "compose", "down"],
+        "args": [
+          { "raw": "-v", "kind": "Literal", "isPath": false, "isFlag": true }
+        ],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/20_bun_run_my_script.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/20_bun_run_my_script.json
@@ -1,0 +1,18 @@
+{
+  "name": "Three-token verb: bun run my-script",
+  "input": "bun run my-script",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["bun", "run", "my-script"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  },
+  "notes": "BashArity['bun run'] = 3 → all three source tokens become the verb chain."
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/21_compound_andif.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/21_compound_andif.json
@@ -1,0 +1,25 @@
+{
+  "name": "Compound: cmd1 && cmd2",
+  "input": "cmd1 && cmd2",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["cmd1"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      },
+      {
+        "operator": "AndIf",
+        "verb": ["cmd2"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/22_compound_orif.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/22_compound_orif.json
@@ -1,0 +1,25 @@
+{
+  "name": "Compound: cmd1 || cmd2",
+  "input": "cmd1 || cmd2",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["cmd1"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      },
+      {
+        "operator": "OrIf",
+        "verb": ["cmd2"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/23_compound_sequence.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/23_compound_sequence.json
@@ -1,0 +1,25 @@
+{
+  "name": "Compound: cmd1 ; cmd2",
+  "input": "cmd1 ; cmd2",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["cmd1"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      },
+      {
+        "operator": "Sequence",
+        "verb": ["cmd2"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/24_compound_pipe.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/24_compound_pipe.json
@@ -1,0 +1,25 @@
+{
+  "name": "Compound: cmd1 | cmd2",
+  "input": "cmd1 | cmd2",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["cmd1"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      },
+      {
+        "operator": "Pipe",
+        "verb": ["cmd2"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/25_cd_then_ls.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/25_cd_then_ls.json
@@ -1,0 +1,28 @@
+{
+  "name": "Compound: cd /tmp && ls",
+  "input": "cd /tmp && ls",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["cd"],
+        "args": [
+          { "raw": "/tmp", "kind": "Literal", "isPath": false }
+        ],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      },
+      {
+        "operator": "AndIf",
+        "verb": ["ls"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  },
+  "notes": "PR 3: no cd-attribution arg. PR 5 will append the synthetic /tmp arg to clause 1."
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/26_git_fetch_pull.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/26_git_fetch_pull.json
@@ -1,0 +1,25 @@
+{
+  "name": "Compound: git fetch && git pull",
+  "input": "git fetch && git pull",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["git", "fetch"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      },
+      {
+        "operator": "AndIf",
+        "verb": ["git", "pull"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/27_make_install.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/27_make_install.json
@@ -1,0 +1,27 @@
+{
+  "name": "Compound: make && make install",
+  "input": "make && make install",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["make"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      },
+      {
+        "operator": "AndIf",
+        "verb": ["make"],
+        "args": [
+          { "raw": "install", "kind": "Literal", "isPath": false }
+        ],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/28_cd_status_push.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/28_cd_status_push.json
@@ -1,0 +1,36 @@
+{
+  "name": "Three-clause compound: cd /repo && git status && git push",
+  "input": "cd /repo && git status && git push",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["cd"],
+        "args": [
+          { "raw": "/repo", "kind": "Literal", "isPath": false }
+        ],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      },
+      {
+        "operator": "AndIf",
+        "verb": ["git", "status"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      },
+      {
+        "operator": "AndIf",
+        "verb": ["git", "push"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  },
+  "notes": "PR 3: no cd-attribution. PR 5 will append /repo to subsequent clauses."
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/29_three_andif.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/29_three_andif.json
@@ -1,0 +1,12 @@
+{
+  "name": "Three-clause AndIf: cmd1 && cmd2 && cmd3",
+  "input": "cmd1 && cmd2 && cmd3",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      { "operator": "None", "verb": ["cmd1"], "args": [], "redirects": [], "isSubshell": false, "isBashCWrapped": false },
+      { "operator": "AndIf", "verb": ["cmd2"], "args": [], "redirects": [], "isSubshell": false, "isBashCWrapped": false },
+      { "operator": "AndIf", "verb": ["cmd3"], "args": [], "redirects": [], "isSubshell": false, "isBashCWrapped": false }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/30_three_orif.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/30_three_orif.json
@@ -1,0 +1,12 @@
+{
+  "name": "Three-clause OrIf: cmd1 || cmd2 || cmd3",
+  "input": "cmd1 || cmd2 || cmd3",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      { "operator": "None", "verb": ["cmd1"], "args": [], "redirects": [], "isSubshell": false, "isBashCWrapped": false },
+      { "operator": "OrIf", "verb": ["cmd2"], "args": [], "redirects": [], "isSubshell": false, "isBashCWrapped": false },
+      { "operator": "OrIf", "verb": ["cmd3"], "args": [], "redirects": [], "isSubshell": false, "isBashCWrapped": false }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/31_three_sequence.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/31_three_sequence.json
@@ -1,0 +1,12 @@
+{
+  "name": "Three-clause Sequence: cmd1 ; cmd2 ; cmd3",
+  "input": "cmd1 ; cmd2 ; cmd3",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      { "operator": "None", "verb": ["cmd1"], "args": [], "redirects": [], "isSubshell": false, "isBashCWrapped": false },
+      { "operator": "Sequence", "verb": ["cmd2"], "args": [], "redirects": [], "isSubshell": false, "isBashCWrapped": false },
+      { "operator": "Sequence", "verb": ["cmd3"], "args": [], "redirects": [], "isSubshell": false, "isBashCWrapped": false }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/32_three_pipe.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/32_three_pipe.json
@@ -1,0 +1,12 @@
+{
+  "name": "Three-stage pipe: cmd1 | cmd2 | cmd3",
+  "input": "cmd1 | cmd2 | cmd3",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      { "operator": "None", "verb": ["cmd1"], "args": [], "redirects": [], "isSubshell": false, "isBashCWrapped": false },
+      { "operator": "Pipe", "verb": ["cmd2"], "args": [], "redirects": [], "isSubshell": false, "isBashCWrapped": false },
+      { "operator": "Pipe", "verb": ["cmd3"], "args": [], "redirects": [], "isSubshell": false, "isBashCWrapped": false }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/33_mixed_andif_orif.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/33_mixed_andif_orif.json
@@ -1,0 +1,12 @@
+{
+  "name": "Mixed compound: cmd1 && cmd2 || cmd3",
+  "input": "cmd1 && cmd2 || cmd3",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      { "operator": "None", "verb": ["cmd1"], "args": [], "redirects": [], "isSubshell": false, "isBashCWrapped": false },
+      { "operator": "AndIf", "verb": ["cmd2"], "args": [], "redirects": [], "isSubshell": false, "isBashCWrapped": false },
+      { "operator": "OrIf", "verb": ["cmd3"], "args": [], "redirects": [], "isSubshell": false, "isBashCWrapped": false }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/34_cd_then_rm.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/34_cd_then_rm.json
@@ -1,0 +1,30 @@
+{
+  "name": "Compound: cd /tmp && rm temp.log",
+  "input": "cd /tmp && rm temp.log",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["cd"],
+        "args": [
+          { "raw": "/tmp", "kind": "Literal", "isPath": false }
+        ],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      },
+      {
+        "operator": "AndIf",
+        "verb": ["rm"],
+        "args": [
+          { "raw": "temp.log", "kind": "Literal", "isPath": false }
+        ],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  },
+  "notes": "Glob handling lives in PR 4; uses literal filename here."
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/35_cd_pipe_grep.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/35_cd_pipe_grep.json
@@ -1,0 +1,37 @@
+{
+  "name": "Compound + pipe: cd /repo && cmd | grep foo",
+  "input": "cd /repo && cmd | grep foo",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["cd"],
+        "args": [
+          { "raw": "/repo", "kind": "Literal", "isPath": false }
+        ],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      },
+      {
+        "operator": "AndIf",
+        "verb": ["cmd"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      },
+      {
+        "operator": "Pipe",
+        "verb": ["grep"],
+        "args": [
+          { "raw": "foo", "kind": "Literal", "isPath": false }
+        ],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/36_redirect_out.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/36_redirect_out.json
@@ -1,0 +1,19 @@
+{
+  "name": "Redirect Out: cmd > /tmp/out",
+  "input": "cmd > /tmp/out",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["cmd"],
+        "args": [],
+        "redirects": [
+          { "direction": "Out", "target": "/tmp/out" }
+        ],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/37_redirect_append.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/37_redirect_append.json
@@ -1,0 +1,19 @@
+{
+  "name": "Redirect Append: cmd >> /tmp/log",
+  "input": "cmd >> /tmp/log",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["cmd"],
+        "args": [],
+        "redirects": [
+          { "direction": "Append", "target": "/tmp/log" }
+        ],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/38_redirect_in.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/38_redirect_in.json
@@ -1,0 +1,19 @@
+{
+  "name": "Redirect In: cmd < /tmp/input",
+  "input": "cmd < /tmp/input",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["cmd"],
+        "args": [],
+        "redirects": [
+          { "direction": "In", "target": "/tmp/input" }
+        ],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/39_redirect_errout.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/39_redirect_errout.json
@@ -1,0 +1,19 @@
+{
+  "name": "Redirect ErrOut: cmd 2> /tmp/err",
+  "input": "cmd 2> /tmp/err",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["cmd"],
+        "args": [],
+        "redirects": [
+          { "direction": "ErrOut", "target": "/tmp/err" }
+        ],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/40_redirect_errappend.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/40_redirect_errappend.json
@@ -1,0 +1,19 @@
+{
+  "name": "Redirect ErrAppend: cmd 2>> /tmp/err",
+  "input": "cmd 2>> /tmp/err",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["cmd"],
+        "args": [],
+        "redirects": [
+          { "direction": "ErrAppend", "target": "/tmp/err" }
+        ],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/41_redirect_out_and_err.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/41_redirect_out_and_err.json
@@ -1,0 +1,20 @@
+{
+  "name": "Multiple redirects: cmd > out 2> err",
+  "input": "cmd > out 2> err",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["cmd"],
+        "args": [],
+        "redirects": [
+          { "direction": "Out", "target": "out" },
+          { "direction": "ErrOut", "target": "err" }
+        ],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/42_pipe_then_redirect.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/42_pipe_then_redirect.json
@@ -1,0 +1,27 @@
+{
+  "name": "Pipe with trailing redirect: cmd1 | cmd2 > /tmp/out",
+  "input": "cmd1 | cmd2 > /tmp/out",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["cmd1"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      },
+      {
+        "operator": "Pipe",
+        "verb": ["cmd2"],
+        "args": [],
+        "redirects": [
+          { "direction": "Out", "target": "/tmp/out" }
+        ],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/43_redirect_then_andif.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/43_redirect_then_andif.json
@@ -1,0 +1,27 @@
+{
+  "name": "Redirect then AndIf: cmd > /tmp/a.txt && cmd2",
+  "input": "cmd > /tmp/a.txt && cmd2",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["cmd"],
+        "args": [],
+        "redirects": [
+          { "direction": "Out", "target": "/tmp/a.txt" }
+        ],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      },
+      {
+        "operator": "AndIf",
+        "verb": ["cmd2"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/44_in_and_out_redirects.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/44_in_and_out_redirects.json
@@ -1,0 +1,20 @@
+{
+  "name": "In + Out redirects: cat < input.txt > output.txt",
+  "input": "cat < input.txt > output.txt",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["cat"],
+        "args": [],
+        "redirects": [
+          { "direction": "In", "target": "input.txt" },
+          { "direction": "Out", "target": "output.txt" }
+        ],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/45_echo_append_log.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/45_echo_append_log.json
@@ -1,0 +1,21 @@
+{
+  "name": "Append redirect: echo hi >> log.txt",
+  "input": "echo hi >> log.txt",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["echo"],
+        "args": [
+          { "raw": "hi", "kind": "Literal", "isPath": false }
+        ],
+        "redirects": [
+          { "direction": "Append", "target": "log.txt" }
+        ],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/46_unparseable_for_loop.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/46_unparseable_for_loop.json
@@ -1,0 +1,9 @@
+{
+  "name": "Unparseable: for-loop control flow",
+  "input": "for i in 1 2; do echo $i; done",
+  "expected": {
+    "isUnparseable": true,
+    "unparseableReasonContains": "'for'"
+  },
+  "notes": "SPEC §11: control-flow keyword as the verb sets outer IsUnparseable."
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/47_unparseable_function.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/47_unparseable_function.json
@@ -1,0 +1,8 @@
+{
+  "name": "Unparseable: function definition",
+  "input": "func() { echo hi; }",
+  "expected": {
+    "isUnparseable": true,
+    "unparseableReasonContains": "function definition"
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/48_unparseable_quote.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/48_unparseable_quote.json
@@ -1,0 +1,8 @@
+{
+  "name": "Unparseable: unbalanced double quote",
+  "input": "cmd \"unbalanced",
+  "expected": {
+    "isUnparseable": true,
+    "unparseableReasonContains": "unbalanced quote"
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/49_unparseable_arithmetic.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/49_unparseable_arithmetic.json
@@ -1,0 +1,8 @@
+{
+  "name": "Unparseable: arithmetic expansion",
+  "input": "echo $((1+2))",
+  "expected": {
+    "isUnparseable": true,
+    "unparseableReasonContains": "arithmetic expansion"
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/50_unparseable_complex_param.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/50_unparseable_complex_param.json
@@ -1,0 +1,8 @@
+{
+  "name": "Unparseable: complex parameter expansion",
+  "input": "echo ${PATH//:/\\n}",
+  "expected": {
+    "isUnparseable": true,
+    "unparseableReasonContains": "complex parameter expansion"
+  }
+}

--- a/tests/ShellSyntaxTree.Tests/Parsing/BashCommandParserTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Parsing/BashCommandParserTests.cs
@@ -1,0 +1,590 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="BashCommandParserTests.cs" company="Aaron Stannard">
+//      Copyright (C) 2026 - 2026 Aaron Stannard <https://github.com/Aaronontheweb>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Linq;
+using Xunit;
+
+namespace ShellSyntaxTree.Tests.Parsing;
+
+/// <summary>
+/// Unit tests for the PR 3 BashCommandParser core. These focus on the
+/// shape that the parser produces — verb chains, args, redirects,
+/// compound splitting, and SPEC §11 anomaly safe-fail. Path classification
+/// (PR 4) and cd-attribution / subshell-flagging (PR 5) are intentionally
+/// out of scope for this test file.
+/// </summary>
+public class BashCommandParserTests
+{
+    private static ParsedCommand Parse(string input)
+    {
+        var parser = new BashParser();
+        return parser.Parse(input);
+    }
+
+    // ---------------- Single-clause: simple ----------------
+
+    [Fact]
+    public void Single_word_verb()
+    {
+        var result = Parse("ls");
+        Assert.False(result.IsUnparseable);
+        var clause = Assert.Single(result.Clauses);
+        Assert.Equal(CompoundOperator.None, clause.Operator);
+        Assert.Equal(new[] { "ls" }, clause.Verb.Tokens);
+        Assert.Empty(clause.Args);
+        Assert.Empty(clause.Redirects);
+    }
+
+    [Fact]
+    public void Single_verb_with_flag_and_path_arg()
+    {
+        var result = Parse("ls -la /tmp");
+        Assert.False(result.IsUnparseable);
+        var clause = Assert.Single(result.Clauses);
+        Assert.Equal(new[] { "ls" }, clause.Verb.Tokens);
+        Assert.Equal(2, clause.Args.Count);
+        Assert.Equal("-la", clause.Args[0].Raw);
+        Assert.True(clause.Args[0].IsFlag);
+        Assert.Equal("/tmp", clause.Args[1].Raw);
+        Assert.False(clause.Args[1].IsFlag);
+    }
+
+    [Fact]
+    public void Mkdir_with_default_arity_one()
+    {
+        var result = Parse("mkdir /tmp");
+        Assert.False(result.IsUnparseable);
+        var clause = Assert.Single(result.Clauses);
+        Assert.Equal(new[] { "mkdir" }, clause.Verb.Tokens);
+        Assert.Equal(new[] { "/tmp" }, clause.Args.Select(a => a.Raw).ToArray());
+    }
+
+    [Fact]
+    public void Echo_with_quoted_arg_preserves_source_raw()
+    {
+        var result = Parse("echo \"hello world\"");
+        Assert.False(result.IsUnparseable);
+        var clause = Assert.Single(result.Clauses);
+        Assert.Equal(new[] { "echo" }, clause.Verb.Tokens);
+        // Raw preserves the surrounding quotes; resolved/value strips them.
+        Assert.Equal("\"hello world\"", clause.Args[0].Raw);
+    }
+
+    [Fact]
+    public void Single_quoted_arg_preserves_quotes_in_raw()
+    {
+        var result = Parse("echo 'hello world'");
+        Assert.False(result.IsUnparseable);
+        var clause = Assert.Single(result.Clauses);
+        Assert.Equal("'hello world'", clause.Args[0].Raw);
+    }
+
+    // ---------------- Multi-token verb chains ----------------
+
+    [Fact]
+    public void Two_token_verb_git_push()
+    {
+        var result = Parse("git push origin main");
+        Assert.False(result.IsUnparseable);
+        var clause = Assert.Single(result.Clauses);
+        Assert.Equal(new[] { "git", "push" }, clause.Verb.Tokens);
+        Assert.Equal(new[] { "origin", "main" }, clause.Args.Select(a => a.Raw).ToArray());
+    }
+
+    [Fact]
+    public void Two_token_verb_dotnet_test()
+    {
+        var result = Parse("dotnet test");
+        var clause = Assert.Single(result.Clauses);
+        Assert.Equal(new[] { "dotnet", "test" }, clause.Verb.Tokens);
+        Assert.Empty(clause.Args);
+    }
+
+    [Fact]
+    public void Three_token_verb_docker_compose_up()
+    {
+        var result = Parse("docker compose up nginx");
+        Assert.False(result.IsUnparseable);
+        var clause = Assert.Single(result.Clauses);
+        Assert.Equal(new[] { "docker", "compose", "up" }, clause.Verb.Tokens);
+        Assert.Equal(new[] { "nginx" }, clause.Args.Select(a => a.Raw).ToArray());
+    }
+
+    [Fact]
+    public void Three_token_verb_bun_run_my_script()
+    {
+        var result = Parse("bun run my-script");
+        Assert.False(result.IsUnparseable);
+        var clause = Assert.Single(result.Clauses);
+        Assert.Equal(new[] { "bun", "run", "my-script" }, clause.Verb.Tokens);
+        Assert.Empty(clause.Args);
+    }
+
+    [Fact]
+    public void Two_token_verb_docker_run()
+    {
+        var result = Parse("docker run nginx");
+        Assert.False(result.IsUnparseable);
+        var clause = Assert.Single(result.Clauses);
+        Assert.Equal(new[] { "docker", "run" }, clause.Verb.Tokens);
+        Assert.Equal(new[] { "nginx" }, clause.Args.Select(a => a.Raw).ToArray());
+    }
+
+    [Fact]
+    public void Verb_chain_capped_by_available_tokens()
+    {
+        // "git" alone (no second token) — chain must collapse to 1.
+        var result = Parse("git");
+        var clause = Assert.Single(result.Clauses);
+        Assert.Equal(new[] { "git" }, clause.Verb.Tokens);
+    }
+
+    [Fact]
+    public void Default_arity_when_verb_unknown()
+    {
+        var result = Parse("totally-unknown-verb foo bar");
+        var clause = Assert.Single(result.Clauses);
+        Assert.Equal(new[] { "totally-unknown-verb" }, clause.Verb.Tokens);
+        Assert.Equal(new[] { "foo", "bar" }, clause.Args.Select(a => a.Raw).ToArray());
+    }
+
+    [Fact]
+    public void Verb_lookup_is_case_insensitive()
+    {
+        var result = Parse("GIT push");
+        var clause = Assert.Single(result.Clauses);
+        Assert.Equal(new[] { "GIT", "push" }, clause.Verb.Tokens);
+    }
+
+    // ---------------- Compound operators ----------------
+
+    [Fact]
+    public void Compound_AndIf_two_clauses()
+    {
+        var result = Parse("ls && pwd");
+        Assert.False(result.IsUnparseable);
+        Assert.Equal(2, result.Clauses.Count);
+        Assert.Equal(CompoundOperator.None, result.Clauses[0].Operator);
+        Assert.Equal(new[] { "ls" }, result.Clauses[0].Verb.Tokens);
+        Assert.Equal(CompoundOperator.AndIf, result.Clauses[1].Operator);
+        Assert.Equal(new[] { "pwd" }, result.Clauses[1].Verb.Tokens);
+    }
+
+    [Fact]
+    public void Compound_OrIf_two_clauses()
+    {
+        var result = Parse("ls || echo nope");
+        Assert.False(result.IsUnparseable);
+        Assert.Equal(2, result.Clauses.Count);
+        Assert.Equal(CompoundOperator.OrIf, result.Clauses[1].Operator);
+    }
+
+    [Fact]
+    public void Compound_Sequence_two_clauses()
+    {
+        var result = Parse("ls ; pwd");
+        Assert.False(result.IsUnparseable);
+        Assert.Equal(2, result.Clauses.Count);
+        Assert.Equal(CompoundOperator.Sequence, result.Clauses[1].Operator);
+    }
+
+    [Fact]
+    public void Compound_Pipe_two_clauses()
+    {
+        var result = Parse("ls | grep foo");
+        Assert.False(result.IsUnparseable);
+        Assert.Equal(2, result.Clauses.Count);
+        Assert.Equal(CompoundOperator.Pipe, result.Clauses[1].Operator);
+        Assert.Equal(new[] { "grep" }, result.Clauses[1].Verb.Tokens);
+    }
+
+    [Fact]
+    public void Compound_mixed_operators()
+    {
+        var result = Parse("cmd1 && cmd2 || cmd3");
+        Assert.False(result.IsUnparseable);
+        Assert.Equal(3, result.Clauses.Count);
+        Assert.Equal(CompoundOperator.None, result.Clauses[0].Operator);
+        Assert.Equal(CompoundOperator.AndIf, result.Clauses[1].Operator);
+        Assert.Equal(CompoundOperator.OrIf, result.Clauses[2].Operator);
+    }
+
+    [Fact]
+    public void Compound_no_whitespace_around_operator()
+    {
+        // The lexer must split `cd /tmp&&ls` per SPEC §5.
+        var result = Parse("cd /tmp&&ls");
+        Assert.False(result.IsUnparseable);
+        Assert.Equal(2, result.Clauses.Count);
+        Assert.Equal(new[] { "cd" }, result.Clauses[0].Verb.Tokens);
+        Assert.Equal(new[] { "ls" }, result.Clauses[1].Verb.Tokens);
+        Assert.Equal(CompoundOperator.AndIf, result.Clauses[1].Operator);
+    }
+
+    [Fact]
+    public void Compound_three_clauses_all_AndIf()
+    {
+        var result = Parse("a && b && c");
+        Assert.Equal(3, result.Clauses.Count);
+        Assert.Equal(CompoundOperator.None, result.Clauses[0].Operator);
+        Assert.Equal(CompoundOperator.AndIf, result.Clauses[1].Operator);
+        Assert.Equal(CompoundOperator.AndIf, result.Clauses[2].Operator);
+    }
+
+    // ---------------- Redirects ----------------
+
+    [Fact]
+    public void Redirect_Out()
+    {
+        var result = Parse("cmd > /tmp/out");
+        var clause = Assert.Single(result.Clauses);
+        var redirect = Assert.Single(clause.Redirects);
+        Assert.Equal(RedirectDirection.Out, redirect.Direction);
+        Assert.Equal("/tmp/out", redirect.Target);
+        Assert.False(redirect.IsDynamicSkip);
+    }
+
+    [Fact]
+    public void Redirect_Append()
+    {
+        var result = Parse("cmd >> log");
+        var clause = Assert.Single(result.Clauses);
+        var redirect = Assert.Single(clause.Redirects);
+        Assert.Equal(RedirectDirection.Append, redirect.Direction);
+        Assert.Equal("log", redirect.Target);
+    }
+
+    [Fact]
+    public void Redirect_In()
+    {
+        var result = Parse("cmd < input");
+        var clause = Assert.Single(result.Clauses);
+        var redirect = Assert.Single(clause.Redirects);
+        Assert.Equal(RedirectDirection.In, redirect.Direction);
+        Assert.Equal("input", redirect.Target);
+    }
+
+    [Fact]
+    public void Redirect_ErrOut()
+    {
+        var result = Parse("cmd 2> err");
+        var clause = Assert.Single(result.Clauses);
+        var redirect = Assert.Single(clause.Redirects);
+        Assert.Equal(RedirectDirection.ErrOut, redirect.Direction);
+        Assert.Equal("err", redirect.Target);
+    }
+
+    [Fact]
+    public void Redirect_ErrAppend()
+    {
+        var result = Parse("cmd 2>> err");
+        var clause = Assert.Single(result.Clauses);
+        var redirect = Assert.Single(clause.Redirects);
+        Assert.Equal(RedirectDirection.ErrAppend, redirect.Direction);
+        Assert.Equal("err", redirect.Target);
+    }
+
+    [Fact]
+    public void Multiple_redirects_on_one_clause()
+    {
+        var result = Parse("cmd > out 2> err");
+        var clause = Assert.Single(result.Clauses);
+        Assert.Equal(2, clause.Redirects.Count);
+        Assert.Equal(RedirectDirection.Out, clause.Redirects[0].Direction);
+        Assert.Equal("out", clause.Redirects[0].Target);
+        Assert.Equal(RedirectDirection.ErrOut, clause.Redirects[1].Direction);
+        Assert.Equal("err", clause.Redirects[1].Target);
+    }
+
+    [Fact]
+    public void Redirect_target_is_dynamic_when_opaque_substitution()
+    {
+        var result = Parse("cmd > $(date +log)");
+        var clause = Assert.Single(result.Clauses);
+        var redirect = Assert.Single(clause.Redirects);
+        Assert.True(redirect.IsDynamicSkip);
+    }
+
+    [Fact]
+    public void Pipe_to_grep_with_output_redirect_on_last_clause()
+    {
+        var result = Parse("cmd1 | cmd2 > /tmp/out");
+        Assert.False(result.IsUnparseable);
+        Assert.Equal(2, result.Clauses.Count);
+        Assert.Empty(result.Clauses[0].Redirects);
+        var lastRedirect = Assert.Single(result.Clauses[1].Redirects);
+        Assert.Equal("/tmp/out", lastRedirect.Target);
+    }
+
+    // ---------------- OpaqueSubstitution → DynamicSkip ----------------
+
+    [Fact]
+    public void Command_substitution_becomes_DynamicSkip_arg()
+    {
+        var result = Parse("rm $(find /tmp)");
+        Assert.False(result.IsUnparseable);
+        var clause = Assert.Single(result.Clauses);
+        Assert.Equal(new[] { "rm" }, clause.Verb.Tokens);
+        var arg = Assert.Single(clause.Args);
+        Assert.Equal(ArgKind.DynamicSkip, arg.Kind);
+        Assert.False(arg.IsPath);
+        Assert.Null(arg.Resolved);
+    }
+
+    [Fact]
+    public void Backtick_substitution_becomes_DynamicSkip_arg()
+    {
+        var result = Parse("rm `find /tmp`");
+        Assert.False(result.IsUnparseable);
+        var clause = Assert.Single(result.Clauses);
+        var arg = Assert.Single(clause.Args);
+        Assert.Equal(ArgKind.DynamicSkip, arg.Kind);
+    }
+
+    // ---------------- Unparseable ----------------
+
+    [Fact]
+    public void Arithmetic_expansion_marks_outer_unparseable()
+    {
+        var result = Parse("echo $((1+2))");
+        Assert.True(result.IsUnparseable);
+        Assert.NotNull(result.UnparseableReason);
+        Assert.Contains("arithmetic", result.UnparseableReason!);
+    }
+
+    [Fact]
+    public void Complex_param_expansion_marks_outer_unparseable()
+    {
+        var result = Parse("echo ${PATH//:/\\n}");
+        Assert.True(result.IsUnparseable);
+        Assert.NotNull(result.UnparseableReason);
+        Assert.Contains("complex parameter expansion", result.UnparseableReason!);
+    }
+
+    [Fact]
+    public void Unbalanced_double_quote_marks_outer_unparseable()
+    {
+        var result = Parse("cmd \"unbalanced");
+        Assert.True(result.IsUnparseable);
+        Assert.Contains("unbalanced quote", result.UnparseableReason!);
+    }
+
+    [Fact]
+    public void Unbalanced_single_quote_marks_outer_unparseable()
+    {
+        var result = Parse("cmd 'unbalanced");
+        Assert.True(result.IsUnparseable);
+    }
+
+    [Fact]
+    public void Unbalanced_open_paren_marks_outer_unparseable()
+    {
+        var result = Parse("(cmd1 && cmd2");
+        Assert.True(result.IsUnparseable);
+        Assert.Contains("unbalanced parens", result.UnparseableReason!);
+    }
+
+    [Fact]
+    public void Unbalanced_close_paren_marks_outer_unparseable()
+    {
+        var result = Parse("cmd1 && cmd2)");
+        Assert.True(result.IsUnparseable);
+        Assert.Contains("unbalanced parens", result.UnparseableReason!);
+    }
+
+    [Fact]
+    public void Control_flow_for_keyword_marks_outer_unparseable()
+    {
+        var result = Parse("for i in 1 2 3; do echo $i; done");
+        Assert.True(result.IsUnparseable);
+        Assert.Contains("'for'", result.UnparseableReason!);
+    }
+
+    [Fact]
+    public void Control_flow_while_keyword_marks_outer_unparseable()
+    {
+        var result = Parse("while true; do echo hi; done");
+        Assert.True(result.IsUnparseable);
+        Assert.Contains("'while'", result.UnparseableReason!);
+    }
+
+    [Fact]
+    public void Function_definition_marks_outer_unparseable()
+    {
+        var result = Parse("name() { echo hi; }");
+        Assert.True(result.IsUnparseable);
+        Assert.Contains("function definition", result.UnparseableReason!);
+    }
+
+    [Fact]
+    public void Process_substitution_input_marks_outer_unparseable()
+    {
+        var result = Parse("cmd <(other)");
+        Assert.True(result.IsUnparseable);
+        Assert.Contains("process substitution", result.UnparseableReason!);
+    }
+
+    [Fact]
+    public void Process_substitution_output_marks_outer_unparseable()
+    {
+        var result = Parse("tee >(other)");
+        Assert.True(result.IsUnparseable);
+        Assert.Contains("process substitution", result.UnparseableReason!);
+    }
+
+    // ---------------- bash -c framework ----------------
+
+    [Fact]
+    public void Bash_c_treated_as_single_clause_in_pr3()
+    {
+        // PR 3: framework only — no recursion into the inner string. The
+        // outer clause is verb=[bash] with `-c` flag and a quoted-string
+        // arg. PR 5 will surface the inner clauses.
+        var result = Parse("bash -c \"cd /a && cmd\"");
+        Assert.False(result.IsUnparseable);
+        var clause = Assert.Single(result.Clauses);
+        Assert.Equal(new[] { "bash" }, clause.Verb.Tokens);
+        Assert.Equal(2, clause.Args.Count);
+        Assert.Equal("-c", clause.Args[0].Raw);
+        Assert.True(clause.Args[0].IsFlag);
+        // The inner string is preserved with quotes in Raw.
+        Assert.Equal("\"cd /a && cmd\"", clause.Args[1].Raw);
+        Assert.False(clause.IsBashCWrapped);
+    }
+
+    // ---------------- Empty / whitespace ----------------
+
+    [Fact]
+    public void Empty_input_returns_empty_clauses()
+    {
+        var result = Parse("");
+        Assert.Equal("", result.Source);
+        Assert.Empty(result.Clauses);
+        Assert.False(result.IsUnparseable);
+    }
+
+    [Fact]
+    public void Whitespace_only_input_returns_empty_clauses()
+    {
+        var result = Parse("   \t  ");
+        Assert.Empty(result.Clauses);
+        Assert.False(result.IsUnparseable);
+    }
+
+    // ---------------- Subshell framework ----------------
+
+    [Fact]
+    public void Subshell_inner_clauses_surface_inline()
+    {
+        // PR 3: subshell parens are recognized; inner clauses are
+        // surfaced inline with IsSubshell=false (PR 5 will set the flag
+        // and add cd-attribution semantics).
+        var result = Parse("(cmd1 && cmd2)");
+        Assert.False(result.IsUnparseable);
+        Assert.Equal(2, result.Clauses.Count);
+        Assert.Equal(new[] { "cmd1" }, result.Clauses[0].Verb.Tokens);
+        Assert.Equal(new[] { "cmd2" }, result.Clauses[1].Verb.Tokens);
+        Assert.Equal(CompoundOperator.AndIf, result.Clauses[1].Operator);
+        Assert.False(result.Clauses[0].IsSubshell);
+        Assert.False(result.Clauses[1].IsSubshell);
+    }
+
+    // ---------------- Quoted args round-trip ----------------
+
+    [Fact]
+    public void Quoted_path_arg_keeps_raw_quotes()
+    {
+        var result = Parse("ls \"/path with space\"");
+        var clause = Assert.Single(result.Clauses);
+        Assert.Equal("\"/path with space\"", clause.Args[0].Raw);
+    }
+
+    // ---------------- Equals-form flag splitting ----------------
+
+    [Fact]
+    public void Equals_form_flag_splits_into_two_args()
+    {
+        var result = Parse("curl --output=file.txt http://example.com");
+        var clause = Assert.Single(result.Clauses);
+        Assert.Equal(new[] { "curl" }, clause.Verb.Tokens);
+        Assert.Equal(3, clause.Args.Count);
+        Assert.Equal("--output", clause.Args[0].Raw);
+        Assert.Equal("file.txt", clause.Args[1].Raw);
+        Assert.Equal("http://example.com", clause.Args[2].Raw);
+    }
+
+    [Fact]
+    public void Equals_form_only_splits_when_starts_with_dash()
+    {
+        // KEY=value (no leading -) stays a single arg.
+        var result = Parse("env KEY=value cmd");
+        var clause = Assert.Single(result.Clauses);
+        Assert.Equal(new[] { "env" }, clause.Verb.Tokens);
+        Assert.Equal(2, clause.Args.Count);
+        Assert.Equal("KEY=value", clause.Args[0].Raw);
+        Assert.Equal("cmd", clause.Args[1].Raw);
+    }
+
+    // ---------------- Source slicing fidelity ----------------
+
+    [Fact]
+    public void Source_field_matches_input()
+    {
+        var result = Parse("ls -la /tmp");
+        Assert.Equal("ls -la /tmp", result.Source);
+    }
+
+    [Fact]
+    public void Arg_raw_uses_source_slice()
+    {
+        // With a single-quoted token, Raw must include the quotes.
+        var result = Parse("echo 'literal $VAR'");
+        var clause = Assert.Single(result.Clauses);
+        Assert.Equal("'literal $VAR'", clause.Args[0].Raw);
+    }
+
+    // ---------------- Pipe with three stages ----------------
+
+    [Fact]
+    public void Pipe_three_stages()
+    {
+        var result = Parse("cmd1 | cmd2 | cmd3");
+        Assert.Equal(3, result.Clauses.Count);
+        Assert.Equal(CompoundOperator.None, result.Clauses[0].Operator);
+        Assert.Equal(CompoundOperator.Pipe, result.Clauses[1].Operator);
+        Assert.Equal(CompoundOperator.Pipe, result.Clauses[2].Operator);
+    }
+
+    // ---------------- Trailing semicolon tolerated ----------------
+
+    [Fact]
+    public void Trailing_semicolon_does_not_create_empty_clause()
+    {
+        var result = Parse("ls;");
+        Assert.False(result.IsUnparseable);
+        Assert.Single(result.Clauses);
+        Assert.Equal(new[] { "ls" }, result.Clauses[0].Verb.Tokens);
+    }
+
+    // ---------------- Git -C flag-with-value retained as args ----------------
+
+    [Fact]
+    public void Git_dash_C_keeps_flag_and_value_as_separate_args()
+    {
+        // PR 3: pairing exists but does not change Arg shape; PR 4 will
+        // mark the value as IsPath=true.
+        var result = Parse("git -C /repo log");
+        var clause = Assert.Single(result.Clauses);
+        Assert.Equal(new[] { "git", "-C" }, clause.Verb.Tokens.Take(1).Concat(new[] { clause.Args[0].Raw }).ToArray());
+        // git's verb chain probe: first token "git", second token "-C" — but
+        // -C is a flag-shaped token and stops verb-chain probing. So verb
+        // chain is just ["git"], and -C / /repo / log are all args.
+        Assert.Equal(new[] { "git" }, clause.Verb.Tokens);
+        Assert.Equal(3, clause.Args.Count);
+        Assert.Equal("-C", clause.Args[0].Raw);
+        Assert.Equal("/repo", clause.Args[1].Raw);
+        Assert.Equal("log", clause.Args[2].Raw);
+    }
+}

--- a/tests/ShellSyntaxTree.Tests/PublicApiSnapshotTests.cs
+++ b/tests/ShellSyntaxTree.Tests/PublicApiSnapshotTests.cs
@@ -71,10 +71,14 @@ public class PublicApiSnapshotTests
     }
 
     [Fact]
-    public void BashParser_Parse_throws_NotImplementedException_in_v0_1_alpha()
+    public void BashParser_Parse_returns_ParsedCommand_for_simple_input()
     {
         var parser = new BashParser();
-        Assert.Throws<NotImplementedException>(() => parser.Parse("ls"));
+        var result = parser.Parse("ls");
+        Assert.NotNull(result);
+        Assert.Equal("ls", result.Source);
+        Assert.False(result.IsUnparseable);
+        Assert.Single(result.Clauses);
     }
 
     [Fact]

--- a/tests/ShellSyntaxTree.Tests/ShellSyntaxTree.Tests.csproj
+++ b/tests/ShellSyntaxTree.Tests/ShellSyntaxTree.Tests.csproj
@@ -23,4 +23,12 @@
     </PackageReference>
   </ItemGroup>
 
+  <!-- Copy the JSON corpus alongside the test binary so the corpus runner
+       can enumerate AppContext.BaseDirectory/Corpus/bash/*.json at runtime. -->
+  <ItemGroup>
+    <None Update="Corpus\bash\*.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary

PR 3 of the v0.1.0-alpha shipping plan. Implements the verb tables from SPEC §6 and a working `BashCommandParser` that wires PR 2's lexer tokens into the public AST. **`BashParser.Parse` is no longer a stub** — the v0.1 contract works end-to-end in literal-only mode (path classification + cd-attribution land in PRs 4-5).

## What landed

- **`Internal/Bash/Verbs/BashVerbs.cs`** — `BashArity`, `CwdVerbs`, `FileVerbs`, `FlagsWithValue`, `ControlFlowKeywords` per SPEC §6 + the longest-prefix probe.
- **`Internal/Bash/Parsing/BashCommandParser.cs`** — token-stream → `ParsedCommand` translator.
- **`BashParser.Parse`** — now delegates to `BashCommandParser.Parse` (no more `NotImplementedException`).
- **53 parser unit tests** + **50 corpus entries** + **CorpusRunnerTests skeleton** with `[Theory] [MemberData]` over `Corpus/bash/*.json`. Combined with PR 1+2: **199/199 passing**.

## Locked interpretations applied

- **#2 (command substitution):** `OpaqueSubstitution` tokens from PR 2 collapse into one `Arg{Kind=DynamicSkip, IsPath=false}`. `UnparseableSentinel` tokens trigger outer `ParsedCommand.IsUnparseable=true` per SPEC §11.
- **#4 (bash -c overflow):** framework only in PR 3 (single-clause shape). PR 5 wires the depth-5 cap that uses `ParsedCommand.IsUnparseable`.

## Anomaly safe-fail

Outer `ParsedCommand.IsUnparseable=true` for:
- Control-flow keywords as verb (`for`, `while`, `do`, `done`, `then`, `fi`, `case`, `esac`, `if`, `else`, `elif`)
- Function definition pattern (`name() { ... }`)
- Process substitution (`<(cmd)`, `>(cmd)`)
- Unbalanced parens
- Lexer-flagged unparseable inputs (unbalanced quotes, arithmetic, complex param expansion, unterminated heredoc)

## Corpus coverage so far (50 entries)

| Category | Count |
|---|---|
| Simple-verb | 10 |
| Multi-token-verb | 10 |
| Compound | 15 |
| Redirect | 10 |
| Unparseable | 5 |

Path-classification, dynamic-skip env-var, per-verb-rule, cd-in-compound, subshell, bash -c, and full unparseable categories arrive in PRs 4-6.

## SPEC.md updates

- §7 `FlagsWithValue` value type changed from `IReadOnlySet<string>` to `HashSet<string>` (netstandard2.0 compat).
- §7 PR 3 → PR 4 follow-up note: verb-chain probe must run *after* flag-with-value consumption for `git -C /repo log` → `Verb.Tokens=["git", "log"]` per SPEC §12.

## PR 3 → PR 4 follow-ups

- Flag-with-value-aware verb-chain probe.
- Per-verb path-arg rules + path-shape classification (`IsPath=true` for paths).
- Corpus entries refresh for path classification.

## Verification

- ✅ `dotnet build -c Release` — clean
- ✅ `dotnet test -c Release` — 199/199 passing
- ✅ `pwsh ./scripts/Add-FileHeaders.ps1 -Verify` — all files have headers
- ✅ `openspec validate v0.1-locked-interpretations --strict` — passes
- ✅ Public API surface unchanged (PublicApiSnapshotTests still green)

## Test plan

- [ ] CI passes on `Test-ubuntu-latest`
- [ ] CI passes on `Test-windows-latest`

## Next

PR 4 implements the resolver (tilde, $HOME, glob detection, env-var skip, relative-path joining) and per-verb path-arg rules. The corpus expectations for path-shaped args will update there.