### PR TITLE
release: promote 0.1.5-beta to stable 0.1.5

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <VersionPrefix>0.1.5</VersionPrefix>
-    <VersionSuffix>beta</VersionSuffix>
+    <VersionSuffix></VersionSuffix>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Target framework matrix -->

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,14 @@
+#### 0.1.5 May 16th 2026 ####
+
+Stable promotion of 0.1.5-beta. No code changes from the beta; this release
+drops the pre-release suffix now that the newline-as-statement-separator
+behavior change (SPEC §4) has been validated against Netclaw's live gate
+evaluator. Consumers on `0.1.5-beta` can upgrade directly.
+
+See the 0.1.5-beta notes below for the full list of changes in this version.
+
+---
+
 #### 0.1.5-beta May 15th 2026 ####
 
 Newline-as-statement-separator. Public API surface unchanged; the


### PR DESCRIPTION
## Summary

Promotes `0.1.5-beta` to stable `0.1.5`. Drops the `-beta` pre-release suffix in `Directory.Build.props`; no code changes from the beta.

The newline-as-statement-separator behavior change (SPEC §4, #34) and the `OpenSegment` refactor (#35) shipped in `0.1.5-beta` and have now been validated against Netclaw's live gate evaluator — this release marks them production-ready.

## Test plan

- [x] `dotnet build -c Release` — clean, 0 warnings
- [x] `dotnet test -c Release` — 429 tests pass
- [x] `pwsh ./scripts/Add-FileHeaders.ps1 -Verify` exits 0
- [x] `dotnet pack -c Release` produces `ShellSyntaxTree.0.1.5.nupkg`