### PR TITLE
release: promote 0.1.4-alpha to stable 0.1.4

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <VersionPrefix>0.1.4</VersionPrefix>
-    <VersionSuffix>alpha</VersionSuffix>
+    <VersionSuffix></VersionSuffix>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Target framework matrix -->

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -185,15 +185,15 @@ bulldoze priorities.
   - PR #19: `chore(ci): assert tags are bare version numbers (no v prefix)`
   - PR #20: `chore(ci): strip section heading from extracted release notes`
 
-### 14. Netclaw integration smoke (SPEC §17 #7-#8)
+### 14. Netclaw integration smoke (SPEC §17 #7-#8) — complete
 
-- [ ] In netclaw repo: `dotnet add package ShellSyntaxTree --version 0.1.0-alpha`
-- [ ] Wire `IShellParser` into Netclaw DI; replace minimal call site in
+- [x] In netclaw repo: `dotnet add package ShellSyntaxTree --version 0.1.0-alpha`
+- [x] Wire `IShellParser` into Netclaw DI; replace minimal call site in
       `src/Netclaw.Security/ShellApprovalSemantics.cs`
-- [ ] One Netclaw integration test exercises a real corpus entry through
+- [x] One Netclaw integration test exercises a real corpus entry through
       the live matcher and gets the expected gate decision
-- [ ] Update this repo's IMPLEMENTATION_PLAN.md: mark SPEC §17 #7–#8
-      satisfied
+- [x] SPEC §17 #7–#8 satisfied (confirmed by Aaron 2026-05-15: all shipped
+      alpha versions are working in Netclaw production)
 
 ### 15. NuGet package icon — PR 7, complete
 
@@ -203,7 +203,7 @@ bulldoze priorities.
 - [x] `Directory.Build.props` wires `<PackageIcon>icon.png</PackageIcon>`
       + a packed `<None>` item (already present from bootstrap)
 - [x] `dotnet pack` validation: icon embedded in `.nupkg` confirmed
-- [ ] Re-pack to validate icon embeds
+- [x] Re-pack to validate icon embeds
 
 ### 16. Bash line comments (#25) — 0.1.3-alpha
 
@@ -245,7 +245,7 @@ bulldoze priorities.
       note, §12 worked examples, §15 versioning, §16 sequencing
 - [x] `Directory.Build.props` `VersionPrefix` 0.1.3 → 0.1.4
 - [x] `RELEASE_NOTES.md` 0.1.4-alpha section
-- [ ] Cut 0.1.4-alpha tag once branch is merged
+- [x] Cut 0.1.4-alpha tag once branch is merged
 
 ---
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,14 @@
+#### 0.1.4 May 15th 2026 ####
+
+Stable promotion of 0.1.4-alpha. No code changes from the alpha; this release
+drops the pre-release suffix to signal that the v0.1 public API surface is
+considered production-ready for Bash parsing use cases (see SPEC.md §17
+acceptance criteria). Consumers on any `0.1.x-alpha` can upgrade directly.
+
+See the 0.1.4-alpha notes below for the full list of changes in this version.
+
+---
+
 #### 0.1.4-alpha May 12th 2026 ####
 
 Greedy verb-chain extraction. Public API surface (`VerbChain`, `Clause`)


### PR DESCRIPTION
## Summary

- Drops `VersionSuffix` from `alpha` to empty — package ships as `ShellSyntaxTree.0.1.4`
- No code changes from the alpha; this is a straight stable promotion
- SPEC §17 acceptance criteria confirmed satisfied in Netclaw production

## Changes

- `Directory.Build.props`: `VersionSuffix` cleared
- `RELEASE_NOTES.md`: stable 0.1.4 section added at top
- `IMPLEMENTATION_PLAN.md`: items 14 (Netclaw integration smoke), 15 (icon re-pack), and 17 (0.1.4-alpha tag) marked complete

## Test plan

- [x] `dotnet build -c Release` — clean, 0 warnings
- [x] `dotnet test -c Release` — 394/394 passed
- [x] `dotnet pack -c Release` — produces `ShellSyntaxTree.0.1.4.nupkg` + `.snupkg`
- [x] Copyright headers verified (`Add-FileHeaders.ps1 -Verify`)
- [ ] Tag `0.1.4` on dev after merge → triggers NuGet publish workflow