### PR TITLE
fix: parser short-circuits fd-dup / fd-close redirect targets (B1)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.1.0</VersionPrefix>
+    <VersionPrefix>0.1.1</VersionPrefix>
     <VersionSuffix>alpha</VersionSuffix>
   </PropertyGroup>
   <PropertyGroup>

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,24 @@
+#### 0.1.1-alpha May 11th 2026 ####
+
+Bug fix release for v0.1.0-alpha consumers.
+
+**Fixed**
+
+- **`2>&1` fd-dup redirects no longer produce phantom `<cwd>/&1` file
+  targets.** The parser now recognizes POSIX fd-dup / fd-close shorthand
+  (`&N`, `&N-`, `&-`) on redirect targets and carries the raw token
+  verbatim on `Redirect.Target` with `Redirect.IsDynamicSkip = true`.
+  Existing consumers that already skip redirects with
+  `IsDynamicSkip = true` get correct behavior with no code changes.
+  (B1)
+
+**Behavior notes**
+
+- Public API surface is unchanged. `Redirect.Target` xmldoc and SPEC.md
+  §3 / §4 are clarified to document the fd-dup rule.
+- The Blazor sample's basename-startswith-`&` workaround has been
+  removed; the sample now relies solely on `Redirect.IsDynamicSkip`.
+
 #### 0.1.0-alpha May 10th 2026 ####
 
 First publishable cut of ShellSyntaxTree — a focused .NET library that

--- a/SPEC.md
+++ b/SPEC.md
@@ -292,9 +292,17 @@ public enum ArgKind
 public sealed record Redirect
 {
     public RedirectDirection Direction { get; init; }
-    /// <summary>Target path (resolved per Arg conventions).</summary>
+    /// <summary>
+    /// Redirect target. Normally a path resolved per Arg conventions
+    /// (§8); for fd-dup / fd-close shorthand (`&N`, `&N-`, `&-`)
+    /// the raw token is carried verbatim and IsDynamicSkip is true.
+    /// </summary>
     public string Target { get; init; } = "";
-    /// <summary>True when target is a dynamic token (skip).</summary>
+    /// <summary>
+    /// True when the target is opaque to path resolution — a dynamic
+    /// token (env var, command substitution) or an fd-dup / fd-close
+    /// form. Consumers MUST NOT treat Target as a path when this is true.
+    /// </summary>
     public bool IsDynamicSkip { get; init; }
 }
 
@@ -354,6 +362,11 @@ quoted_string   := single-quoted | double-quoted
 - Heredocs (`<<EOF ... EOF`) are recognized as a redirect operator but the
   body is **skipped** (not extracted). The clause containing the heredoc
   parses normally with the heredoc body removed.
+- Redirect targets matching the POSIX fd-dup / fd-close shorthand —
+  `&N`, `&N-`, or `&-` (where `N` is one or more decimal digits) — are
+  NOT path-resolved. The parser carries the raw token (e.g. `&1`) on
+  `Redirect.Target` and sets `Redirect.IsDynamicSkip = true`. This
+  prevents `2>&1` from being incorrectly resolved to `<cwd>/&1`.
 - Function definitions, `for`/`while`/`do`/`done`/`then`/`fi`/`case`/`esac`
   control-flow keywords, and arithmetic expansion `$(( ... ))` cause
   `IsUnparseable = true`. We don't support these in v0.1.

--- a/samples/ShellSyntaxTree.Web.Sample/Services/MermaidRenderer.cs
+++ b/samples/ShellSyntaxTree.Web.Sample/Services/MermaidRenderer.cs
@@ -124,20 +124,10 @@ public static class MermaidRenderer
                     var redirect = clause.Redirects[r];
                     if (redirect.IsDynamicSkip)
                     {
-                        continue;
-                    }
-
-                    // `2>&1` and similar `N>&M` fd-dup targets aren't files;
-                    // the parser resolves `&1` against the cwd into something
-                    // like `/work/&1`, so check the basename, not the prefix.
-                    // v0.1.x candidate: have the parser surface fd-dup targets
-                    // distinctly (e.g. IsFdDup) so consumers don't have to
-                    // string-match.
-                    var basename = redirect.Target.LastIndexOf('/') is var lastSlash and >= 0
-                        ? redirect.Target[(lastSlash + 1)..]
-                        : redirect.Target;
-                    if (basename.StartsWith('&'))
-                    {
+                        // Skips both env-var-style dynamic targets AND the
+                        // fd-dup / fd-close forms (`2>&1`, `2>&-`), which
+                        // the parser surfaces with IsDynamicSkip=true as of
+                        // v0.1.1.
                         continue;
                     }
 

