### PR TITLE
fix: newline-as-statement-separator (0.1.5-beta)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,8 +7,8 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.1.4</VersionPrefix>
-    <VersionSuffix></VersionSuffix>
+    <VersionPrefix>0.1.5</VersionPrefix>
+    <VersionSuffix>beta</VersionSuffix>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Target framework matrix -->

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -247,19 +247,31 @@ bulldoze priorities.
 - [x] `RELEASE_NOTES.md` 0.1.4-alpha section
 - [x] Cut 0.1.4-alpha tag once branch is merged
 
+### 18. Newline-as-statement-separator — 0.1.5-beta
+
+- [x] `BashToken.IsStatementSeparator` init-property (internal)
+- [x] `BashLexer` flags the newline-branch Whitespace token and the
+      heredoc-terminator Whitespace token
+- [x] `BashCommandParser`: `FilterSignificant` retains flagged
+      Whitespace; `SplitIntoSegments` splits on it as a `Sequence`
+      boundary (an empty pending segment collapses — no empty clause);
+      `TryDetectAnomaly` treats it as a verb-slot boundary
+- [x] SPEC.md §4 grammar + notes, §5 `WHITESPACE` bullet, §15
+      versioning, §16 sequencing note
+- [x] 8 new `BashLexerTests` + 14 new `BashCommandParserTests`; stale
+      comment in `Comment_between_two_statements_preserves_both_clauses`
+      corrected
+- [x] 11 new corpus entries (139–149); entry 126 note corrected
+- [x] `Directory.Build.props` `VersionPrefix` 0.1.4 → 0.1.5,
+      `VersionSuffix` → `beta`
+- [x] `RELEASE_NOTES.md` 0.1.5-beta section
+- [ ] Cut 0.1.5-beta tag once branch is merged; promote to stable
+      0.1.5 after Netclaw validates the behavior change
+
 ---
 
 ## NEXT (0.1.x — additive, post-alpha)
 
