### PR TITLE
chore: mark IMPLEMENTATION_PLAN phase 18 complete

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -265,7 +265,7 @@ bulldoze priorities.
 - [x] `Directory.Build.props` `VersionPrefix` 0.1.4 → 0.1.5,
       `VersionSuffix` → `beta`
 - [x] `RELEASE_NOTES.md` 0.1.5-beta section
-- [ ] Cut 0.1.5-beta tag once branch is merged; promote to stable
+- [x] Cut 0.1.5-beta tag once branch is merged; promote to stable
       0.1.5 after Netclaw validates the behavior change
 
 ---


### PR DESCRIPTION
## Summary

Flips the `IMPLEMENTATION_PLAN.md` phase 18 final checkbox to done — the `0.1.5-beta` tag was cut and promoted to stable `0.1.5` after Netclaw validated the newline-as-statement-separator behavior change against its live gate evaluator.

Docs-only; no code change.