### PR TITLE
chore(ci): strip section heading from extracted release notes

### DIFF
--- a/.github/workflows/publish_nuget.yml
+++ b/.github/workflows/publish_nuget.yml
@@ -80,12 +80,18 @@ jobs:
       - name: "Extract latest release notes"
         shell: pwsh
         run: |
+          # RELEASE_NOTES.md uses `#### X.Y.Z[-suffix] <date> ####` per-section
+          # headings. Capture only the BODY of the first section (no heading)
+          # so the GitHub release page doesn't duplicate the version string in
+          # both the title and the first line of the body, and so a stale
+          # hand-typed date in the heading doesn't fight the published date
+          # GitHub renders automatically.
           if (-not (Test-Path RELEASE_NOTES.md)) {
             "No release notes available." | Set-Content RELEASE_NOTES_LATEST.md
             exit 0
           }
           $content = Get-Content RELEASE_NOTES.md -Raw
-          if ($content -match '(?s)(####.+?)(?=\n####|\z)') {
+          if ($content -match '(?s)####[^\r\n]*\r?\n+(.+?)(?=\r?\n####|\z)') {
             $Matches[1].Trim() | Set-Content RELEASE_NOTES_LATEST.md
           } else {
             $content | Set-Content RELEASE_NOTES_LATEST.md


### PR DESCRIPTION
## Summary

The release-notes extraction regex in \`publish_nuget.yml\` captured the entire matched section INCLUDING the \`#### X.Y.Z <date> ####\` heading line. The GitHub release page then duplicated the version string (in both the title and the first line of the body) and showed a stale hand-typed date that often disagrees with the actual publication date GitHub renders.

Visible on the existing \`0.1.0-alpha\` release before the fix:

> **ShellSyntaxTree 0.1.0-alpha** (release title)
>
> #### 0.1.0-alpha May 10th 2026 #### (first line of body, redundant)
> First publishable cut of ShellSyntaxTree...

## Fix

Tweak the PowerShell regex to capture only the section BODY (everything after the \`####\`-headed line). GitHub renders the publication date alongside the release title automatically.

```pwsh
# before
if (\$content -match '(?s)(####.+?)(?=\n####|\z)') { ... }

# after
if (\$content -match '(?s)####[^\r\n]*\r?\n+(.+?)(?=\r?\n####|\z)') { ... }
```

The existing 0.1.0-alpha release body has been hand-fixed via \`gh release edit\`.

## Test plan

- [ ] CI passes on \`Test-ubuntu-latest\`
- [ ] CI passes on \`Test-windows-latest\`
- [ ] Next tag push (e.g., 0.1.1 / 0.2.0) produces a release whose body starts with prose, not a \`####\` heading