-- Newline-as-statement-separator at the parser level (SPEC §4 gap
-  surfaced by #25). The lexer already emits Whitespace tokens for
-  newlines with the intent of acting as separators (see the lexer
-  comment at the newline branch), but `BashCommandParser.SplitIntoSegments`
-  only splits on `&&` / `||` / `;` / `|`. As a result, `cmd1\ncmd2`
-  currently parses to one clause `[cmd1]` with `cmd2` as an argument.
-  v0.1.3 corpus entry 126 works around this with an explicit `;`;
-  the long-term fix is to bridge newline-Whitespace tokens to the
-  segment splitter as synthetic `;` separators.
 - Seed 50–100 corpus entries from sanitized real-world dogfood logs
   (SPEC §14 workflow)
 - Expand verb tables as corpus surfaces real commands

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,56 @@
+#### 0.1.5-beta May 15th 2026 ####
+
+Newline-as-statement-separator. Public API surface unchanged; the
+*content* of `ParsedCommand.Clauses` changes for any input that spans
+multiple lines. Shipped as a **beta** prerelease so Netclaw can validate
+the AST-shape change against its live gate evaluator before this is
+promoted to a stable `0.1.5`.
+
+**BEHAVIOR CHANGE: a bare newline now separates clauses (SPEC §4)**
+
+- A bare newline outside quotes, heredoc bodies, line continuations, and
+  `$()` / backtick substitutions is now a statement separator equivalent
+  to `;` — the clause after it carries `CompoundOperator.Sequence`.
+  Before this release `BashCommandParser` only split clauses on `&&` /
+  `||` / `;` / `|`, so `cmd1\ncmd2` parsed to a single clause `[cmd1]`
+  with `cmd2` wrongly absorbed as an argument.
+- The lexer flags the newline-bearing `Whitespace` token — and the
+  newline after a heredoc terminator — with a new internal
+  `IsStatementSeparator` bit; `FilterSignificant` retains those tokens
+  and `SplitIntoSegments` splits clauses on them.
+- Consecutive newlines, leading and trailing newlines, and a newline
+  immediately after a compound operator (`cmd1 &&\ncmd2`) all collapse —
+  they never produce an empty clause.
+- A heredoc followed by a command on the next line now parses to two
+  clauses (previously the heredoc clause and the following command
+  merged into one).
+- A control-flow keyword opening a newline-separated clause
+  (`echo hi\nfor i in 1 2 3`) safe-fails to `IsUnparseable=true`, exactly
+  as it would after `;`.
+
+Examples that change:
+
+- `cmd1\ncmd2` → two clauses `[cmd1]`, `[cmd2]` (was one clause `[cmd1]`
+  with `cmd2` as an arg).
+- `git pull # done\ndotnet build` → two clauses (was one).
+
+**Behavior notes**
+
+- Public API surface is unchanged (no `PublicApiSnapshotTests` delta).
+- SPEC.md updates: §4 grammar (`compound_op` includes `NEWLINE`, new
+  notes bullet), §5 `WHITESPACE` tokenization, §15 versioning, §16
+  sequencing note.
+- Corpus: 11 new entries (139–149) covering newline separation, blank
+  lines, leading/trailing newlines, newline after an operator, newline
+  inside quotes and subshells, line continuation, comment-then-newline,
+  and the control-flow-after-newline safe-fail. Entry 126's note is
+  corrected — newline-as-separator is no longer a pending gap.
+- Unit tests: 8 new `BashLexerTests` cases + 14 new
+  `BashCommandParserTests` cases; the stale comment in
+  `Comment_between_two_statements_preserves_both_clauses` is corrected.
+
+---
+
 #### 0.1.4 May 15th 2026 ####
 
 Stable promotion of 0.1.4-alpha. No code changes from the alpha; this release

--- a/SPEC.md
+++ b/SPEC.md
@@ -340,7 +340,7 @@ is unparseable (`ParsedCommand.IsUnparseable = true`).
 
 ```
 command         := clause (compound_op clause)*
-compound_op     := "&&" | "||" | ";" | "|"
+compound_op     := "&&" | "||" | ";" | "|" | NEWLINE
 clause          := subshell | bash_c_wrapper | simple_clause
 subshell        := "(" command ")"
 bash_c_wrapper  := ("bash" | "sh") "-c" QUOTED_STRING
@@ -363,6 +363,13 @@ quoted_string   := single-quoted | double-quoted
 **Notes:**
 
 - Whitespace between tokens is one or more spaces or tabs.
+- A bare newline outside quotes, heredoc bodies, line continuations, and
+  `$(...)` / backtick substitutions is a **statement separator** —
+  semantically equivalent to `;`, producing `CompoundOperator.Sequence`.
+  Consecutive newlines, leading and trailing newlines, and a newline
+  immediately following a compound operator all collapse: they never
+  yield an empty clause. The newline after a heredoc terminator likewise
+  separates the heredoc's clause from what follows.
 - `\` followed by a newline is a line continuation (treat as whitespace).
 - Bash line comments (`#` at a word boundary through end-of-line) are
   whitespace-equivalent at the lexer level — they emit a Comment token
@@ -398,8 +405,12 @@ The lexer produces tokens consumed by the parser. Token kinds:
   becomes the token value `hello world`.
 - **OPERATOR** — `&&`, `||`, `;`, `|`, `>`, `>>`, `<`, `2>`, `2>>`,
   `(`, `)`, `<<`, `<<-`.
-- **WHITESPACE** — one or more spaces or tabs (or newlines outside a
-  heredoc body). Discarded after splitting.
+- **WHITESPACE** — one or more spaces, tabs, or newlines (newlines inside
+  a skipped heredoc body are not tokenized). A whitespace run that
+  contains a newline — including the newline after a heredoc terminator —
+  is flagged as a **statement separator**; the parser retains those
+  tokens past `FilterSignificant` and splits clauses on them per §4. A
+  pure space/tab run carries no flag and is discarded after splitting.
 - **CONTINUATION** — `\` + `\n`. Treated as whitespace.
 - **OPAQUE_SUBSTITUTION** — `$(cmd)` or backtick `` `cmd` ``. The full
   substitution slice (including delimiters) becomes a single token.
@@ -1330,8 +1341,11 @@ Adapt for ShellSyntaxTree:
   `BashArity` static table with the greedy verb-chain heuristic per
   issue #27).
 - **v0.1.0** — first publishable non-alpha cut. Bash-only.
-- **v0.1.x** (post-0.1.0) — additive changes only (more verb table
-  entries, more corpus, bug fixes that don't shift parsed-AST shape).
+- **v0.1.x** (post-0.1.0) — additive changes and SPEC-conformance fixes
+  (more verb table entries, more corpus, bug fixes). A fix may shift the
+  parsed-AST shape when the prior shape violated this SPEC — e.g. v0.1.5
+  makes a bare newline a statement separator per §4. The §2 public API
+  surface stays locked.
 - **v0.2.0** — first PowerShell parser implementation.
 - **v1.0.0** — ready when at least one external consumer beyond Netclaw
   ships against it without finding API gaps.
@@ -1385,6 +1399,10 @@ A natural order for the implementer:
 
 Estimated implementation effort: 600-800 LOC of source + 400-600 LOC of
 test infrastructure + 100-150 corpus entries (~50 KB JSON).
+
+Post-v0.1.0 increments (e.g. v0.1.5 newline-as-statement-separator) are
+sequenced through `IMPLEMENTATION_PLAN.md` — §16 records the one-time
+v0.1.0 build order, not the ongoing changelog.
 
 ---
 

--- a/src/ShellSyntaxTree/Internal/Bash/Lexing/BashLexer.cs
+++ b/src/ShellSyntaxTree/Internal/Bash/Lexing/BashLexer.cs
@@ -90,7 +90,8 @@ internal static class BashLexer
                 }
 
                 tokens.Add(new BashToken(
-                    BashTokenKind.Whitespace, "", null, start, i - start, null));
+                    BashTokenKind.Whitespace, "", null, start, i - start, null)
+                    { IsStatementSeparator = true });
                 continue;
             }
 
@@ -770,7 +771,8 @@ internal static class BashLexer
                 if (j < src.Length && src[j] == '\n')
                 {
                     tokens.Add(new BashToken(
-                        BashTokenKind.Whitespace, "", null, j, 1, null));
+                        BashTokenKind.Whitespace, "", null, j, 1, null)
+                        { IsStatementSeparator = true });
                     return j + 1;
                 }
 

--- a/src/ShellSyntaxTree/Internal/Bash/Lexing/BashToken.cs
+++ b/src/ShellSyntaxTree/Internal/Bash/Lexing/BashToken.cs
@@ -48,4 +48,14 @@ internal readonly record struct BashToken(
     /// substitution per SPEC §8 step 3).
     /// </summary>
     public bool IsSingleQuoted { get; init; }
+
+    /// <summary>
+    /// True when this <see cref="BashTokenKind.Whitespace"/> token contains
+    /// a newline and therefore acts as a statement separator equivalent to
+    /// <c>;</c> per SPEC §4. The lexer sets this on the newline branch and
+    /// on the heredoc-terminator newline; the parser retains these tokens
+    /// past <c>FilterSignificant</c> and splits clauses on them. Default
+    /// <c>false</c> for plain space/tab whitespace and every other kind.
+    /// </summary>
+    public bool IsStatementSeparator { get; init; }
 }

--- a/src/ShellSyntaxTree/Internal/Bash/Parsing/BashCommandParser.cs
+++ b/src/ShellSyntaxTree/Internal/Bash/Parsing/BashCommandParser.cs
@@ -496,7 +496,12 @@ internal static class BashCommandParser
         var filtered = new List<BashToken>(tokens.Count);
         foreach (var t in tokens)
         {
-            if (t.Kind == BashTokenKind.Whitespace
+            // A newline-bearing Whitespace token is a statement separator
+            // (SPEC §4) — it survives filtering so SplitIntoSegments can
+            // split clauses on it, exactly like an explicit ';'. Plain
+            // space/tab Whitespace, Continuation, and Comment carry no
+            // structural signal and are dropped.
+            if ((t.Kind == BashTokenKind.Whitespace && !t.IsStatementSeparator)
                 || t.Kind == BashTokenKind.Continuation
                 || t.Kind == BashTokenKind.Comment)
             {
@@ -529,6 +534,16 @@ internal static class BashCommandParser
             if (t.Kind == BashTokenKind.Operator)
             {
                 nextIsVerbSlot = t.OperatorText is "&&" or "||" or ";" or "|" or "(";
+                continue;
+            }
+
+            // A retained Whitespace token is a newline statement separator
+            // (SPEC §4); the word after it sits at a verb slot, exactly as
+            // it would after ';'. Without this, a control-flow keyword that
+            // opens a newline-separated clause would slip past detection.
+            if (t.Kind == BashTokenKind.Whitespace)
+            {
+                nextIsVerbSlot = true;
                 continue;
             }
 
@@ -629,6 +644,29 @@ internal static class BashCommandParser
         for (var i = 0; i < tokens.Count; i++)
         {
             var t = tokens[i];
+
+            // A retained Whitespace token is a newline statement separator
+            // (SPEC §4), equivalent to ';'. Unlike a stray ';', a newline
+            // on an empty pending segment is NOT an error — it simply
+            // collapses, so blank lines, leading newlines, and a newline
+            // right after a compound operator never produce an empty clause.
+            if (t.Kind == BashTokenKind.Whitespace)
+            {
+                if (current.Tokens.Count == 0)
+                {
+                    continue;
+                }
+
+                segments.Add(current);
+                current = new Segment
+                {
+                    PrecedingOperator = CompoundOperator.Sequence,
+                    FromSubshell = depth > 0,
+                    SubshellDepth = depth,
+                    SubshellStack = subshellStack.ToArray(),
+                };
+                continue;
+            }
 
             if (t.Kind == BashTokenKind.Operator)
             {

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/139_newline_separates_two_commands.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/139_newline_separates_two_commands.json
@@ -1,0 +1,26 @@
+{
+  "name": "Newline separates two commands",
+  "input": "ls\npwd",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["ls"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      },
+      {
+        "operator": "Sequence",
+        "verb": ["pwd"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  },
+  "notes": "SPEC §4: a bare newline is a statement separator equivalent to ';' — the second clause carries CompoundOperator.Sequence."
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/140_newline_separates_three_commands.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/140_newline_separates_three_commands.json
@@ -1,0 +1,34 @@
+{
+  "name": "Newline separates three commands",
+  "input": "cmd1\ncmd2\ncmd3",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["cmd1"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      },
+      {
+        "operator": "Sequence",
+        "verb": ["cmd2"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      },
+      {
+        "operator": "Sequence",
+        "verb": ["cmd3"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  },
+  "notes": "SPEC §4: each newline yields a Sequence-joined clause, exactly like ';'."
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/141_blank_lines_collapse.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/141_blank_lines_collapse.json
@@ -1,0 +1,26 @@
+{
+  "name": "Blank lines collapse — no empty clauses",
+  "input": "cmd1\n\n\ncmd2",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["cmd1"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      },
+      {
+        "operator": "Sequence",
+        "verb": ["cmd2"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  },
+  "notes": "SPEC §4: consecutive newlines collapse into a single separator — blank lines never produce an empty clause."
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/142_leading_and_trailing_newlines.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/142_leading_and_trailing_newlines.json
@@ -1,0 +1,26 @@
+{
+  "name": "Leading and trailing newlines are ignored",
+  "input": "\ncmd1\ncmd2\n",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["cmd1"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      },
+      {
+        "operator": "Sequence",
+        "verb": ["cmd2"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  },
+  "notes": "SPEC §4: a leading newline does not create a clause (first clause keeps Operator=None); a trailing newline does not create a phantom clause."
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/143_newline_after_andif.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/143_newline_after_andif.json
@@ -1,0 +1,26 @@
+{
+  "name": "Newline after && does not create an empty clause",
+  "input": "cmd1 &&\ncmd2",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["cmd1"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      },
+      {
+        "operator": "AndIf",
+        "verb": ["cmd2"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  },
+  "notes": "SPEC §4: a newline immediately after a compound operator collapses — the && carries onto the next clause with no empty clause between them."
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/144_newline_after_pipe.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/144_newline_after_pipe.json
@@ -1,0 +1,26 @@
+{
+  "name": "Newline after pipe does not create an empty clause",
+  "input": "cmd1 |\ncmd2",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["cmd1"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      },
+      {
+        "operator": "Pipe",
+        "verb": ["cmd2"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  },
+  "notes": "SPEC §4: a newline immediately after a pipe collapses — the | carries onto the next clause."
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/145_newline_inside_double_quotes_literal.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/145_newline_inside_double_quotes_literal.json
@@ -1,0 +1,20 @@
+{
+  "name": "Newline inside double quotes is literal, not a separator",
+  "input": "echo \"a\nb\"",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["echo"],
+        "args": [
+          { "raw": "\"a\nb\"", "kind": "Literal", "isPath": false }
+        ],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  },
+  "notes": "SPEC §4/§5: a newline inside a quoted string is literal content — the command stays one clause with a single quoted arg."
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/146_newline_inside_subshell.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/146_newline_inside_subshell.json
@@ -1,0 +1,26 @@
+{
+  "name": "Newline inside a subshell separates inner clauses",
+  "input": "(cmd1\ncmd2)",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["cmd1"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": true,
+        "isBashCWrapped": false
+      },
+      {
+        "operator": "Sequence",
+        "verb": ["cmd2"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": true,
+        "isBashCWrapped": false
+      }
+    ]
+  },
+  "notes": "SPEC §4: a newline inside ( ) separates clauses within the subshell, exactly like ';'."
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/147_continuation_newline_not_separator.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/147_continuation_newline_not_separator.json
@@ -1,0 +1,18 @@
+{
+  "name": "Backslash-newline continuation is not a separator",
+  "input": "echo one \\\ntwo",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["echo", "one", "two"],
+        "args": [],
+        "redirects": [],
+        "isSubshell": false,
+        "isBashCWrapped": false
+      }
+    ]
+  },
+  "notes": "SPEC §5: a backslash + newline is a line continuation, not a statement separator — the two source lines remain one clause."
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/148_comment_then_newline_separates.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/148_comment_then_newline_separates.json
@@ -1,6 +1,6 @@
 {
-  "name": "Comment between two ;-separated commands",
-  "input": "git pull ; # now build\ndotnet build",
+  "name": "Trailing comment then newline separates clauses",
+  "input": "git pull # done\ndotnet build",
   "expected": {
     "isUnparseable": false,
     "clauses": [
@@ -22,5 +22,5 @@
       }
     ]
   },
-  "notes": "Issue #25: a comment between two clauses must not pollute either verb chain. The ';' and the trailing newline are both statement separators (SPEC §4); the newline after the comment lands on the segment the ';' already opened, so it collapses — still exactly two clauses."
+  "notes": "SPEC §4/§5: a trailing comment ends at the newline; the newline still separates the two statements. Bare-newline form of the explicit-';' workaround in corpus entry 126."
 }

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/149_control_flow_keyword_after_newline.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/149_control_flow_keyword_after_newline.json
@@ -1,0 +1,9 @@
+{
+  "name": "Control-flow keyword after a newline is unparseable",
+  "input": "echo hi\nfor i in 1 2 3",
+  "expected": {
+    "isUnparseable": true,
+    "unparseableReasonContains": "'for'"
+  },
+  "notes": "SPEC §4/§11: a newline opens a new clause; a control-flow keyword at that verb slot safe-fails just as it would after ';'."
+}

--- a/tests/ShellSyntaxTree.Tests/Lexing/BashLexerTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Lexing/BashLexerTests.cs
@@ -702,6 +702,92 @@ public class BashLexerTests
         Assert.Equal("cmd", tokens[2].Value);
     }
 
+    // ------------------------------------------------------------ newline separators (SPEC §4)
+
+    [Fact]
+    public void Newline_whitespace_token_is_flagged_statement_separator()
+    {
+        // `a\nb` → Word(a), Whitespace(\n), Word(b). The newline-bearing
+        // Whitespace token carries IsStatementSeparator=true so the parser
+        // can split clauses on it, exactly like an explicit ';'.
+        var tokens = BashLexer.Tokenize("a\nb");
+        Assert.Equal(3, tokens.Count);
+        Assert.Equal(BashTokenKind.Whitespace, tokens[1].Kind);
+        Assert.True(tokens[1].IsStatementSeparator);
+    }
+
+    [Theory]
+    [InlineData("a b")]
+    [InlineData("a\tb")]
+    public void Space_and_tab_whitespace_is_not_a_statement_separator(string input)
+    {
+        // Only newline-bearing Whitespace separates statements; plain
+        // space/tab runs carry no structural signal.
+        var tokens = BashLexer.Tokenize(input);
+        Assert.Equal(BashTokenKind.Whitespace, tokens[1].Kind);
+        Assert.False(tokens[1].IsStatementSeparator);
+    }
+
+    [Fact]
+    public void Consecutive_newlines_lex_as_one_flagged_whitespace_token()
+    {
+        // `a\n\n\nb` — the newline run collapses into a single Whitespace
+        // token; blank lines never produce empty clauses downstream.
+        var tokens = BashLexer.Tokenize("a\n\n\nb");
+        Assert.Equal(3, tokens.Count);
+        Assert.Equal(BashTokenKind.Whitespace, tokens[1].Kind);
+        Assert.True(tokens[1].IsStatementSeparator);
+        Assert.Equal(3, tokens[1].SourceLength);
+    }
+
+    [Fact]
+    public void Crlf_newline_is_a_flagged_statement_separator()
+    {
+        var tokens = BashLexer.Tokenize("a\r\nb");
+        Assert.Equal(3, tokens.Count);
+        Assert.Equal(BashTokenKind.Whitespace, tokens[1].Kind);
+        Assert.True(tokens[1].IsStatementSeparator);
+    }
+
+    [Fact]
+    public void Continuation_token_is_not_a_statement_separator()
+    {
+        // `\` + newline is a line continuation (SPEC §5), not a separator.
+        var tokens = BashLexer.Tokenize("cmd \\\nfoo");
+        Assert.Contains(tokens, t => t.Kind == BashTokenKind.Continuation);
+        Assert.DoesNotContain(tokens, t => t.IsStatementSeparator);
+    }
+
+    [Fact]
+    public void Newline_inside_double_quotes_does_not_emit_a_separator()
+    {
+        // A newline inside a quoted string is literal content — the lexer
+        // never reaches the newline branch.
+        var tokens = BashLexer.Tokenize("echo \"a\nb\"");
+        Assert.DoesNotContain(tokens, t => t.IsStatementSeparator);
+        var quoted = tokens.Single(t => t.Kind == BashTokenKind.QuotedString);
+        Assert.Equal("a\nb", quoted.Value);
+    }
+
+    [Fact]
+    public void Newline_inside_single_quotes_does_not_emit_a_separator()
+    {
+        var tokens = BashLexer.Tokenize("echo 'a\nb'");
+        Assert.DoesNotContain(tokens, t => t.IsStatementSeparator);
+        var quoted = tokens.Single(t => t.Kind == BashTokenKind.QuotedString);
+        Assert.Equal("a\nb", quoted.Value);
+    }
+
+    [Fact]
+    public void Newline_inside_opaque_substitution_does_not_emit_a_separator()
+    {
+        // `$(...)` is one opaque token; an interior newline stays inside it.
+        var tokens = BashLexer.Tokenize("$(echo\nfoo)");
+        Assert.DoesNotContain(tokens, t => t.IsStatementSeparator);
+        var sub = Assert.Single(tokens);
+        Assert.Equal(BashTokenKind.OpaqueSubstitution, sub.Kind);
+    }
+
     // ------------------------------------------------------------ misc
 
     [Fact]

--- a/tests/ShellSyntaxTree.Tests/Parsing/BashCommandParserTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Parsing/BashCommandParserTests.cs
@@ -631,9 +631,10 @@ public class BashCommandParserTests
     [Fact]
     public void Comment_between_two_statements_preserves_both_clauses()
     {
-        // v0.1 does not treat top-level newlines as statement separators
-        // (SPEC §4 gap — separate from #25). Use explicit `;` so the
-        // separator survives FilterSignificant.
+        // The `;` and the trailing newline are both statement separators;
+        // the comment between them must not pollute either verb chain. The
+        // newline after the comment lands on the segment the `;` already
+        // opened, so it collapses — still exactly two clauses.
         var result = Parse("git pull ; # now build\ndotnet build");
         Assert.Equal(2, result.Clauses.Count);
         Assert.Equal(new[] { "git", "pull" }, result.Clauses[0].Verb.Tokens);
@@ -684,6 +685,169 @@ public class BashCommandParserTests
         Assert.Equal(new[] { "curl" }, result.Clauses[0].Verb.Tokens);
         Assert.Equal(new[] { "echo" }, result.Clauses[1].Verb.Tokens);
         Assert.False(result.IsUnparseable);
+    }
+
+    // ---------------- Newline statement separators (SPEC §4) ----------------
+
+    [Fact]
+    public void Newline_separates_two_clauses_as_Sequence()
+    {
+        var result = Parse("ls\npwd");
+        Assert.False(result.IsUnparseable);
+        Assert.Equal(2, result.Clauses.Count);
+        Assert.Equal(CompoundOperator.None, result.Clauses[0].Operator);
+        Assert.Equal(new[] { "ls" }, result.Clauses[0].Verb.Tokens);
+        Assert.Equal(CompoundOperator.Sequence, result.Clauses[1].Operator);
+        Assert.Equal(new[] { "pwd" }, result.Clauses[1].Verb.Tokens);
+    }
+
+    [Fact]
+    public void Newline_separates_three_clauses()
+    {
+        var result = Parse("cmd1\ncmd2\ncmd3");
+        Assert.False(result.IsUnparseable);
+        Assert.Equal(3, result.Clauses.Count);
+        Assert.Equal(CompoundOperator.None, result.Clauses[0].Operator);
+        Assert.Equal(CompoundOperator.Sequence, result.Clauses[1].Operator);
+        Assert.Equal(CompoundOperator.Sequence, result.Clauses[2].Operator);
+    }
+
+    [Fact]
+    public void Blank_lines_do_not_create_empty_clauses()
+    {
+        var result = Parse("cmd1\n\n\ncmd2");
+        Assert.False(result.IsUnparseable);
+        Assert.Equal(2, result.Clauses.Count);
+        Assert.Equal(new[] { "cmd1" }, result.Clauses[0].Verb.Tokens);
+        Assert.Equal(new[] { "cmd2" }, result.Clauses[1].Verb.Tokens);
+    }
+
+    [Fact]
+    public void Leading_newline_keeps_first_clause_operator_None()
+    {
+        var result = Parse("\ncmd1\ncmd2");
+        Assert.False(result.IsUnparseable);
+        Assert.Equal(2, result.Clauses.Count);
+        Assert.Equal(CompoundOperator.None, result.Clauses[0].Operator);
+        Assert.Equal(new[] { "cmd1" }, result.Clauses[0].Verb.Tokens);
+    }
+
+    [Fact]
+    public void Trailing_newline_does_not_create_a_phantom_clause()
+    {
+        var result = Parse("cmd1\n");
+        Assert.False(result.IsUnparseable);
+        var clause = Assert.Single(result.Clauses);
+        Assert.Equal(new[] { "cmd1" }, clause.Verb.Tokens);
+    }
+
+    [Fact]
+    public void Newline_after_AndIf_does_not_create_an_empty_clause()
+    {
+        // `cmd1 &&\ncmd2` — bash allows a newline right after a compound
+        // operator; the newline must not produce an empty clause, and the
+        // && must survive onto cmd2.
+        var result = Parse("cmd1 &&\ncmd2");
+        Assert.False(result.IsUnparseable);
+        Assert.Equal(2, result.Clauses.Count);
+        Assert.Equal(CompoundOperator.AndIf, result.Clauses[1].Operator);
+        Assert.Equal(new[] { "cmd2" }, result.Clauses[1].Verb.Tokens);
+    }
+
+    [Fact]
+    public void Newline_after_Pipe_does_not_create_an_empty_clause()
+    {
+        var result = Parse("cmd1 |\ncmd2");
+        Assert.False(result.IsUnparseable);
+        Assert.Equal(2, result.Clauses.Count);
+        Assert.Equal(CompoundOperator.Pipe, result.Clauses[1].Operator);
+    }
+
+    [Fact]
+    public void Newline_after_Semicolon_does_not_create_an_empty_clause()
+    {
+        var result = Parse("cmd1 ;\ncmd2");
+        Assert.False(result.IsUnparseable);
+        Assert.Equal(2, result.Clauses.Count);
+        Assert.Equal(CompoundOperator.Sequence, result.Clauses[1].Operator);
+    }
+
+    [Fact]
+    public void Newline_inside_subshell_separates_inner_clauses()
+    {
+        var result = Parse("(cmd1\ncmd2)");
+        Assert.False(result.IsUnparseable);
+        Assert.Equal(2, result.Clauses.Count);
+        Assert.True(result.Clauses[0].IsSubshell);
+        Assert.True(result.Clauses[1].IsSubshell);
+        Assert.Equal(CompoundOperator.Sequence, result.Clauses[1].Operator);
+    }
+
+    [Fact]
+    public void Newline_inside_double_quotes_is_a_single_arg()
+    {
+        // A newline inside a quoted string is literal content, not a
+        // separator — the whole thing stays one clause with one arg.
+        var result = Parse("echo \"a\nb\"");
+        Assert.False(result.IsUnparseable);
+        var clause = Assert.Single(result.Clauses);
+        Assert.Equal(new[] { "echo" }, clause.Verb.Tokens);
+        Assert.Single(clause.Args);
+    }
+
+    [Fact]
+    public void Continuation_newline_is_not_a_separator()
+    {
+        // `\` + newline is a line continuation — the two source lines
+        // remain a single clause.
+        var result = Parse("echo one \\\ntwo");
+        Assert.False(result.IsUnparseable);
+        var clause = Assert.Single(result.Clauses);
+        Assert.Equal(new[] { "echo", "one", "two" }, clause.Verb.Tokens);
+    }
+
+    [Fact]
+    public void Comment_then_newline_separates_clauses()
+    {
+        // A trailing comment ends at the newline; the newline still
+        // separates the two statements — the bare-newline form of the
+        // explicit-`;` workaround in corpus entry 126.
+        var result = Parse("git pull # done\ndotnet build");
+        Assert.False(result.IsUnparseable);
+        Assert.Equal(2, result.Clauses.Count);
+        Assert.Equal(new[] { "git", "pull" }, result.Clauses[0].Verb.Tokens);
+        Assert.Equal(new[] { "dotnet", "build" }, result.Clauses[1].Verb.Tokens);
+    }
+
+    [Fact]
+    public void Whitespace_and_newline_only_input_returns_empty_clauses()
+    {
+        var result = Parse("  \n  ");
+        Assert.False(result.IsUnparseable);
+        Assert.Empty(result.Clauses);
+    }
+
+    [Fact]
+    public void Heredoc_terminator_newline_separates_following_clause()
+    {
+        // The newline after the heredoc terminator is a statement
+        // separator: `rest` is its own clause, not an arg of `cmd`.
+        var result = Parse("cmd <<EOF\nbody\nEOF\nrest");
+        Assert.False(result.IsUnparseable);
+        Assert.Equal(2, result.Clauses.Count);
+        Assert.Equal(new[] { "rest" }, result.Clauses[1].Verb.Tokens);
+        Assert.Equal(CompoundOperator.Sequence, result.Clauses[1].Operator);
+    }
+
+    [Fact]
+    public void Control_flow_keyword_after_newline_marks_outer_unparseable()
+    {
+        // A control-flow keyword opening a newline-separated clause must
+        // still safe-fail per SPEC §11 — TryDetectAnomaly treats the
+        // newline as a verb-slot boundary.
+        var result = Parse("echo hi\nfor i in 1 2 3");
+        Assert.True(result.IsUnparseable);
+        Assert.Contains("'for'", result.UnparseableReason!);
     }
 
     // ---------------- Subshell ----------------


### PR DESCRIPTION
## Summary

- A bare newline now splits clauses like `;` (`CompoundOperator.Sequence`). Previously the parser only split on `&& || ; |`, so `cmd1\ncmd2` collapsed into one clause with `cmd2` absorbed as an argument of `cmd1` — hiding a second command from any per-clause security gate.
- The lexer flags newline-bearing `Whitespace` tokens (and the heredoc-terminator newline) with a new internal `IsStatementSeparator` bit; `FilterSignificant` retains them and `SplitIntoSegments` splits clauses on them. `TryDetectAnomaly` treats them as verb-slot boundaries so a control-flow keyword opening a newline-separated clause still safe-fails.
- Consecutive / leading / trailing / post-operator newlines collapse with no empty clause; the heredoc-terminator newline now separates the heredoc clause from what follows.
- Public API surface unchanged. `SPEC.md` §4/§5/§15/§16 updated. Ships as `0.1.5-beta` so Netclaw can validate the AST-shape change before stable promotion.

## Test plan

- [x] `dotnet build -c Release` — clean, 0 warnings
- [x] `dotnet test -c Release` — 429 tests pass (8 new lexer + 14 new parser unit tests; 11 new corpus entries 139–149)
- [x] `PublicApiSnapshotTests` pass with no edits (public API untouched)
- [x] PII audit passes
- [x] `pwsh ./scripts/Add-FileHeaders.ps1 -Verify` exits 0
- [x] `dotnet pack -c Release` produces `ShellSyntaxTree.0.1.5-beta.nupkg`