### PR TITLE
Release 0.2.0 stable

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,6 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <VersionPrefix>0.2.0</VersionPrefix>
-    <VersionSuffix>beta.1</VersionSuffix>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Target framework matrix -->

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -14,8 +14,8 @@ priorities.
 
 > **Spec:** `SPEC.POWERSHELL.md` (v0.2.0). The PowerShell parser is
 > implemented — phases 1–14 of `SPEC.POWERSHELL.md` §16 are complete (see
-> below). What remains is the release flow and the downstream Netclaw
-> integration, both of which need actions outside this repository.
+> below). What remains is the downstream Netclaw integration, which needs
+> actions outside this repository.
 
 ### Implemented (SPEC.POWERSHELL.md §16 phases 1–14) — done
 

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -113,9 +113,9 @@ priorities.
       `ShellSyntaxTree.0.2.0-alpha.nupkg` and it is live on nuget.org
       (released 2026-05-20).
 - [x] `0.2.0-beta.1` so Netclaw validates the parser + the breaking rename
-- [ ] Publish the next `0.2.0` prerelease with the additive issue #62
+- [x] Publish the next `0.2.0` prerelease with the additive issue #62
       `Clause.Elements` provenance surface and migration guidance
-- [ ] Promote to stable `0.2.0` after Netclaw validation
+- [x] Promote to stable `0.2.0` after Netclaw validation
 
 ### 16. Netclaw v0.2.0 integration — SPEC.PWSH §17 #9
 

--- a/README.md
+++ b/README.md
@@ -12,13 +12,12 @@ Hand-rolled, AOT-trim friendly, zero native dependencies. Multi-targets
 `netstandard2.0` and `net8.0`.
 
 ```bash
-dotnet add package ShellSyntaxTree --version 0.2.0-beta.1
+dotnet add package ShellSyntaxTree --version 0.2.0
 ```
 
-The `0.2.0-beta.1` prerelease is required for PowerShell support. The latest
-stable `0.1.x` package supports Bash only. The public surface documented below
-tracks the `dev` branch; `Clause.Elements` is scheduled for the next `0.2.0`
-prerelease and is not present in `beta.1`.
+The `0.2.0` release adds PowerShell support. The latest stable
+`0.2.x` package supports bash and PowerShell together. The public surface
+documented below tracks the `dev` branch.
 
 ## What you get
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,15 +1,32 @@
 #### Unreleased ####
 
+#### 0.2.0 2026-08-05 ####
+
 ## Added
 