--- a/src/ShellSyntaxTree/Internal/Bash/Parsing/BashCommandParser.cs
+++ b/src/ShellSyntaxTree/Internal/Bash/Parsing/BashCommandParser.cs
@@ -1255,6 +1255,23 @@ internal static class BashCommandParser
             return;
         }
 
+        if (IsFdDupTarget(target.Value))
+        {
+            // POSIX fd-dup / fd-close shorthand: `&N`, `&N-`, `&-`. These
+            // duplicate or close a file descriptor; they are NOT file paths
+            // and MUST NOT be path-resolved (else `2>&1` would resolve to
+            // `<cwd>/&1`, a phantom file). Carry the raw token verbatim and
+            // mark IsDynamicSkip=true so consumers iterating redirects as
+            // paths skip them by default.
+            redirectList.Add(new Redirect
+            {
+                Direction = direction,
+                Target = target.Value,
+                IsDynamicSkip = true,
+            });
+            return;
+        }
+
         var raw = SourceSlice(source, target);
 
         // Redirect targets are always treated as paths. SPEC §8 +
@@ -1286,6 +1303,45 @@ internal static class BashCommandParser
 
     private static bool IsFlag(string raw) =>
         raw.Length > 0 && raw[0] == '-';
+
+    private static bool IsFdDupTarget(string value)
+    {
+        // Recognized shapes (POSIX `[n]>&word` / `[n]<&word`):
+        //   &-        close fd
+        //   &N        duplicate fd N (one or more digits)
+        //   &N-       duplicate fd N, then close the source (move semantics)
+        // Anything else (e.g. `&foo`, `&`, `&1bad`) falls through and is
+        // treated as an ordinary redirect target — currently the lexer
+        // already treats bare `&` followed by a word char as part of a
+        // Word token, so we only need to recognize these well-formed cases.
+        if (value.Length < 2 || value[0] != '&')
+        {
+            return false;
+        }
+
+        if (value.Length == 2 && value[1] == '-')
+        {
+            return true;
+        }
+
+        var i = 1;
+        while (i < value.Length && value[i] >= '0' && value[i] <= '9')
+        {
+            i++;
+        }
+
+        if (i == 1)
+        {
+            return false;
+        }
+
+        if (i == value.Length)
+        {
+            return true;
+        }
+
+        return i == value.Length - 1 && value[i] == '-';
+    }
 
     private static bool TryMapRedirect(string? op, out RedirectDirection direction)
     {

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/116_redirect_fd_dup_stderr_to_stdout.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/116_redirect_fd_dup_stderr_to_stdout.json
@@ -1,0 +1,20 @@
+{
+  "name": "Redirect fd-dup: cmd 2>&1",
+  "input": "cmd 2>&1",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["cmd"],
+        "args": [],
+        "redirects": [
+          { "direction": "ErrOut", "target": "&1", "isDynamicSkip": true }
+        ],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  },
+  "notes": "v0.1.1 / B1: POSIX fd-dup targets (&N) are NOT path-resolved. Target carries the verbatim '&1' and IsDynamicSkip=true tells consumers iterating redirects-as-paths to skip."
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/117_redirect_out_with_fd_dup.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/117_redirect_out_with_fd_dup.json
@@ -1,0 +1,21 @@
+{
+  "name": "Redirect: cmd > /tmp/log 2>&1 (file + fd-dup pair)",
+  "input": "cmd > /tmp/log 2>&1",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["cmd"],
+        "args": [],
+        "redirects": [
+          { "direction": "Out", "target": "/tmp/log", "isDynamicSkip": false },
+          { "direction": "ErrOut", "target": "&1", "isDynamicSkip": true }
+        ],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  },
+  "notes": "Most common real-world idiom: redirect stdout to a file AND merge stderr into stdout. The file redirect resolves as a path; the fd-dup carries '&1' verbatim with IsDynamicSkip=true."
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/118_redirect_fd_close.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/118_redirect_fd_close.json
@@ -1,0 +1,20 @@
+{
+  "name": "Redirect fd-close: cmd 2>&-",
+  "input": "cmd 2>&-",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["cmd"],
+        "args": [],
+        "redirects": [
+          { "direction": "ErrOut", "target": "&-", "isDynamicSkip": true }
+        ],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  },
+  "notes": "fd-close form: '>&-' closes the source fd. Same parser treatment as fd-dup — target is the verbatim '&-' and IsDynamicSkip=true."
+}


