### PR TITLE
PR 7: v0.1.0-alpha release prep

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -169,24 +169,36 @@ bulldoze priorities.
 - [x] Wired into `pr_validation.yml` via standard `dotnet test`
       (no separate job)
 
-### 13. Release v0.1.0-alpha
+### 13. Release v0.1.0-alpha — PR 7 in flight
 
-- [ ] `RELEASE_NOTES.md` updated with v0.1.0-alpha section
-- [ ] Tag `v0.1.0-alpha`; verify `publish_nuget.yml` produces and pushes
-      the package
+- [x] `RELEASE_NOTES.md` updated with v0.1.0-alpha section
+- [x] `dotnet pack -c Release -o ./bin/nuget` produces clean
+      `ShellSyntaxTree.0.1.0-alpha.nupkg` + `.snupkg` with embedded
+      README, icon, SourceLink metadata
+- [ ] **STOP after PR 7 merges** — await user go-ahead before pushing
+      `v0.1.0-alpha` tag (the tag → nuget.org publish is irreversible)
+- [ ] On user go-ahead: `git tag v0.1.0-alpha && git push origin v0.1.0-alpha`
+- [ ] Verify `publish_nuget.yml` produces release on tag push and the
+      package appears on nuget.org
 
 ### 14. Netclaw integration smoke (SPEC §17 #7-#8)
 
-- [ ] Add `<PackageReference Include="ShellSyntaxTree">` to a Netclaw
-      project; verify `IShellParser` resolves in DI
+- [ ] In netclaw repo: `dotnet add package ShellSyntaxTree --version 0.1.0-alpha`
+- [ ] Wire `IShellParser` into Netclaw DI; replace minimal call site in
+      `src/Netclaw.Security/ShellApprovalSemantics.cs`
 - [ ] One Netclaw integration test exercises a real corpus entry through
       the live matcher and gets the expected gate decision
+- [ ] Update this repo's IMPLEMENTATION_PLAN.md: mark SPEC §17 #7–#8
+      satisfied
 
-### 15. NuGet package icon
+### 15. NuGet package icon — PR 7, complete
 
-- [ ] Generate a fitting icon via `/generate-image` (HCTI)
-- [ ] Place at `assets/icon.png`; wire into `Directory.Build.props`
-      (`PackageIcon` + a packed `<None>` item)
+- [x] Icon already generated as `assets/icon.png` (ShellSyntaxTree-themed
+      AST tree on dark green background with `>_` shell prompt motif —
+      512x512 PNG, ~98 KB; created during template bootstrap)
+- [x] `Directory.Build.props` wires `<PackageIcon>icon.png</PackageIcon>`
+      + a packed `<None>` item (already present from bootstrap)
+- [x] `dotnet pack` validation: icon embedded in `.nupkg` confirmed
 - [ ] Re-pack to validate icon embeds
 
 ---

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,61 @@
-#### 1.0.0 April 10th 2025 ####
+#### 0.1.0-alpha May 10th 2026 ####
 
