### PR TITLE
chore(ci): assert tags are bare version numbers (no `v` prefix)

### DIFF
--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -2,9 +2,10 @@ name: Publish NuGet
 
 on:
   push:
+    # Fire on ALL tag pushes so the format guard (below) catches mistakes
+    # like `v0.1.0-alpha` loudly instead of silently no-op-ing.
     tags:
-      - 'v*.*.*'
-      - 'v*.*.*-*'
+      - '*'
 
 permissions:
   contents: write
@@ -17,6 +18,24 @@ jobs:
     environment: nuget   # Must match the environment named in the nuget.org Trusted Publisher policy.
 
     steps:
+      - name: "Assert tag is a bare version number"
+        shell: bash
+        run: |
+          # ShellSyntaxTree convention: tags are SemVer version numbers WITHOUT
+          # a leading 'v'. E.g., `0.1.0-alpha`, NOT `v0.1.0-alpha`. The tag is
+          # the package version verbatim.
+          TAG="${GITHUB_REF_NAME}"
+          if [[ "$TAG" == v* ]]; then
+            echo "::error::Tag '$TAG' starts with 'v'. ShellSyntaxTree tags must be bare SemVer version numbers (e.g., '0.1.0-alpha', not 'v0.1.0-alpha'). Delete this tag and retag without the leading 'v'."
+            exit 1
+          fi
+          if ! [[ "$TAG" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9._-]+)?$ ]]; then
+            echo "::error::Tag '$TAG' is not a valid SemVer version. Expected '<major>.<minor>.<patch>' or '<major>.<minor>.<patch>-<prerelease>' (e.g., '1.0.0' or '0.2.0-beta.1')."
+            exit 1
+          fi
+          echo "PACKAGE_VERSION=${TAG}" >> "$GITHUB_ENV"
+          echo "Tag '$TAG' is a valid bare version. Publishing package version: ${TAG}"
+
       - name: "Checkout"
         uses: actions/checkout@v6.0.2
         with:
@@ -30,15 +49,6 @@ jobs:
 
       - name: "Restore .NET tools"
         run: dotnet tool restore
-
-      - name: "Compute package version from tag"
-        shell: bash
-        run: |
-          # tag form is vX.Y.Z or vX.Y.Z-suffix
-          TAG="${GITHUB_REF_NAME}"
-          VERSION="${TAG#v}"
-          echo "PACKAGE_VERSION=${VERSION}" >> "$GITHUB_ENV"
-          echo "Publishing package version: ${VERSION}"
 
       - name: "dotnet pack"
         run: dotnet pack /p:PackageVersion=${{ env.PACKAGE_VERSION }} -c Release -o ./output

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -9,7 +9,7 @@ bulldoze priorities.
 
 ---
 
