### PR TITLE
Release 0.2.0-beta.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <VersionPrefix>0.2.0</VersionPrefix>
-    <VersionSuffix>alpha</VersionSuffix>
+    <VersionSuffix>beta.1</VersionSuffix>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Target framework matrix -->

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -64,7 +64,7 @@ priorities.
 - [x] Tag `0.2.0-alpha`; `publish_nuget.yml` produced
       `ShellSyntaxTree.0.2.0-alpha.nupkg` and it is live on nuget.org
       (released 2026-05-20).
-- [ ] `0.2.0-beta` so Netclaw validates the parser + the breaking rename
+- [x] `0.2.0-beta.1` so Netclaw validates the parser + the breaking rename
 - [ ] Promote to stable `0.2.0` after Netclaw validation
 
 ### 16. Netclaw v0.2.0 integration — SPEC.PWSH §17 #9

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,17 @@
+#### 0.2.0-beta.1 2026-07-22 ####
+
+## Fixed
+
+- **Preserved hyphenated PowerShell native options for safer parsing (#60)**
+  PowerShell native options now keep their full hyphenated form when present in
+  command text. Parameter forms like `-Native-Flag` and `-Native-Flag=value` now
+  stay correctly grouped instead of being split in ways that could confuse
+  downstream approvals. The parser also avoids over-reading ambiguous colon-value
+  combinations by marking those cases as `DynamicSkip` when the shape is unclear.
+  See [#60](https://github.com/Aaronontheweb/ShellSyntaxTree/issues/60) for
+  details.
+
+
 #### 0.2.0-alpha May 19th 2026 ####
 
 First **PowerShell** parser. ShellSyntaxTree now ships two `IShellParser`
@@ -393,4 +407,3 @@ SourceLink metadata.
 - `openspec/changes/` — change-proposal history with rationale for the
   eight v0.1 SPEC interpretations resolved during planning
 - `README.md` — quick-start usage
-


### PR DESCRIPTION
## Summary
- Update release notes with 0.2.0-beta.1 user-facing changes
- Mark 0.2.0-beta.1 done in IMPLEMENTATION_PLAN
- Move package prerelease suffix to beta.1 in Directory.Build.props
- Run release validation: dotnet tool restore, dotnet build/test, dotnet pack

## Validation
- dotnet tool restore
- dotnet build -c Release
- dotnet test -c Release
- dotnet pack -c Release -o ./bin/nuget