-Example release notes
+First publishable cut of ShellSyntaxTree — a focused .NET library that
+parses bash command strings into a structured AST for security-gate
+evaluators. Hand-rolled, AOT-trim friendly, no native dependencies.
+
+**What's in this release**
+
+- `IShellParser` interface + `BashParser` implementation per locked
+  v0.1 contract (SPEC.md §2 / §3)
+- Bash lexer: words, quoted strings, operators, opaque substitutions
+  (`$()` / backticks → DynamicSkip), arithmetic (`$((...))`) and complex
+  parameter expansion (`${var//.../...}`) → IsUnparseable
+- Verb tables (BashArity, CwdVerbs, FileVerbs, FlagsWithValue) + per-verb
+  path-arg rules + flag-with-value-aware verb-chain probe
+- Path resolver: tilde / `$HOME` expansion, `filesystem::` prefix strip,
+  glob detection (covering-dir heuristic preserved), cross-platform
+  forward-slash normalization
+- cd-in-compound attribution: synthetic `Arg.IsCwdAttribution` propagated
+  to subsequent clauses; `cd $VAR` produces a DynamicSkip attribution
+  signal
+- Subshell isolation via attribution stack with monotonic IDs (handles
+  sibling subshells `(a) && (b)` cleanly)
+- `bash -c` / `sh -c` recursion (cap at depth 5 → outer
+  `ParsedCommand.IsUnparseable=true`)
+- 115-entry corpus across all 11 SPEC §13 categories, validated by
+  `CorpusRunnerTests` with a polished `AstAssert.Equal` helper
+- PII audit `[Fact]` enforcing SPEC §14 sanitization patterns
+
+**Public API surface (locked per SPEC §2 / §3)**
+
+`IShellParser`, `BashParser`, `BashParserOptions`, `ParsedCommand`,
+`Clause`, `VerbChain`, `Arg`, `Redirect` (records); `ArgKind`,
+`RedirectDirection`, `CompoundOperator` (enums). Multi-target
+`netstandard2.0;net8.0`; AOT-friendly (`<IsAotCompatible>true</IsAotCompatible>`).
+
+**Verification**
+
+353 tests passing on Linux + Windows. `dotnet pack` produces
+`ShellSyntaxTree.0.1.0-alpha.nupkg` with embedded README, icon, and
+SourceLink metadata.
+
+**Known limitations (tracked for v0.1.x)**
+
+- `pushd` / `popd` parse as CwdVerbs but don't propagate cwd
+  attribution (only `cd` / `chdir` do in v0.1)
+- `tar` falls through to the default per-verb rule (no action-flag
+  awareness)
+- `docker -v "/host:/container"` is a single literal arg with
+  `IsPath=false` (no colon-split in v0.1)
+- Single-quoted `'$HOME'` is substituted by the resolver (bash
+  semantics: doesn't substitute in single quotes)
+
+**Documentation**
+
+- `SPEC.md` — locked v0.1 contract (the source of truth for parser
+  behavior)
+- `openspec/changes/` — change-proposal history with rationale for the
+  eight v0.1 SPEC interpretations resolved during planning
+- `README.md` — quick-start usage
+


### PR DESCRIPTION
## Summary

PR 7 of the v0.1.0-alpha shipping plan. **Final PR before tag.** Updates `RELEASE_NOTES.md` with the v0.1.0-alpha entry; verifies `dotnet pack` produces a clean `.nupkg` with embedded README, icon, and SourceLink metadata.

## What landed

- **`RELEASE_NOTES.md`** — v0.1.0-alpha entry summarizing the shipping shape: public API surface, lexer/parser/resolver/per-verb rules, cd-attribution + subshell isolation + bash -c recursion, 115-entry corpus, PII audit, known v0.1.x limitations.
- **`IMPLEMENTATION_PLAN.md`** — PR 7 status updated; awaiting tag-push approval.

## Icon

Already ShellSyntaxTree-specific — syntax-tree visualization on dark green background with `>_` shell prompt motif (512x512 PNG, ~98 KB). Generated during template bootstrap and wired into `Directory.Build.props` from day one.

## Verification (local)

- ✅ `dotnet build -c Release` — clean
- ✅ `dotnet test -c Release` — **353/353 passing**
- ✅ `dotnet pack -c Release -o ./bin/nuget` produces:
  - `ShellSyntaxTree.0.1.0-alpha.nupkg` (148 KB) with `icon.png`, `README.md`, SourceLink metadata, `lib/net8.0/ShellSyntaxTree.dll`, `lib/netstandard2.0/ShellSyntaxTree.dll`
  - `ShellSyntaxTree.0.1.0-alpha.snupkg` (31 KB)
- ✅ `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`
- ✅ `openspec validate v0.1-locked-interpretations --strict`

## Test plan

- [ ] CI passes on `Test-ubuntu-latest`
- [ ] CI passes on `Test-windows-latest`

## ⚠️ STOP after merge — do NOT push the tag

Per the autonomous PR loop plan: this PR auto-merges with squash when CI passes. **The agent will NOT push the `v0.1.0-alpha` tag** — the tag → nuget.org publish via `publish_nuget.yml` is irreversible.

After merge, the agent leaves a status entry in `IMPLEMENTATION_PLAN.md` and stops the pipeline. The user (you, Aaron) decides when to push the tag:

\`\`\`bash
git checkout dev && git pull origin dev
git tag v0.1.0-alpha
git push origin v0.1.0-alpha
\`\`\`

Once the tag pushes, `publish_nuget.yml` produces the GitHub release + nuget.org package automatically.

## Post-tag follow-ups (PR 8+)

- Archive `openspec/changes/v0.1-locked-interpretations/` to `archive/2026-05-10-v0.1-locked-interpretations/`
- Netclaw integration smoke (SPEC §17 #7-#8): `dotnet add package ShellSyntaxTree --version 0.1.0-alpha` in the netclaw repo; one Netclaw integration test exercising a corpus entry through the live matcher