-## NOW (v0.1.0-alpha shipping path)
+## NOW (0.1.0-alpha shipping path)
 
 > **Active OpenSpec change:** `v0.1-locked-interpretations` — captures
 > the eight planning-interview decisions (see
@@ -169,15 +169,16 @@ bulldoze priorities.
 - [x] Wired into `pr_validation.yml` via standard `dotnet test`
       (no separate job)
 
-### 13. Release v0.1.0-alpha — PR 7 in flight
+### 13. Release 0.1.0-alpha — PR 7 in flight
 
-- [x] `RELEASE_NOTES.md` updated with v0.1.0-alpha section
+- [x] `RELEASE_NOTES.md` updated with 0.1.0-alpha section
 - [x] `dotnet pack -c Release -o ./bin/nuget` produces clean
       `ShellSyntaxTree.0.1.0-alpha.nupkg` + `.snupkg` with embedded
       README, icon, SourceLink metadata
 - [ ] **STOP after PR 7 merges** — await user go-ahead before pushing
-      `v0.1.0-alpha` tag (the tag → nuget.org publish is irreversible)
-- [ ] On user go-ahead: `git tag v0.1.0-alpha && git push origin v0.1.0-alpha`
+      `0.1.0-alpha` tag (the tag → nuget.org publish is irreversible)
+- [ ] On user go-ahead: `git tag 0.1.0-alpha && git push origin 0.1.0-alpha`
+      (tags are bare SemVer, no `v` prefix — `publish_nuget.yml` asserts this)
 - [ ] Verify `publish_nuget.yml` produces release on tag push and the
       package appears on nuget.org
 
@@ -203,7 +204,7 @@ bulldoze priorities.
 
 ---
 
-## NEXT (v0.1.x — additive, post-alpha)
+## NEXT (0.1.x — additive, post-alpha)
 
 - Seed 50–100 corpus entries from sanitized real-world dogfood logs
   (SPEC §14 workflow)
@@ -214,7 +215,7 @@ bulldoze priorities.
 - Performance sanity check (~1 ms typical) with a tiny BenchmarkDotNet
   harness — only if anything in the daemon hot path complains
 
-## LATER (v0.2+ — out of v0.1 scope)
+## LATER (0.2+ — out of 0.1 scope)
 
 - PowerShell parser (`PwshParser : IShellParser`) — first time we exercise
   the multi-shell seam

--- a/README.md
+++ b/README.md
@@ -173,11 +173,14 @@ dotnet pack  -c Release -o ./bin/nuget
 
 ## Versioning
 
-- **v0.1.0-alpha** — first publishable cut. Bash-only.
-- **v0.1.x** — additive (more verb table entries, more corpus, bug
+Tags are bare SemVer version numbers — no `v` prefix. The release
+workflow asserts this and fails fast on misformatted tags.
+
+- **0.1.0-alpha** — first publishable cut. Bash-only.
+- **0.1.x** — additive (more verb table entries, more corpus, bug
   fixes).
-- **v0.2.0** — first PowerShell parser.
-- **v1.0.0** — when an external consumer beyond Netclaw ships against
+- **0.2.0** — first PowerShell parser.
+- **1.0.0** — when an external consumer beyond Netclaw ships against
   it without finding API gaps.
 
 ## License


### PR DESCRIPTION
## Summary

ShellSyntaxTree convention: release tags are bare SemVer version numbers — no `v` prefix. `0.1.0-alpha`, not `v0.1.0-alpha`. The tag value IS the package version, verbatim.

This PR enforces that convention in the release pipeline before the first tag pushes.

## Workflow changes (`publish_nuget.yml`)

- **Trigger broadened to `tags: ['*']`** so the workflow fires on ANY tag push. Mistakes (e.g., `v0.1.0` accidentally pushed) show up loudly in CI instead of silently no-op-ing.
- **New first step "Assert tag is a bare version number":**
  - Fails fast with `::error::` if the tag starts with `v`
  - Fails if the tag isn't SemVer-shaped (`<major>.<minor>.<patch>` or `<major>.<minor>.<patch>-<prerelease>`)
  - On success, writes `PACKAGE_VERSION=<tag>` straight to `$GITHUB_ENV`
- **Old "Compute package version from tag" step removed** — folded into the assert. No more `${TAG#v}` strip needed.

## Doc cleanups

- `README.md` Versioning section: `0.1.0-alpha` / `0.1.x` / `0.2.0` / `1.0.0` (no `v` prefix). Added a one-liner explaining the convention.
- `IMPLEMENTATION_PLAN.md`: NOW / NEXT / LATER bucket headings updated; example tag-push command is now `git tag 0.1.0-alpha && git push origin 0.1.0-alpha`.

## Verification

- ✅ `dotnet build -c Release` — clean
- ✅ `dotnet test -c Release` — 353/353 passing
- ✅ `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`
- ⚠️ Workflow change only exercises on tag push; cannot be CI-verified until 0.1.0-alpha is tagged.

## Test plan

- [ ] CI passes on \`Test-ubuntu-latest\`
- [ ] CI passes on \`Test-windows-latest\`
- [ ] After merge: push `0.1.0-alpha` tag and verify the workflow's assert step accepts it; verify the workflow rejects a deliberately-misformatted test tag (optional sanity check; can also be deferred to whenever someone accidentally mistypes).

## Next

After this merges: I push the `0.1.0-alpha` tag (per your go-ahead).