### PR TITLE
refactor: extract an OpenSegment helper in SplitIntoSegments

### DIFF
--- a/src/ShellSyntaxTree/Internal/Bash/Parsing/BashCommandParser.cs
+++ b/src/ShellSyntaxTree/Internal/Bash/Parsing/BashCommandParser.cs
@@ -631,15 +631,20 @@ internal static class BashCommandParser
         var segments = new List<Segment>();
         var subshellStack = new List<int> { 0 }; // ID 0 is the top-level command.
         var nextSubshellId = 1;
+        var depth = 0;
 
-        var current = new Segment
+        // Shared factory for the segment opened at every clause boundary:
+        // FromSubshell / SubshellDepth / SubshellStack are uniform (driven
+        // by the current `depth`), so only the preceding operator varies.
+        Segment OpenSegment(CompoundOperator precedingOperator) => new()
         {
-            PrecedingOperator = CompoundOperator.None,
-            SubshellDepth = 0,
+            PrecedingOperator = precedingOperator,
+            FromSubshell = depth > 0,
+            SubshellDepth = depth,
             SubshellStack = subshellStack.ToArray(),
         };
 
-        var depth = 0;
+        var current = OpenSegment(CompoundOperator.None);
 
         for (var i = 0; i < tokens.Count; i++)
         {
@@ -658,13 +663,7 @@ internal static class BashCommandParser
                 }
 
                 segments.Add(current);
-                current = new Segment
-                {
-                    PrecedingOperator = CompoundOperator.Sequence,
-                    FromSubshell = depth > 0,
-                    SubshellDepth = depth,
-                    SubshellStack = subshellStack.ToArray(),
-                };
+                current = OpenSegment(CompoundOperator.Sequence);
                 continue;
             }
 
@@ -681,15 +680,9 @@ internal static class BashCommandParser
 
                     depth++;
                     subshellStack.Add(nextSubshellId++);
-                    current = new Segment
-                    {
-                        PrecedingOperator = current.Tokens.Count > 0
-                            ? CompoundOperator.Sequence
-                            : current.PrecedingOperator,
-                        FromSubshell = true,
-                        SubshellDepth = depth,
-                        SubshellStack = subshellStack.ToArray(),
-                    };
+                    current = OpenSegment(current.Tokens.Count > 0
+                        ? CompoundOperator.Sequence
+                        : current.PrecedingOperator);
                     continue;
                 }
 
@@ -709,13 +702,7 @@ internal static class BashCommandParser
                         segments.Add(current);
                     }
 
-                    current = new Segment
-                    {
-                        PrecedingOperator = CompoundOperator.None,
-                        FromSubshell = depth > 0,
-                        SubshellDepth = depth,
-                        SubshellStack = subshellStack.ToArray(),
-                    };
+                    current = OpenSegment(CompoundOperator.None);
                     continue;
                 }
 
@@ -732,13 +719,7 @@ internal static class BashCommandParser
                         segments.Add(current);
                     }
 
-                    current = new Segment
-                    {
-                        PrecedingOperator = MapOperator(op),
-                        FromSubshell = depth > 0,
-                        SubshellDepth = depth,
-                        SubshellStack = subshellStack.ToArray(),
-                    };
+                    current = OpenSegment(MapOperator(op));
                     continue;
                 }
 


### PR DESCRIPTION
## Summary

Follow-up cleanup to #34. `SplitIntoSegments` opened a `new Segment { ... }` at five clause-boundary sites (initial, `(`, `)`, `&&/||/;/|`, and the newline branch) with a near-identical four-field initializer.

- `FromSubshell`, `SubshellDepth`, and `SubshellStack` are uniform across all five — each derives from the current `depth` — so a one-parameter local `OpenSegment` helper collapses them; only the preceding operator varies per call site. Net −19 lines.
- Behavior-preserving: the `(` branch's former `FromSubshell = true` equals `depth > 0` (it runs after `depth++`); the initial segment's omitted `FromSubshell` equals `depth > 0` at depth 0. No public API or parsed-AST change.

## Test plan

- [x] `dotnet build -c Release` — clean, 0 warnings
- [x] `dotnet test -c Release` — 429 tests pass (unchanged)