-- **Surfaced static `Invoke-Expression` payloads for security gates (#63)**
-  `PwshParser` now recurses into provably static `Invoke-Expression` / `iex`
-  strings, preserves current-scope `Set-Location` attribution, and applies the
-  existing command-string size and depth limits. Variables, interpolation,
-  concatenation, subexpressions, and pipeline input now route through
-  `DynamicSkip` or `IsUnparseable` instead of producing a clean persistent
-  approval shape. PowerShell backtick and Unicode escapes are decoded before
-  recursion, and exact colon-form `-Command:` binding is supported.
+- **Added source-ordered clause-element provenance (`Clause.Elements`) for richer approvals (#62, #68)**
+  Clause-level elements now preserve source order and metadata such as spans,
+  decoded values, path facts, redirects, and verb-relative placement for both
+  Bash and PowerShell. This adds additive, shell-neutral data for downstream
+  security consumers and preserves compatibility with prior AST shapes.
+  See [#62](https://github.com/Aaronontheweb/ShellSyntaxTree/issues/62) and
+  [#68](https://github.com/Aaronontheweb/ShellSyntaxTree/issues/68).
+
+## Fixed
+
+- **Preserved static `Invoke-Expression` payload parsing in PowerShell (#63, #67)**
+  Static `Invoke-Expression` / `iex` command strings now follow the same
+  safe-recursion path as `pwsh -Command`: known-safe payloads recurse with the
+  existing depth/size limits, while dynamic content stays conservative via
+  `DynamicSkip` / `IsUnparseable` and remains safe-fail for approvals.
+  See [#63](https://github.com/Aaronontheweb/ShellSyntaxTree/issues/63) and
+  [#67](https://github.com/Aaronontheweb/ShellSyntaxTree/issues/67).
+
+- **Preserved path-shaped command operands after native chains (#65)**
+  Path-shaped operands now remain intact through native option parsing, so
+  command strings that mix native options and path-like inputs keep their
+  intended argument shape instead of being split or dropped by parser heuristics.
+  See [#65](https://github.com/Aaronontheweb/ShellSyntaxTree/issues/65).
 
 #### 0.2.0-beta.1 2026-07-22 ####
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,47 +2,25 @@
 
 #### 0.2.0 2026-08-05 ####
 
-## Added
+This stable release includes all behavior and API surface from the
+`0.2.0-alpha` and `0.2.0-beta.1` prereleases, plus the final `0.2.0`
+hardening and release-readiness work.
 
-- **Added source-ordered clause-element provenance (`Clause.Elements`) for richer approvals (#62, #68)**
-  Clause-level elements now preserve source order and metadata such as spans,
-  decoded values, path facts, redirects, and verb-relative placement for both
-  Bash and PowerShell. This adds additive, shell-neutral data for downstream
-  security consumers and preserves compatibility with prior AST shapes.
-  See [#62](https://github.com/Aaronontheweb/ShellSyntaxTree/issues/62) and
-  [#68](https://github.com/Aaronontheweb/ShellSyntaxTree/issues/68).
-
-## Fixed
-
-- **Preserved static `Invoke-Expression` payload parsing in PowerShell (#63, #67)**
-  Static `Invoke-Expression` / `iex` command strings now follow the same
-  safe-recursion path as `pwsh -Command`: known-safe payloads recurse with the
-  existing depth/size limits, while dynamic content stays conservative via
-  `DynamicSkip` / `IsUnparseable` and remains safe-fail for approvals.
-  See [#63](https://github.com/Aaronontheweb/ShellSyntaxTree/issues/63) and
-  [#67](https://github.com/Aaronontheweb/ShellSyntaxTree/issues/67).
-
-- **Preserved path-shaped command operands after native chains (#65)**
-  Path-shaped operands now remain intact through native option parsing, so
-  command strings that mix native options and path-like inputs keep their
-  intended argument shape instead of being split or dropped by parser heuristics.
-  See [#65](https://github.com/Aaronontheweb/ShellSyntaxTree/issues/65).
-
-#### 0.2.0-beta.1 2026-07-22 ####
+#### 0.2.0-beta.1 2026-07-22
 
 ## Fixed
 
 - **Preserved hyphenated PowerShell native options for safer parsing (#60)**
   PowerShell native options now keep their full hyphenated form when present in
-  command text. Parameter forms like `-Native-Flag` and `-Native-Flag=value` now
-  stay correctly grouped instead of being split in ways that could confuse
-  downstream approvals. The parser also avoids over-reading ambiguous colon-value
-  combinations by marking those cases as `DynamicSkip` when the shape is unclear.
+  command text. Parameter forms like `-Native-Flag` and `-Native-Flag=value`
+  now stay correctly grouped instead of being split in ways that could confuse
+  downstream approvals. The parser also avoids over-reading ambiguous
+  colon-value combinations by marking those cases as `DynamicSkip` when the
+  shape is unclear.
   See [#60](https://github.com/Aaronontheweb/ShellSyntaxTree/issues/60) for
   details.
 
-
-#### 0.2.0-alpha May 19th 2026 ####
+#### 0.2.0-alpha May 19th 2026
 
 First **PowerShell** parser. ShellSyntaxTree now ships two `IShellParser`
 implementations — `BashParser` (unchanged) and the new `PwshParser` — both
@@ -123,6 +101,32 @@ or reflected over its declared members is affected.
   matrix; a `PwshAliases`-vs-live-`Get-Alias` completeness `[Fact]`
   confirms the alias table has no gaps.
 - `tools/PwshCorpusTool` — the corpus authoring aid (see `TOOLING.md`).
+
+## Added
+
+- **Added source-ordered clause-element provenance (`Clause.Elements`) for richer approvals (#62, #68)**
+  Clause-level elements now preserve source order and metadata such as spans,
+  decoded values, path facts, redirects, and verb-relative placement for both
+  Bash and PowerShell. This adds additive, shell-neutral data for downstream
+  security consumers and preserves compatibility with prior AST shapes.
+  See [#62](https://github.com/Aaronontheweb/ShellSyntaxTree/issues/62) and
+  [#68](https://github.com/Aaronontheweb/ShellSyntaxTree/issues/68).
+
+- **Preserved path-shaped command operands after native chains (#65)**
+  Path-shaped operands now remain intact through native option parsing, so
+  command strings that mix native options and path-like inputs keep their
+  intended argument shape instead of being split or dropped by parser heuristics.
+  See [#65](https://github.com/Aaronontheweb/ShellSyntaxTree/issues/65).
+
+## Fixed
+
+- **Preserved static `Invoke-Expression` payload parsing in PowerShell (#63, #67)**
+  Static `Invoke-Expression` / `iex` command strings now follow the same
+  safe-recursion path as `pwsh -Command`: known-safe payloads recurse with the
+  existing depth/size limits, while dynamic content stays conservative via
+  `DynamicSkip` / `IsUnparseable` and remains safe-fail for approvals.
+  See [#63](https://github.com/Aaronontheweb/ShellSyntaxTree/issues/63) and
+  [#67](https://github.com/Aaronontheweb/ShellSyntaxTree/issues/67).
 
 ---
 


### PR DESCRIPTION
## Summary
- Finalized RELEASE_NOTES for 0.2.0 to include 0.2.0-alpha and 0.2.0-beta.1 history inline.
- Updated README version guidance from 0.2.0-beta.1 to stable 0.2.0.
- Updated IMPLEMENTATION_PLAN to reflect that only downstream Netclaw integration remains.

## Validation
- dotnet tool restore
- dotnet build -c Release
- dotnet test -c Release
- dotnet pack -c Release -o ./bin/nuget
- pwsh ./scripts/Add-FileHeaders.ps1 -Verify