### PR DESCRIPTION
## Summary

POSIX redirect targets of the form `&N`, `&N-`, or `&-` are fd duplications / closes, **not** file paths. v0.1.0-alpha path-resolved them against the working directory, producing phantom targets like `<cwd>/&1` from `2>&1`. Consumers either crashed on the phantom path or carried a string-match workaround (the Blazor sample's `basename.StartsWith('&')` check).

This is the **B1** fix from the v0.1.x backlog — the one item explicitly called out in the hand-off memory as worth landing before the Netclaw integration so Netclaw's zone-gate doesn't have to codify the workaround.

## What changed

| File | Change |
|---|---|
| `src/ShellSyntaxTree/Internal/Bash/Parsing/BashCommandParser.cs` | New `IsFdDupTarget` helper. `BuildRedirect` now short-circuits fd-dup targets before the resolver — emits `Redirect { Target = "&1" (verbatim), IsDynamicSkip = true }`. |
| `SPEC.md` §3 | Clarify `Redirect.Target` xmldoc covers the carry-raw-token semantics; tighten `IsDynamicSkip` description. |
| `SPEC.md` §4 | New Notes bullet enumerating the recognized shapes (`&N`, `&N-`, `&-`). |
| `tests/.../Corpus/bash/116-118` | Three new entries pinning `cmd 2>&1`, `cmd > /tmp/log 2>&1`, `cmd 2>&-`. |
| `samples/.../MermaidRenderer.cs` | Drop the `basename.StartsWith('&')` workaround — `IsDynamicSkip` now catches fd-dup correctly. |
| `Directory.Build.props` | `VersionPrefix` 0.1.0 → 0.1.1 (suffix unchanged: `alpha`). Final: `0.1.1-alpha`. |
| `RELEASE_NOTES.md` | New `#### 0.1.1-alpha May 11th 2026 ####` section. |

## Public API impact

**Zero.** No new fields, no removed fields, no changed signatures. Existing consumers that already check `Redirect.IsDynamicSkip` become correct for free.

`PublicApiSnapshotTests` count remains 18.

## Verification

- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify` — all files have headers.
- `dotnet build -c Release` — **0 warnings, 0 errors**.
- `dotnet test -c Release` — **356 / 356 passing** (was 353; +3 new corpus entries).
- `dotnet pack -c Release -o ./bin/nuget` — `ShellSyntaxTree.0.1.1-alpha.nupkg` + `.snupkg` produced cleanly.

## Test plan

- [x] All existing tests still pass (no regression in existing redirect cases).
- [x] New corpus entries assert `IsDynamicSkip = true` AND verbatim `&1` / `&-` targets.
- [x] `cmd > /tmp/log 2>&1` pins the file-then-fd-dup pair so the parser handles both kinds in one clause.
- [ ] CI green on ubuntu-latest + windows-latest.

## What follows this PR

After merge: push `0.1.1-alpha` tag (bare SemVer, per the convention asserted in `publish_nuget.yml`). Let trusted-publishing push the package to nuget.org. Then start the Netclaw integration against v0.1.1-alpha.