### PR TITLE
docs: propose v0.3 structured shell analysis

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -10,7 +10,7 @@ priorities.
 
 ---
 
-## NOW (0.2.0 — PowerShell parser)
+## NOW (0.2.0 downstream acceptance / 0.3.0 contract design)
 
 > **Spec:** `SPEC.POWERSHELL.md` (v0.2.0). The PowerShell parser is
 > implemented — phases 1–14 of `SPEC.POWERSHELL.md` §16 are complete (see
@@ -124,6 +124,26 @@ priorities.
 - [ ] ≥1 Netclaw integration test exercises a real PowerShell corpus entry
       through the live matcher and gets the expected gate decision
 
+### 17. v0.3 structured shell analysis contract — issue #72
+
+- [x] Create the release-level OpenSpec proposal, design, capability deltas,
+      and ordered task list under
+      `openspec/changes/v0-3-structured-shell-analysis/`.
+- [x] Create [issue #72](https://github.com/Aaronontheweb/ShellSyntaxTree/issues/72)
+      as the v0.3 roadmap and cross-link issue #71 control flow and issue #69
+      shared native argument-fragment classification without merging their
+      scopes.
+- [ ] Complete OpenSpec task group 1: lock the additive public type names,
+      compatibility projection, fixed analysis bounds, and supported-construct
+      matrix before production implementation.
+- [ ] Implement [issue #69](https://github.com/Aaronontheweb/ShellSyntaxTree/issues/69)
+      as the first behavior-preserving preparation after contract lock.
+- [ ] Add the structural and command-occurrence projections for the existing
+      grammar before enabling any control-flow construct.
+- [ ] Deliver Bash `for ... in` and PowerShell `foreach` as the first two
+      language-specific vertical slices, then extract only the shared analysis
+      proven by both implementations.
+
 ---
 
 ## NEXT (0.1.x / 0.2.x — additive)
@@ -136,23 +156,20 @@ priorities.
 
 ## LATER (post-0.2.0)
 
-- v0.2.x candidates from `SPEC.POWERSHELL.md` §18 — lossless redirect-stream
-  identity (grow the `RedirectDirection` enum), per-element comma-array
-  path extraction (`-Path a,b,c`).
-- PowerShell script-level constructs — control flow, `function` / `class` /
-  `enum` definitions, `param()` / `begin` / `process` / `end` blocks,
-  `.ps1` file parsing (`SPEC.POWERSHELL.md` §18).
-- [Issue #69](https://github.com/Aaronontheweb/ShellSyntaxTree/issues/69) —
-  extract shared native argument-fragment classification before adding a third
-  shell or another fragment rule; keep shell tokenization and parsing local.
-- Extract a shared lexer/parser core now that two parsers exist — the seam
-  can be designed from real duplication (`SPEC.POWERSHELL.md` §18); the
-  path-normalization helpers duplicated between `BashResolver` and
-  `PwshResolver` are the first candidate.
+- The remaining v0.2.x candidate from `SPEC.POWERSHELL.md` §18 is per-element
+  comma-array path extraction (`-Path a,b,c`). Lossless cross-shell redirect
+  identity is now part of issue #72's explicit v0.3 redirect model.
+- PowerShell definitions, `param()` / `begin` / `process` / `end` blocks, and
+  `.ps1` file parsing remain outside issue #72 (`SPEC.POWERSHELL.md` §18).
+- Any broader shared parser/analysis extraction beyond issue #69 follows the
+  two language-specific tracer bullets in issue #72; lexers and structural
+  parsers remain shell-specific unless proven duplication justifies a narrower
+  composed helper.
 - Windows `cmd` parser.
 - Source-mapping (line/column on AST nodes) — only if an IDE consumer asks.
-- Heredoc body extraction, process substitution, bash function definitions
-  — only if a real consumer need surfaces.
+- Heredoc body preservation and process substitution are separately gated
+  issue #72 tasks backed by production need; Bash function definitions remain
+  deferred until a consumer need surfaces.
 
 ## Parked
 

--- a/openspec/changes/v0-3-structured-shell-analysis/.openspec.yaml
+++ b/openspec/changes/v0-3-structured-shell-analysis/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-06

--- a/openspec/changes/v0-3-structured-shell-analysis/design.md
+++ b/openspec/changes/v0-3-structured-shell-analysis/design.md
@@ -1,0 +1,800 @@
+## Context
+
+ShellSyntaxTree v0.2 parses Bash and PowerShell into a flat list of `Clause`
+records. The projection works for simple commands, pipelines, command lists,
+groups, and supported static command-string wrappers, but control-flow tokens
+are rejected because the public model cannot represent headers, nested bodies,
+branch alternatives, repeated execution, or state joins.
+
+Netclaw uses the parser as a security-gate input. It must account for every
+command that may execute and fail closed when command identity, path scope,
+redirect behavior, or another policy-sensitive value is unknown. Production
+evidence behind issue #71 shows that flat-grammar rejection causes material
+approval fatigue. The 0.25.3 redirect incident also shows why consumers must
+not infer shell semantics from `DynamicSkip` and raw token prefixes.
+
+The v0.2 public leaf records are already shipped. Version 0.3 may add public
+types and members deliberately, but it must preserve source facts, existing
+consumer projections, multi-targeting, AOT compatibility, and the rule that
+incomplete executable regions never become authorization evidence.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Represent supported nested command structure for Bash and PowerShell.
+- Expose every command that may execute without requiring consumers to walk an
+  evolving syntax-node hierarchy.
+- Resolve constrained loop values and shell state only when bounded proof is
+  possible.
+- Distinguish static redirect operations from dynamic redirect targets.
+- Preserve existing v0.2 command leaves and a conservative flat projection.
+- Deliver grammar support in corpus-driven vertical slices.
+- Share semantic machinery only where both shell implementations prove the
+  same abstraction.
+
+**Non-Goals:**
+
+- Execute commands, expand a filesystem glob, inspect the filesystem, or ask a
+  live shell to determine a value.
+- Embed executable-specific option, operand, object, or subcommand grammars.
+- Unify the Bash and PowerShell lexers or introduce a shared parser base class.
+- Treat Bash and PowerShell constructs as equivalent when their scoping,
+  expansion, pipeline, or expression semantics differ.
+- Make every construct named by issue #71 part of the first implementation
+  slice.
+- Classify URL-like arguments or environment assignments as harmless without
+  executable-aware consumer semantics.
+- Interpret heredoc bodies as commands merely because they contain text that
+  resembles shell syntax.
+
+## Decisions
+
+### Use three public layers with one compatibility projection
+
+`ParsedCommand` gains a canonical syntax root and a canonical may-execute
+projection while retaining `Clauses`:
+
+```text
+ParsedCommand
+├── Syntax       authored nested shell structure
+├── Commands     every command occurrence that may execute
+└── Clauses      conservative v0.2 compatibility projection
+```
+
+The syntax tree exists for structure, source display, and specialized
+analysis. `Commands` is the authorization entry point. `Clauses` remains for
+source and binary migration but is no longer the preferred traversal API.
+
+This separates three questions that a single recursive AST cannot answer
+safely for all consumers: what was authored, which commands may execute, and
+what an older consumer can observe.
+
+### Use a closed library-owned node family, not consumer-extensible nodes
+
+Public syntax nodes derive from one `ShellSyntaxNode` base. The base prevents
+external derivation so ShellSyntaxTree owns the complete node family. Common
+execution structure may use shell-neutral nodes such as blocks, simple
+commands, pipelines, command lists, groups, foreach-style loops, condition
+loops, and branches. A shell-specific public node is preferred whenever a
+shared type would erase material semantics.
+
+Consumers are not required to exhaustively match node types for authorization.
+They use `Commands`; a consumer that does inspect `Syntax` must fail closed or
+ignore only for non-authorization display when it encounters a type introduced
+after its package version.
+
+A single enum-tagged record was considered. It would force unrelated optional
+members onto every node and make invalid combinations representable. A public
+interface was also considered, but it would permit external implementations
+that the parser cannot produce or analyze. A library-owned record hierarchy is
+the closest practical C# approximation to an evolvable discriminated union.
+
+### Keep shell front ends separate and compose shared post-parse passes
+
+`BashLexer` and `PwshLexer` remain independent. Each shell receives its own
+recursive structural parser and adapts shell-owned syntax into the public node
+contract. Shared internal components operate only on proven common inputs:
+
+- native argument-fragment classification from issue #69;
+- source spans and opaque-region handling;
+- structural command-occurrence projection;
+- the value-domain lattice and bounded combination rules;
+- conservative state joins;
+- compatibility flattening;
+- path-normalization primitives whose semantics are identical.
+
+There is no shared parser base class. Inheritance would couple token
+consumption, error recovery, quoting, and expression boundaries that already
+differ between the two shells. Shared components are composed as explicit
+classifiers and analysis passes instead.
+
+### Represent simple commands with existing Clause leaves
+
+A simple-command syntax node wraps the same `Clause` value exposed through the
+occurrence and compatibility projections. Existing `VerbChain`, `Arg`,
+`Redirect`, and `ClauseElement` facts are not replaced.
+
+New structural nodes preserve their complete source range when it can be mapped
+exactly. Expanded wrapper content retains the current nullable-span rule rather
+than inventing offsets into escaped or encoded outer text.
+
+### Project authored command occurrences exactly once
+
+`Commands` contains one entry per authored simple command that may execute,
+not one entry per predicted runtime iteration. Each occurrence carries its
+`Clause`, structural role, ancestry suitable for diagnostics, and an explicit
+completeness fact. Roles include at least ordinary, pipeline stage, condition,
+iterator, loop body, branch, and substitution; the final names are locked with
+the public API review.
+
+Condition and iterator commands are never omitted. Mutually exclusive branch
+commands all appear because the collection is a may-execute set. Runtime loop
+counts do not duplicate occurrences; bounded variable domains describe the
+possible effective values at the occurrence.
+
+If any executable region cannot be discovered completely, the containing
+`ParsedCommand` remains `IsUnparseable=true`. Partial syntax and occurrences
+may be returned for diagnostics but MUST NOT be used to authorize execution.
+
+### Preserve Clauses as a conservative flattened view
+
+For a fully parseable result, `ParsedCommand.Clauses` contains every authored
+simple command occurrence in source order, including nested iterator,
+condition, branch, body, and substitution commands. It does not invent
+compound operators across structural boundaries. Existing `Clause.Operator`
+values are retained only for actual authored relationships.
+
+The compatibility clauses preserve authored arguments. They do not substitute
+loop variables into `Arg` and therefore retain dynamic markers that make
+v0.2-style security consumers prompt rather than silently authorize a broader
+scope. Proven effective values belong to the new occurrence analysis.
+
+### Use a small bounded value-domain lattice
+
+The analysis domain distinguishes:
+
+- `Exact`: one completely proved shell value;
+- `FiniteSet`: a bounded, fully enumerated set of values;
+- `Pattern`: a shell-specific symbolic pattern plus conservative covering
+  scope when one can be proved without enumeration;
+- `Unknown`: runtime-produced, mutated, indirectly expanded, unsupported, or
+  above the configured proof bound.
+
+The analysis never evaluates command substitutions or PowerShell pipelines.
+It exposes their commands, then treats the resulting value as unknown. It does
+not assume Bash glob options or PowerShell object-to-string conversion.
+Combinations that exceed the locked candidate cap collapse to `Unknown`.
+
+Initial loop-variable substitution is restricted to contexts whose quoting and
+shell rules prove the resulting argument boundary. Unquoted Bash expansion,
+PowerShell object-valued pipelines, indirect expansion, mutation, and
+cross-product explosion remain unknown until separately specified.
+
+Effective values are shell facts, not executable semantics. A consumer must
+re-run its executable-aware option grammar for every exact or finite candidate;
+for example, a loop value beginning with `-` may inject an option even if the
+authored `$variable` token was not option-shaped.
+
+### Join state rather than selecting a path
+
+The analysis carries abstract working-directory and supported variable state
+through the structure. Sequential lists propagate state. Subshell or
+scope-isolated groups do not leak state. Branches join their possible exit
+states; loops include the zero-iteration path unless shell semantics prove at
+least one iteration.
+
+The first implementation may collapse any differing cwd states to `Unknown`
+rather than publish a finite cwd set. Selecting one branch's directory is
+never allowed. A later additive version may expose bounded cwd alternatives if
+the consumer contract demonstrates a need.
+
+### Model redirect operation and target independently
+
+The new redirect facts separate:
+
+- source descriptor, when explicit;
+- operation: file input/output/append, descriptor duplicate, close, move,
+  combined output, heredoc/here-string where supported, or unknown;
+- static target descriptor, when present;
+- target value or value domain;
+- path relevance;
+- analysis completeness.
+
+`2>&1`, `2>&1-`, and `2>&-` are static operations. `2>&$FD` is a computed
+target and cannot be exempted merely because its raw value starts with `&`.
+The existing `RedirectDirection`, target text, and `IsDynamicSkip` properties
+remain compatibility facts during migration.
+
+Heredoc body representation is a separate design task. A heredoc body is data,
+not inherently a child command. Delimiter quoting, expansion mode, body source,
+and any executable substitutions must be preserved before a heredoc can be
+declared completely analyzable.
+
+### Deliver alternating vertical slices
+
+The implementation order is:
+
+1. Lock public types, compatibility behavior, completeness, and fixed bounds.
+2. Extract issue #69 and other behavior-preserving shared helpers.
+3. Produce `Syntax`, `Commands`, and unchanged `Clauses` for existing grammar.
+4. Validate the new consumer path on existing Netclaw cases.
+5. Add Bash `for ... in` with literal values first.
+6. Add PowerShell `foreach` with literal arrays next.
+7. Extract shared occurrence/value/state machinery proven by both slices.
+8. Add bounded patterns and iterator/substitution command discovery.
+9. Add condition loops and branches in separately testable shell-specific
+   slices.
+
+This order prevents a complete Bash implementation from hardening a
+Bash-shaped public abstraction before PowerShell exercises it.
+
+### Make the corpus an execution-accounting contract
+
+New corpus expectations cover syntax shape, compatibility clauses, command
+occurrences, roles, completeness, value domains, redirects, and joined state.
+Every supported input has adversarial pairs. The tests assert that every
+authored executable region appears exactly once and no parser path can return
+`IsUnparseable=false` after silently discarding an executable region.
+
+Both direct parser tests and Netclaw integration cases are required. The public
+corpus remains sanitized under the existing PII audit.
+
+## Risks / Trade-offs
+
+- **[Public hierarchy evolves after 0.3]** -> Consumers authorize through
+  `Commands`, not exhaustive syntax matching; new node types require new corpus
+  and compatibility tests.
+- **[Adding record properties changes generated behavior]** -> Document
+  equality, hashing, `ToString()`, and serialization changes and pin public API
+  snapshots before the first prerelease.
+- **[Compatibility flattening loses structure]** -> Preserve every command and
+  dynamic authored operand so old security consumers remain conservative;
+  direct new consumers to `Commands`.
+- **[Finite analysis is mistaken for shell execution]** -> Use explicit domain
+  kinds, fixed caps, no filesystem enumeration, and unknown fallback.
+- **[Shared abstractions erase language semantics]** -> Keep lexers and
+  structural parsers separate; extract only duplication demonstrated by both
+  working slices.
+- **[Partial trees invite partial authorization]** -> Keep
+  `IsUnparseable=true`, mark occurrences incomplete, and state that partial
+  results are diagnostic only.
+- **[Scope grows to every script construct]** -> Treat heredocs, process
+  substitution, background lists, C-style loops, arithmetic, definitions, and
+  `.ps1` files as separately gated slices.
+- **[Candidate combinations become expensive]** -> Apply a small fixed cap and
+  collapse the complete fact to `Unknown` before combinatorial growth.
+
+## Migration Plan
+
+1. Keep the Netclaw 0.25.4 static-descriptor workaround while it consumes
+   ShellSyntaxTree 0.2.
+2. Accept the OpenSpec and synchronize the locked API and grammar into
+   `SPEC.md`, `SPEC.POWERSHELL.md`, `PROJECT_CONTEXT.md`, and
+   `IMPLEMENTATION_PLAN.md`.
+3. Ship the new structural and occurrence API in a 0.3.0 alpha while all
+   existing grammar produces byte-for-byte equivalent compatibility facts.
+4. Migrate Netclaw to `Commands` and explicit redirect facts before enabling
+   supported control flow for authorization reuse.
+5. Add Bash and PowerShell vertical slices behind corpus and integration gates.
+6. Promote 0.3.0 only after both shells, old-consumer fail-closed behavior, and
+   the new Netclaw consumer path pass their acceptance matrices.
+
+Before stable 0.3.0, a flawed new surface can be revised with prerelease
+migration notes. After stable release, removals or renames follow the normal
+minor-version rule for this 0.x library. `Clauses` is not removed in 0.3.
+
+## Open Questions
+
+1. What are the exact public names and members for the syntax root, occurrence,
+   ancestry, value-domain, and redirect-detail types?
+2. What fixed candidate-count and nesting limits are small enough for security
+   review while useful for agent-authored loops?
+3. Should an occurrence refer to the identical `Clause` instance used by the
+   syntax leaf and compatibility projection, or only guarantee value equality?
+4. Which initial pattern facts can safely expose a covering directory when
+   Bash unmatched-glob options are unknown?
+5. Is any divergent cwd domain useful in v0.3, or should every disagreement
+   immediately become `Unknown`?
+6. Which heredoc forms, process substitutions, and background-list forms belong
+   in 0.3 rather than subsequent additive releases?
+
+## Appendix A: Non-Normative Candidate Public API
+
+The following sketches make the design review concrete. They are deliberately
+non-normative: task group 1 must reconcile names, default values, XML
+documentation, serialization behavior, and the exact member set with the five
+capability specifications before any public type is implemented.
+
+### Structural node family
+
+```csharp
+namespace ShellSyntaxTree;
+
+public abstract record ShellSyntaxNode
+{
+    // Prevent consumers from extending the parser-owned node family.
+    private protected ShellSyntaxNode() { }
+
+    public int? SourceStart { get; init; }
+    public int? SourceLength { get; init; }
+}
+
+public sealed record ShellBlockSyntax : ShellSyntaxNode
+{
+    public IReadOnlyList<ShellSyntaxNode> Statements { get; init; } = [];
+}
+
+public sealed record SimpleCommandSyntax : ShellSyntaxNode
+{
+    public Clause Clause { get; init; } = new();
+}
+
+public sealed record PipelineSyntax : ShellSyntaxNode
+{
+    public IReadOnlyList<ShellSyntaxNode> Stages { get; init; } = [];
+}
+
+public sealed record CommandListSyntax : ShellSyntaxNode
+{
+    public IReadOnlyList<CommandListItemSyntax> Items { get; init; } = [];
+}
+
+public sealed record CommandListItemSyntax
+{
+    public CompoundOperator Operator { get; init; }
+    public ShellSyntaxNode Command { get; init; } = new ShellBlockSyntax();
+}
+
+public sealed record GroupSyntax : ShellSyntaxNode
+{
+    public ShellGroupKind Kind { get; init; }
+    public ShellBlockSyntax Body { get; init; } = new();
+}
+
+public sealed record ForEachSyntax : ShellSyntaxNode
+{
+    public LoopBindingSyntax Binding { get; init; } = new();
+    public ShellValueExpressionSyntax Iterable { get; init; } = new();
+    public ShellBlockSyntax IteratorCommands { get; init; } = new();
+    public ShellBlockSyntax Body { get; init; } = new();
+}
+
+public sealed record ConditionLoopSyntax : ShellSyntaxNode
+{
+    public ConditionLoopKind Kind { get; init; }
+    public ShellBlockSyntax Condition { get; init; } = new();
+    public ShellBlockSyntax Body { get; init; } = new();
+}
+
+public sealed record ConditionalSyntax : ShellSyntaxNode
+{
+    public ShellBlockSyntax Condition { get; init; } = new();
+    public ShellBlockSyntax Then { get; init; } = new();
+    public IReadOnlyList<ConditionalBranchSyntax> ElseIf { get; init; } = [];
+    public ShellBlockSyntax? Else { get; init; }
+}
+```
+
+`ForEachSyntax` is shown as a shared execution-structure node, not a claim that
+Bash words and PowerShell expressions share a grammar. If the contract review
+shows that their iterable or binding facts cannot coexist without optional
+members or semantic ambiguity, the public family should instead use
+`BashForEachSyntax` and `PwshForEachSyntax` derived from a smaller common loop
+base.
+
+The same rule applies to `ConditionalSyntax`: share the shape only when the
+public fields preserve every material shell distinction. Internal parse nodes
+remain shell-specific regardless of the eventual public choice.
+
+### Command occurrence and bounded values
+
+```csharp
+public sealed record CommandOccurrence
+{
+    public Clause Clause { get; init; } = new();
+    public CommandOccurrenceRole Role { get; init; }
+    public IReadOnlyList<CommandAncestryFrame> Ancestry { get; init; } = [];
+    public IReadOnlyList<EffectiveArgument> EffectiveArguments { get; init; } = [];
+    public ShellValueDomain WorkingDirectory { get; init; } = ShellValueDomain.Unknown;
+    public IReadOnlyList<RedirectAnalysis> Redirects { get; init; } = [];
+    public bool IsComplete { get; init; }
+}
+
+public enum CommandOccurrenceRole
+{
+    Ordinary,
+    PipelineStage,
+    Condition,
+    Iterator,
+    LoopBody,
+    Branch,
+    Substitution,
+}
+
+public sealed record EffectiveArgument
+{
+    // A stable authored coordinate is safer than correlating by string value.
+    public int ClauseElementIndex { get; init; }
+    public ShellValueDomain Value { get; init; } = ShellValueDomain.Unknown;
+}
+
+public sealed record ShellValueDomain
+{
+    public static ShellValueDomain Unknown { get; } = new();
+
+    public ShellValueDomainKind Kind { get; init; }
+    public IReadOnlyList<string> Values { get; init; } = [];
+    public string? Pattern { get; init; }
+    public string? CoveringDirectory { get; init; }
+}
+
+public enum ShellValueDomainKind
+{
+    Unknown,
+    Exact,
+    FiniteSet,
+    Pattern,
+}
+```
+
+The candidate uses a source-authored element coordinate rather than attaching
+derived values directly to `Arg`. This prevents a loop iteration from mutating
+the compatibility leaf and provides a place for one authored token to have
+multiple possible effective values. Contract review must still account for
+redirect operands, inline option bindings, shell expansions that create more
+than one argument, and occurrences that do not have an exact outer source span.
+
+### Explicit redirect facts
+
+```csharp
+public sealed record RedirectAnalysis
+{
+    public int RedirectIndex { get; init; }
+    public int? SourceDescriptor { get; init; }
+    public RedirectOperation Operation { get; init; }
+    public int? TargetDescriptor { get; init; }
+    public ShellValueDomain Target { get; init; } = ShellValueDomain.Unknown;
+    public bool IsPathRelevant { get; init; }
+    public bool IsComplete { get; init; }
+}
+
+public enum RedirectOperation
+{
+    Unknown,
+    FileInput,
+    FileOutput,
+    FileAppend,
+    DescriptorDuplicate,
+    DescriptorClose,
+    DescriptorMove,
+    CombinedOutput,
+    CombinedOutputAppend,
+    HereDocument,
+    HereString,
+}
+```
+
+This sketch places occurrence-specific redirect analysis on
+`CommandOccurrence` and leaves the existing `Redirect` record untouched. An
+alternative is an additive `Redirect.Analysis` property. The contract review
+should prefer the shape that avoids duplicated facts while preserving v0.2
+equality and serialization expectations as far as an additive record change
+allows.
+
+### ParsedCommand composition and consumer entry point
+
+```csharp
+public sealed record ParsedCommand
+{
+    public string Source { get; init; } = "";
+
+    public ShellBlockSyntax Syntax { get; init; } = new();
+    public IReadOnlyList<CommandOccurrence> Commands { get; init; } = [];
+
+    // v0.2 compatibility projection; not canonical for structured analysis.
+    public IReadOnlyList<Clause> Clauses { get; init; } = [];
+
+    public bool IsUnparseable { get; init; }
+    public string? UnparseableReason { get; init; }
+}
+```
+
+The intended security-consumer shape is therefore:
+
+```csharp
+var parsed = parser.Parse(source);
+if (parsed.IsUnparseable || parsed.Commands.Count == 0)
+{
+    return Prompt(parsed.UnparseableReason ?? "no complete command occurrences");
+}
+
+foreach (var occurrence in parsed.Commands)
+{
+    if (!occurrence.IsComplete || occurrence.Clause.Verb.IsDynamic)
+    {
+        return Prompt("command execution is not statically bounded");
+    }
+
+    var interpreted = executableGrammar.Interpret(occurrence);
+    if (!interpreted.IsComplete)
+    {
+        return Prompt("executable arguments are ambiguous");
+    }
+
+    EvaluateEveryCandidate(interpreted);
+}
+```
+
+## Appendix B: Non-Normative Grammar and Parser Mocks
+
+These sketches show how the existing flat parsers can evolve. They are not a
+replacement for the normative BNF that task group 1 adds to `SPEC.md` and
+`SPEC.POWERSHELL.md`.
+
+### Shared structural vocabulary, not a shared grammar
+
+The two front ends can target a similar internal structural vocabulary:
+
+```text
+block            := ordered structural statements
+statement        := simple_command
+                  | pipeline
+                  | command_list
+                  | group
+                  | foreach_loop
+                  | condition_loop
+                  | conditional
+```
+
+This vocabulary describes output relationships only. Each shell defines its
+own token boundaries, contextual keywords, expression forms, terminators,
+scope, and recovery rules.
+
+### Candidate Bash grammar delta
+
+The initial Bash slice extends the current `command := clause
+(compound_op clause)*` grammar into recursive command lists. Only contextual
+keywords in command position participate; `echo for` continues to parse `for`
+as an argument.
+
+```text
+bash_script(stop)    := bash_list_item (list_sep bash_list_item)*
+bash_list_item       := bash_and_or
+bash_and_or          := bash_pipeline (("&&" | "||") bash_pipeline)*
+bash_pipeline        := bash_command ("|" bash_command)*
+bash_command         := bash_for_in
+                      | bash_group
+                      | bash_subshell
+                      | bash_c_wrapper
+                      | bash_simple_command
+
+// Initial v0.3 tracer bullet: explicit `in` form only.
+bash_for_in          := "for" binding_name "in" iterable_word*
+                        list_terminator "do"
+                        bash_script(stop = "done")
+                        "done"
+
+list_sep             := ";" | NEWLINE
+list_terminator      := ";" | NEWLINE+
+binding_name         := shell_identifier
+iterable_word        := word | quoted_string | supported_substitution
+```
+
+Later Bash deltas add `while` / `until`, `if` / `elif` / `else`, and `case`
+using explicit stop-keyword sets. C-style `for ((...))`, implicit `for name`
+iteration over positional parameters, arithmetic expansion, and substitutions
+whose inner commands cannot be discovered remain rejected until separately
+specified.
+
+The current Bash lexer already emits `for`, `in`, `do`, and `done` as `Word`
+tokens. The first slice therefore does not require dedicated keyword token
+kinds. The structural parser interprets them contextually and preserves the
+existing lexer values and spans.
+
+### Candidate Bash recursive-descent flow
+
+```csharp
+internal sealed class BashStructuralParser
+{
+    private readonly BashTokenCursor _tokens;
+    private readonly string _source;
+
+    internal BashNode ParseRoot() => ParseList(BashStopSet.EndOfInput);
+
+    private BashBlockNode ParseList(BashStopSet stop)
+    {
+        var statements = new List<BashNode>();
+        while (!_tokens.AtEnd && !stop.Matches(_tokens))
+        {
+            statements.Add(ParseAndOr());
+            ConsumeListSeparatorOrStop(stop);
+        }
+
+        return new BashBlockNode(statements, SpanFrom(statements));
+    }
+
+    private BashNode ParseCommand()
+    {
+        if (_tokens.AtCommandPositionWord("for"))
+        {
+            return ParseForIn();
+        }
+
+        if (_tokens.AtOperator("("))
+        {
+            return ParseSubshell();
+        }
+
+        return ParseExistingSimpleCommand();
+    }
+
+    private BashForInNode ParseForIn()
+    {
+        var start = _tokens.ExpectWord("for");
+        var binding = _tokens.ExpectIdentifier();
+        _tokens.ExpectWord("in");
+        var iterable = ParseWordsUntilListTerminator();
+        ConsumeListTerminator();
+        _tokens.ExpectWord("do");
+        var body = ParseList(BashStopSet.Word("done"));
+        var end = _tokens.ExpectWord("done");
+        return new BashForInNode(binding, iterable, body, Span(start, end));
+    }
+}
+```
+
+`ParseExistingSimpleCommand` is an adapter around today's segment and
+`ParseClauseSegment` machinery. The structural parser replaces the current
+whole-stream top-level split; it does not replace verb extraction, native
+argument classification, redirects, resolver behavior, provenance, or wrapper
+recursion inside a simple-command leaf.
+
+All `Expect*` failures return one outer unparseable result. They do not skip to
+`done` and return a partial tree that could be mistaken for authorization
+evidence.
+
+### Candidate PowerShell grammar delta
+
+PowerShell retains its statement-versus-pipeline distinction and contextual
+keyword rules. In particular, `foreach` is a language keyword only at a
+statement position when followed by `(`; `Get-ChildItem | foreach { ... }`
+continues to treat `foreach` as command or alias syntax.
+
+```text
+pwsh_script(stop)    := pwsh_statement (statement_sep pwsh_statement)*
+pwsh_statement       := pwsh_foreach
+                      | pwsh_pipeline
+
+pwsh_foreach         := "foreach" "(" variable "in" foreach_expression ")"
+                        script_block_body
+
+// Initial v0.3 tracer bullet only.
+foreach_expression   := literal_value
+                      | literal_array
+                      | pipeline_expression
+literal_array        := "@(" literal_value ("," literal_value)* ")"
+script_block_body    := "{" pwsh_script(stop = "}") "}"
+```
+
+`pipeline_expression` is structurally parsed so its commands become iterator
+occurrences, but its produced object values are `Unknown`. The initial exact or
+finite domain is limited to literal scalar and array elements whose PowerShell
+conversion and argument boundaries are completely specified.
+
+The current PowerShell lexer emits a balanced `{ ... }` as one `ScriptBlock`
+token. The first slice can preserve that behavior for ordinary command
+arguments while recursively tokenizing the interior only after the structural
+parser has proved that the token is the body of a recognized statement. The
+recursive call carries the body's absolute source offset so direct-source
+child spans still index `ParsedCommand.Source`.
+
+### Candidate PowerShell recursive-descent flow
+
+```csharp
+internal sealed class PwshStructuralParser
+{
+    private readonly PwshTokenCursor _tokens;
+
+    private PwshNode ParseStatement()
+    {
+        if (_tokens.AtStatementKeywordFollowedBy("foreach", "("))
+        {
+            return ParseForeach();
+        }
+
+        return ParseExistingPipeline();
+    }
+
+    private PwshForEachNode ParseForeach()
+    {
+        var start = _tokens.ExpectWord("foreach");
+        _tokens.ExpectOperator("(");
+        var binding = _tokens.ExpectVariable();
+        _tokens.ExpectWord("in");
+        var iterable = ParseForeachExpressionUntilMatchingParen();
+        _tokens.ExpectOperator(")");
+
+        var bodyToken = _tokens.Expect(PwshTokenKind.ScriptBlock);
+        var body = ParseScriptBlockInterior(
+            bodyToken,
+            absoluteOffset: bodyToken.SourceStart + 1);
+
+        return new PwshForEachNode(
+            binding, iterable, body, Span(start, bodyToken));
+    }
+}
+```
+
+`ParseExistingPipeline` adapts the current `SplitIntoSegments` and
+`BuildSegment` logic. A `ScriptBlock` token remains an opaque `DynamicSkip`
+argument everywhere the enclosing grammar does not explicitly own that block
+as a statement body. This avoids accidentally executing or authorizing the
+contents of `ForEach-Object { ... }`, arbitrary script-block arguments, or a
+dynamic call operator.
+
+### Candidate internal nodes and lowering pipeline
+
+The internal tree may retain shell-specific syntax even if the reviewed public
+tree shares a smaller set of structural records:
+
+```csharp
+internal abstract record BashNode(SourceRange Range);
+internal sealed record BashBlockNode(
+    IReadOnlyList<BashNode> Statements,
+    SourceRange Range) : BashNode(Range);
+internal sealed record BashSimpleCommandNode(
+    Clause Clause,
+    SourceRange Range) : BashNode(Range);
+internal sealed record BashForInNode(
+    BashBinding Binding,
+    IReadOnlyList<BashWordExpression> Iterable,
+    BashBlockNode Body,
+    SourceRange Range) : BashNode(Range);
+
+internal abstract record PwshNode(SourceRange Range);
+internal sealed record PwshForEachNode(
+    PwshBinding Binding,
+    PwshExpression Iterable,
+    PwshBlockNode Body,
+    SourceRange Range) : PwshNode(Range);
+```
+
+The proposed data flow is:
+
+```text
+shell-specific lexer
+        ↓
+shell-specific recursive structural parser
+        ↓
+shell-specific internal syntax tree
+        ↓
+public syntax lowering
+        ↓
+complete authored command-occurrence projection
+        ↓
+bounded shell-value and state analysis
+        ↓
+occurrences enriched with effective facts
+        ↓
+conservative v0.2 Clauses compatibility projection
+```
+
+The occurrence projector and compatibility flattener consume structure; they
+do not re-tokenize `ParsedCommand.Source`. The bounded analyzer consumes
+shell-specific expression adapters and a shared value-domain/state-join
+lattice. Executable-aware interpretation still occurs only in the consumer.
+
+### Parser failure matrix
+
+| Input condition | Structural result | Authorization-facing result |
+|---|---|---|
+| Missing Bash `do` or `done` | Parse failure with the offending range | `IsUnparseable=true`; partial nodes diagnostic only |
+| Bash keyword used as an argument | Existing simple-command leaf | No false control-flow node |
+| Unsupported Bash substitution in an iterable | Inner commands surfaced only if completely parsed | Otherwise the entire result is unparseable |
+| PowerShell `foreach` at statement position followed by `(` | `PwshForEachNode` | Iterator and body occurrences exposed |
+| PowerShell `foreach` in a pipeline command slot | Existing pipeline/simple-command path | Alias or command semantics preserved |
+| PowerShell statement body `ScriptBlock` | Interior recursively parsed with adjusted spans | Every body command exposed |
+| PowerShell script block used as an ordinary argument | Existing opaque argument | `DynamicSkip`; contents are not invented as executed commands |
+| Candidate cap or state-join overflow | Structure remains parseable | Affected effective fact becomes `Unknown` |
+| Any executable region is skipped or cannot be delimited | Partial diagnostic tree allowed | `IsUnparseable=true`; no authorization from the subset |

--- a/openspec/changes/v0-3-structured-shell-analysis/proposal.md
+++ b/openspec/changes/v0-3-structured-shell-analysis/proposal.md
@@ -35,9 +35,9 @@ fail-closed behavior for incomplete analysis.
   by explicit executable-region and value-semantics requirements.
 - Keep executable-specific option and operand interpretation, authorization
   policy, and durable approval scope consumer-owned.
-- Update the consumer contract so security gates authorize the complete
-  command-occurrence projection and use the syntax tree only for structure,
-  display, and specialized analysis.
+- Update `docs/CONSUMER_GUIDE.md` and the README usage path so security gates
+  authorize the complete command-occurrence projection and use the syntax tree
+  only for structure, display, and specialized analysis.
 
 ## Capabilities
 

--- a/openspec/changes/v0-3-structured-shell-analysis/proposal.md
+++ b/openspec/changes/v0-3-structured-shell-analysis/proposal.md
@@ -1,0 +1,76 @@
+## Why
+
+ShellSyntaxTree's flat `ParsedCommand.Clauses` projection cannot represent
+control flow, nested executable regions, bounded loop variables, or divergent
+shell state without either omitting commands or marking useful static syntax
+unparseable. Production approval data also shows that overloaded
+`DynamicSkip` and redirect facts force consumers to reconstruct shell grammar,
+causing avoidable prompts and unsafe opportunities for inconsistent inference.
+
+Version 0.3 should add a structured, security-oriented model that identifies
+every command that may execute while preserving the v0.2 leaf records and
+fail-closed behavior for incomplete analysis.
+
+## What Changes
+
+- Add a strongly typed syntax-node hierarchy above the existing `Clause` leaf
+  model, with shell-specific front ends producing one shared structural
+  contract where their semantics actually coincide.
+- Add a library-owned command-occurrence projection containing every command
+  that may execute, including condition, iterator, branch, loop-body, wrapped,
+  and substitution commands.
+- Add conservative value and shell-state analysis that distinguishes exact,
+  finite, bounded-symbolic, and unknown facts without executing commands or
+  enumerating the filesystem.
+- Add explicit redirect operation and target facts so consumers do not infer
+  descriptor duplication, close, move, combined output, or dynamic targets
+  from raw strings and `DynamicSkip` alone.
+- Preserve `Clause`, `Arg`, `Redirect`, `ClauseElement`, `VerbChain`, and
+  `ParsedCommand.Clauses` as compatibility projections. Existing consumers
+  that check `IsUnparseable` continue to fail closed and do not silently miss
+  nested executable commands.
+- Expand grammar in vertical slices: Bash `for ... in`, PowerShell `foreach`,
+  then condition loops and branches. Heredocs, process substitution,
+  background lists, C-style loops, and arithmetic remain independently gated
+  by explicit executable-region and value-semantics requirements.
+- Keep executable-specific option and operand interpretation, authorization
+  policy, and durable approval scope consumer-owned.
+- Update the consumer contract so security gates authorize the complete
+  command-occurrence projection and use the syntax tree only for structure,
+  display, and specialized analysis.
+
+## Capabilities
+
+### New Capabilities
+
+- `structured-shell-syntax`: Represent nested Bash and PowerShell command
+  structure with typed nodes while retaining existing simple-command leaves.
+- `executable-command-projection`: Expose every authored command occurrence
+  that may execute, with structural role, ancestry, and completeness facts.
+- `bounded-shell-analysis`: Derive exact, finite, bounded-symbolic, or unknown
+  values and conservatively join working-directory and variable state.
+- `explicit-redirect-semantics`: Distinguish file redirects, descriptor
+  duplication, close, move, combined output, and computed targets directly.
+- `consumer-compatibility`: Define the conservative `Clauses` projection,
+  migration rules, unknown-case behavior, and authorization-consumer contract.
+
+### Modified Capabilities
+
+None. This repository has not yet synchronized its shipped v0.2 contracts
+into `openspec/specs/`; accepted deltas from this change will be reconciled
+into `SPEC.md` and `SPEC.POWERSHELL.md` before implementation.
+
+## Impact
+
+This is an additive but release-shaped public API change affecting
+`ParsedCommand`, new syntax and analysis records, redirect modeling, both
+shell parsers, corpus schemas, public API snapshots, the shared and
+PowerShell specifications, and `docs/CONSUMER_GUIDE.md`. Adding properties to
+public records also changes generated equality, hashing, `ToString()`, and
+default serialization and therefore requires explicit migration notes.
+
+Netclaw is the validating consumer. Its 0.25.4 redirect workaround remains the
+short-term containment; a v0.3 integration must switch authorization traversal
+to the command-occurrence projection and retain strict or prompt behavior for
+unknown executable shapes. No native dependency or command execution is
+introduced.

--- a/openspec/changes/v0-3-structured-shell-analysis/specs/bounded-shell-analysis/spec.md
+++ b/openspec/changes/v0-3-structured-shell-analysis/specs/bounded-shell-analysis/spec.md
@@ -1,0 +1,98 @@
+## ADDED Requirements
+
+### Requirement: Shell values use explicit proof domains
+The analysis SHALL classify a policy-relevant shell value as exact, finite,
+bounded symbolic pattern, or unknown, and SHALL NOT present a weaker proof as a
+stronger domain.
+
+#### Scenario: One literal value
+- **WHEN** a loop binds a variable from the single literal `a.txt`
+- **THEN** the binding domain is exact with value `a.txt`
+
+#### Scenario: Finite literal values
+- **WHEN** Bash parses `for f in a.txt b.txt; do rm -- "$f"; done`
+- **THEN** the binding domain is the finite set `a.txt`, `b.txt`
+
+#### Scenario: Runtime-produced values
+- **WHEN** a loop iterable is produced by a command or PowerShell object pipeline
+- **THEN** the binding domain is unknown even though the producing commands are exposed
+
+### Requirement: Analysis is bounded and non-executing
+The parser SHALL NOT execute commands, enumerate filesystem matches, inspect
+runtime shell variables, or expand candidate combinations beyond a fixed
+documented bound. Any value exceeding the bound SHALL become unknown.
+
+#### Scenario: Glob is not enumerated
+- **WHEN** Bash parses `for f in /tmp/*.txt; do rm -- "$f"; done`
+- **THEN** the parser does not read `/tmp`
+- **THEN** it may expose a pattern with conservative covering directory `/tmp`
+
+#### Scenario: Candidate cross product exceeds the limit
+- **WHEN** combining finite values would exceed the locked candidate cap
+- **THEN** the resulting domain is unknown
+- **THEN** the parser does not truncate the set and call the truncated result complete
+
+### Requirement: Variable substitution preserves argument-boundary uncertainty
+A loop binding SHALL affect an effective command value only when the selected
+shell's quoting and expansion rules prove the resulting argument boundaries.
+
+#### Scenario: Quoted Bash variable
+- **WHEN** `f` has finite literal values and a body argument is exactly `"$f"`
+- **THEN** the effective argument has the corresponding finite domain
+
+#### Scenario: Unquoted Bash variable
+- **WHEN** a Bash body uses `$f` unquoted and word splitting or glob expansion could change argument count
+- **THEN** the effective argument is unknown until those semantics are explicitly supported
+
+#### Scenario: PowerShell object value
+- **WHEN** a PowerShell `foreach` variable may hold objects emitted by a pipeline
+- **THEN** its effective string or path value is unknown
+
+### Requirement: Executable semantics are reapplied after substitution
+ShellSyntaxTree SHALL preserve effective candidate values without claiming
+whether they are options, operands, subcommands, revisions, or paths for a
+particular executable. Consumers SHALL interpret every candidate through a
+complete executable-aware grammar before reusing authorization.
+
+#### Scenario: Finite value injects an rm option
+- **WHEN** Bash parses `for f in -rf /tmp/x; do rm "$f"; done`
+- **THEN** the finite domain preserves `-rf` and `/tmp/x`
+- **THEN** the parser does not claim that quoting makes `-rf` a non-option
+
+#### Scenario: Explicit option terminator
+- **WHEN** Bash parses `for f in -rf /tmp/x; do rm -- "$f"; done`
+- **THEN** the authored `--` remains visible before the effective candidate
+- **THEN** the consumer may account for it using rm semantics
+
+### Requirement: Control-flow state joins conservatively
+Working-directory and supported variable state SHALL be propagated through
+sequential regions and joined across branches and loop exits. Disagreement
+SHALL never be resolved by arbitrarily choosing one path.
+
+#### Scenario: Branch-dependent cwd
+- **WHEN** one branch changes cwd to `/a` and another changes cwd to `/b`
+- **THEN** a following relative path is not resolved solely under `/a` or solely under `/b`
+- **THEN** the cwd is unknown unless a bounded multi-state contract is explicitly supported
+
+#### Scenario: Zero-iteration loop path
+- **WHEN** a loop may execute zero times and its body changes cwd
+- **THEN** the post-loop state includes the pre-loop possibility
+
+#### Scenario: Isolated shell scope
+- **WHEN** a supported subshell or scope-isolated group changes cwd
+- **THEN** that cwd does not leak into the enclosing continuation
+
+### Requirement: Unknown analysis remains policy-sensitive
+An unknown value SHALL identify the occurrence and position it affects so a
+consumer can determine whether command identity, option parsing, path scope,
+redirect behavior, or another policy-sensitive fact requires prompt or deny.
+
+#### Scenario: Unknown rm path
+- **WHEN** a runtime-produced loop variable is used as the path operand of `rm`
+- **THEN** the occurrence exposes that operand as unknown
+- **THEN** no durable path approval is synthesized from its raw spelling
+
+#### Scenario: Unknown echo data
+- **WHEN** an unknown value is passed as ordinary data to `echo`
+- **THEN** the parser still reports the unknown fact
+- **THEN** the consumer, not the parser, decides whether that position affects its policy

--- a/openspec/changes/v0-3-structured-shell-analysis/specs/consumer-compatibility/spec.md
+++ b/openspec/changes/v0-3-structured-shell-analysis/specs/consumer-compatibility/spec.md
@@ -1,0 +1,81 @@
+## ADDED Requirements
+
+### Requirement: Existing Clause projection remains conservative
+`ParsedCommand.Clauses` SHALL remain available in v0.3 and SHALL contain every
+authored simple command that may execute for a fully parseable result, including
+nested condition, iterator, branch, body, and substitution commands.
+
+#### Scenario: Old consumer sees loop body command
+- **WHEN** Bash fully parses `for f in a b; do rm "$f"; done`
+- **THEN** the compatibility clauses include the authored `rm` command
+- **THEN** its authored variable argument remains conservatively dynamic rather than being silently replaced
+
+#### Scenario: Structural boundaries do not invent operators
+- **WHEN** clauses are flattened from separate control-flow regions
+- **THEN** `Clause.Operator` represents only an actual authored operator relationship
+- **THEN** no synthetic `Sequence`, `AndIf`, `OrIf`, or `Pipe` relationship is invented
+
+### Requirement: Unparseable results are never authorization evidence
+All syntax, occurrence, clause, value, and redirect facts SHALL be treated as
+partial diagnostic evidence when `ParsedCommand.IsUnparseable=true`. The
+consumer guide SHALL require prompt or deny before evaluating them for allow.
+
+#### Scenario: Partial body discovered before unsupported syntax
+- **WHEN** the parser discovers a command in a body but later encounters an unsupported executable region
+- **THEN** the result remains unparseable
+- **THEN** a consumer does not authorize from the discovered subset
+
+### Requirement: Security consumers authorize command occurrences
+The consumer guide SHALL direct v0.3 security consumers to evaluate every
+command occurrence, including conditions and iterators, and SHALL NOT require
+recursive syntax traversal to discover executable commands.
+
+#### Scenario: All loop regions are evaluated
+- **WHEN** a parsed loop exposes iterator and body occurrences
+- **THEN** the example authorization algorithm evaluates both
+- **THEN** it does not grant scope to the loop keyword itself
+
+#### Scenario: Syntax remains useful for explanation
+- **WHEN** a UI groups approvals by loop or branch
+- **THEN** it may use syntax ancestry for display
+- **THEN** authorization still uses the complete occurrence collection
+
+### Requirement: Unknown facts fail closed when policy-sensitive
+The consumer guide SHALL require strict matching, prompt, or deny whenever an
+unknown fact can affect command identity, option interpretation, path scope,
+redirect behavior, effective cwd, or another consumer-defined sensitive
+position.
+
+#### Scenario: Unknown executable operand
+- **WHEN** an executable-aware interpreter cannot completely consume effective operands
+- **THEN** the consumer falls back to strict matching or prompts
+- **THEN** it does not discard the unknown operand to reuse a broader approval
+
+#### Scenario: Unknown node or enum member
+- **WHEN** a consumer encounters a syntax, role, domain, or redirect kind it does not recognize
+- **THEN** it fails closed for authorization
+
+### Requirement: Proven candidates are interpreted individually
+For every exact or finite effective value, the consumer guide SHALL require
+the consumer to reapply executable-specific option and operand semantics. A
+finite shell proof SHALL NOT itself grant authorization.
+
+#### Scenario: Loop candidate changes option parsing
+- **WHEN** one effective candidate begins with `-`
+- **THEN** the consumer evaluates that candidate at its actual authored position
+- **THEN** it does not rely solely on the original argument's `IsFlag` value
+
+### Requirement: v0.2 consumers have a documented migration path
+Release notes and the consumer guide SHALL document the new canonical
+projections, retained compatibility fields, record equality and serialization
+effects, and the period during which `Clauses` remains supported.
+
+#### Scenario: Consumer remains on Clauses during alpha
+- **WHEN** a consumer upgrades to a v0.3 prerelease without adopting `Commands`
+- **THEN** existing simple-command behavior remains available
+- **THEN** supported nested constructs expose conservative authored clauses rather than omitting commands
+
+#### Scenario: Netclaw adopts v0.3 analysis
+- **WHEN** Netclaw migrates to the occurrence and explicit redirect APIs
+- **THEN** integration tests cover ordinary commands, static fd operations, bounded loops, and unknown-value fallback
+- **THEN** its temporary raw-prefix redirect workaround can be removed

--- a/openspec/changes/v0-3-structured-shell-analysis/specs/executable-command-projection/spec.md
+++ b/openspec/changes/v0-3-structured-shell-analysis/specs/executable-command-projection/spec.md
@@ -1,0 +1,82 @@
+## ADDED Requirements
+
+### Requirement: Parsed commands expose a complete may-execute set
+Every fully parseable result SHALL expose a command-occurrence collection that
+contains each authored simple command that may execute exactly once, regardless
+of whether the command is top-level or nested.
+
+#### Scenario: Commands in mutually exclusive branches
+- **WHEN** Bash parses `if test -f a; then rm a; else echo missing; fi`
+- **THEN** the collection contains `test`, `rm`, and `echo` exactly once each
+- **THEN** the collection does not predict which branch will run
+
+#### Scenario: Loop body occurrence is not multiplied
+- **WHEN** Bash parses `for f in a b c; do echo "$f"; done`
+- **THEN** the authored `echo` command appears once
+- **THEN** its possible effective values are represented by analysis facts rather than three duplicated occurrences
+
+### Requirement: Occurrences identify structural execution roles
+Each command occurrence SHALL identify the structural role by which it may
+execute and SHALL retain enough ancestry for diagnostics and UI grouping.
+
+#### Scenario: While condition and body roles
+- **WHEN** Bash parses `while curl URL; do sleep 1; done`
+- **THEN** `curl` is identified as a condition occurrence
+- **THEN** `sleep` is identified as a loop-body occurrence
+
+#### Scenario: PowerShell iterator pipeline role
+- **WHEN** PowerShell parses `foreach ($f in Get-ChildItem C:\input) { Remove-Item $f }`
+- **THEN** `Get-ChildItem` is identified as an iterator occurrence
+- **THEN** `Remove-Item` is identified as a loop-body occurrence
+
+### Requirement: Iterator and substitution commands remain visible
+The parser SHALL include every inner command from a supported executable
+iterator, substitution, or nested command in the occurrence collection even
+when the produced value is unknown.
+
+#### Scenario: Bash command substitution iterable
+- **WHEN** Bash supports and parses `for f in $(find /tmp -type f); do rm "$f"; done`
+- **THEN** both `find` and `rm` appear in the occurrence collection
+- **THEN** the value produced by `find` is not presented as exact or finite
+
+#### Scenario: Process substitution remains gated
+- **WHEN** Bash encounters `diff <(git show HEAD) <(git show HEAD~1)` before process substitution discovery is supported
+- **THEN** the result is unparseable rather than omitting either `git` command
+
+### Requirement: Occurrence completeness is explicit
+Each occurrence SHALL state whether its command identity, structural ancestry,
+and parser-owned shell analysis are complete. No incomplete occurrence SHALL
+be sufficient authorization evidence.
+
+#### Scenario: Dynamic command identity
+- **WHEN** PowerShell parses a supported structure whose body invokes `& $exe arg`
+- **THEN** the invocation occurrence is incomplete or has dynamic command identity
+- **THEN** a security consumer is directed to prompt or deny
+
+#### Scenario: Complete literal command
+- **WHEN** Bash parses `echo ready` in a supported loop body
+- **THEN** the occurrence is structurally complete
+- **THEN** completeness does not imply that `echo` is authorized
+
+### Requirement: Source order is deterministic
+The occurrence collection SHALL be ordered by authored command occurrence,
+including commands nested in headers and bodies, with a documented tie-breaker
+for enclosing and enclosed regions.
+
+#### Scenario: Iterator precedes body
+- **WHEN** Bash parses `for f in $(find .); do rm "$f"; done`
+- **THEN** the `find` occurrence precedes the `rm` occurrence
+
+#### Scenario: Branches preserve authored order
+- **WHEN** PowerShell parses an `if` statement with then and else commands
+- **THEN** condition commands precede then-body commands
+- **THEN** then-body commands precede else-body commands in the projection
+
+### Requirement: Command discovery is library-owned
+Security consumers SHALL be able to enumerate every potentially executable
+command without recursively matching syntax-node types.
+
+#### Scenario: New syntax node in a later version
+- **WHEN** a later package adds a syntax-node type whose commands are fully supported
+- **THEN** those commands appear through the existing occurrence collection
+- **THEN** an occurrence-based consumer does not need a new tree visitor merely to discover them

--- a/openspec/changes/v0-3-structured-shell-analysis/specs/explicit-redirect-semantics/spec.md
+++ b/openspec/changes/v0-3-structured-shell-analysis/specs/explicit-redirect-semantics/spec.md
@@ -1,0 +1,90 @@
+## ADDED Requirements
+
+### Requirement: Redirect operation is explicit
+Each parsed redirect SHALL identify its operation independently from its raw
+text and compatibility direction. Supported operations SHALL distinguish file
+input, file output, append, descriptor duplicate, descriptor close,
+descriptor move, combined output, and any separately supported here-document
+or here-string form.
+
+#### Scenario: Static descriptor duplication
+- **WHEN** Bash parses `dotnet test 2>&1`
+- **THEN** the redirect operation is descriptor duplicate
+- **THEN** the source descriptor is `2` and the target descriptor is `1`
+
+#### Scenario: Static descriptor close
+- **WHEN** Bash parses `command 2>&-`
+- **THEN** the redirect operation is descriptor close
+- **THEN** it is not classified as a dynamic path
+
+#### Scenario: Static descriptor move
+- **WHEN** Bash parses `command 2>&1-`
+- **THEN** the redirect operation is descriptor move
+- **THEN** the source and target descriptors are explicit
+
+### Requirement: Static and computed descriptor targets differ
+A descriptor operation SHALL expose a static target descriptor only when the
+complete target is a literal descriptor. A variable, substitution, malformed
+suffix, or other computed target SHALL remain dynamic or incomplete.
+
+#### Scenario: Variable descriptor target
+- **WHEN** Bash parses `command 2>&$FD`
+- **THEN** the target is computed rather than static descriptor `FD`
+- **THEN** a consumer cannot exempt it using the raw `&` prefix
+
+#### Scenario: Braced variable descriptor target
+- **WHEN** Bash parses `command >&${FD}`
+- **THEN** the redirect remains policy-relevant unknown input
+
+### Requirement: Combined output redirects preserve their semantics
+The Bash parser SHALL distinguish `&>` and `&>>` from background-list syntax
+and SHALL identify whether combined standard output and standard error are
+overwritten or appended.
+
+#### Scenario: Combined output overwrite
+- **WHEN** Bash parses `command &> output.log`
+- **THEN** one combined-output file redirect targets `output.log`
+
+#### Scenario: Combined output append
+- **WHEN** Bash parses `command &>> output.log`
+- **THEN** one combined-output append redirect targets `output.log`
+
+### Requirement: Redirect path relevance is independent
+Redirect details SHALL state whether the target is a filesystem path without
+overloading dynamic-value classification. Static descriptor operations SHALL
+not be paths; file targets SHALL retain normal literal, pattern, and unknown
+value facts.
+
+#### Scenario: Static error file
+- **WHEN** Bash parses `command 2> error.log`
+- **THEN** `error.log` is a path-relevant file target
+
+#### Scenario: Duplication is not a path
+- **WHEN** Bash parses `command 2>&1`
+- **THEN** descriptor `1` is not path-relevant
+
+### Requirement: Redirect compatibility facts remain available
+Existing redirect members SHALL remain populated according to their documented
+v0.2 compatibility meanings while consumers migrate to explicit operation
+facts. New facts SHALL NOT silently reinterpret a dynamic target as static.
+
+#### Scenario: Existing consumer inspects static duplication
+- **WHEN** a v0.2-style consumer reads the compatibility redirect for `2>&1`
+- **THEN** the raw target remains available
+- **THEN** the v0.3 consumer can distinguish the operation without parsing that raw value
+
+### Requirement: Heredoc bodies are data with explicit expansion facts
+When heredoc support is enabled, the redirect model SHALL preserve delimiter
+quoting, body source, expansion mode, and analysis completeness. It SHALL NOT
+classify the body itself as a child command merely because the receiving
+executable may interpret that data as code.
+
+#### Scenario: Quoted heredoc delimiter
+- **WHEN** Bash parses a supported heredoc with a quoted delimiter
+- **THEN** the body is preserved as non-expanding authored data
+- **THEN** the parser does not execute or reinterpret the receiving command
+
+#### Scenario: Executable substitution in an expanding body
+- **WHEN** a supported expanding heredoc body contains command substitution
+- **THEN** the inner command is exposed or the result is unparseable
+- **THEN** the body is not reported as completely static while executable content is hidden

--- a/openspec/changes/v0-3-structured-shell-analysis/specs/structured-shell-syntax/spec.md
+++ b/openspec/changes/v0-3-structured-shell-analysis/specs/structured-shell-syntax/spec.md
@@ -1,0 +1,94 @@
+## ADDED Requirements
+
+### Requirement: Parsed commands expose authored nested structure
+Every fully parsed command SHALL expose one library-owned syntax root that
+preserves the authored nesting and source order of supported command lists,
+pipelines, groups, simple commands, loops, and branches.
+
+#### Scenario: Existing flat command receives a structural root
+- **WHEN** either parser parses `git status && dotnet test`
+- **THEN** the syntax root contains the two simple commands in authored order
+- **THEN** the `&&` relationship is preserved structurally
+
+#### Scenario: External code cannot invent syntax nodes
+- **WHEN** a consumer references the public syntax-node base type
+- **THEN** it cannot derive and inject an external node implementation
+
+### Requirement: Simple-command nodes preserve existing leaves
+A simple-command syntax node SHALL expose the existing `Clause` facts rather
+than replacing `VerbChain`, `Arg`, `Redirect`, or `ClauseElement` with a second
+incompatible leaf model.
+
+#### Scenario: Clause provenance survives structural wrapping
+- **WHEN** Bash parses `git -C /repo status > status.txt`
+- **THEN** the simple-command node exposes the existing verb, arguments, redirect, and ordered elements
+- **THEN** their raw values and source spans retain the v0.2 meanings
+
+### Requirement: Bash for-in loops preserve header and body structure
+The Bash parser SHALL represent a supported `for name in words; do body; done`
+loop as a typed loop node with its binding name, authored iterable expression,
+and nested body block.
+
+#### Scenario: Literal Bash loop
+- **WHEN** Bash parses `for f in a.txt b.txt; do rm -- "$f"; done`
+- **THEN** the root contains one loop node binding `f`
+- **THEN** the iterable preserves `a.txt` and `b.txt` in source order
+- **THEN** the body contains one simple command for `rm -- "$f"`
+
+#### Scenario: Nested Bash loop
+- **WHEN** Bash parses `for d in a b; do for f in x y; do echo "$d/$f"; done; done`
+- **THEN** the outer loop body contains the inner loop node
+- **THEN** the `echo` command remains nested beneath both loops
+
+### Requirement: PowerShell foreach loops preserve header and body structure
+The PowerShell parser SHALL represent a supported `foreach` statement as a
+typed loop node with its binding, iterable expression, and nested body block
+without treating the script block as one opaque argument.
+
+#### Scenario: Literal PowerShell foreach
+- **WHEN** PowerShell parses `foreach ($f in @('a.txt', 'b.txt')) { Remove-Item -LiteralPath $f }`
+- **THEN** the root contains one loop node binding `f`
+- **THEN** the iterable preserves the two literal array elements
+- **THEN** the body contains one simple command for `Remove-Item`
+
+### Requirement: Condition loops and branches preserve executable regions
+The parser SHALL preserve the condition, every branch body, and the
+continuation after each supported Bash or PowerShell condition loop or branch
+as distinct structural regions.
+
+#### Scenario: Bash while condition contains a command
+- **WHEN** Bash parses `while curl https://example.invalid/ready; do echo waiting; done`
+- **THEN** the condition block contains the `curl` command
+- **THEN** the body block contains the `echo` command
+
+#### Scenario: PowerShell branch preserves both alternatives
+- **WHEN** PowerShell parses `if (Test-Path a.txt) { Remove-Item a.txt } else { Write-Output missing }`
+- **THEN** the condition, then body, and else body remain distinct regions
+- **THEN** no branch is discarded based on predicted runtime behavior
+
+### Requirement: Source ranges are exact or explicitly unavailable
+Each direct-source structural node SHALL carry a source range into
+`ParsedCommand.Source`. A node lifted from decoded, escaped, or encoded wrapper
+content SHALL report an unavailable outer range unless an exact mapping exists.
+
+#### Scenario: Direct loop span
+- **WHEN** Bash parses a direct `for` loop
+- **THEN** the loop range starts at `for` and ends after `done`
+
+#### Scenario: Decoded wrapper span
+- **WHEN** PowerShell lifts a command from a decoded `-EncodedCommand` payload
+- **THEN** the inner node does not claim an approximate range in the encoded outer source
+
+### Requirement: Unsupported executable structure fails closed
+The parser SHALL set `ParsedCommand.IsUnparseable=true` whenever it cannot
+account for every potentially executable region in an input. Preserved partial
+syntax SHALL be diagnostic evidence only.
+
+#### Scenario: Arithmetic contains command substitution
+- **WHEN** Bash encounters `for ((i = $(next); i < 10; i++)); do run "$i"; done` before that form is supported
+- **THEN** the result is unparseable
+- **THEN** the parser does not treat the arithmetic header as harmless opaque text
+
+#### Scenario: Unknown PowerShell expression boundary
+- **WHEN** a PowerShell control-flow expression contains execution-bearing syntax the parser cannot delimit completely
+- **THEN** the result is unparseable even if the body commands were discovered

--- a/openspec/changes/v0-3-structured-shell-analysis/tasks.md
+++ b/openspec/changes/v0-3-structured-shell-analysis/tasks.md
@@ -1,0 +1,108 @@
+## 1. Contract Lock
+
+- [ ] 1.1 Review Appendix A and lock the public syntax-root, node, occurrence, ancestry, value-domain, and redirect-detail type names and members.
+- [ ] 1.2 Decide and document whether projections share identical `Clause` instances or guarantee value equality only.
+- [ ] 1.3 Lock candidate-count, structural-nesting, and existing wrapper-recursion limits with boundary scenarios.
+- [ ] 1.4 Review Appendix B, lock the v0.3 grammar separately for Bash and PowerShell, and park every deferred form explicitly.
+- [ ] 1.5 Resolve the initial pattern and divergent-cwd exposure rules, updating the bounded-analysis specification.
+- [ ] 1.6 Synchronize the accepted public API and shared requirements into `SPEC.md`.
+- [ ] 1.7 Synchronize PowerShell grammar and analysis deltas into `SPEC.POWERSHELL.md`.
+- [ ] 1.8 Update `PROJECT_CONTEXT.md` and `IMPLEMENTATION_PLAN.md` with the accepted v0.3 scope and delivery slices.
+
+## 2. Behavior-Preserving Shared Preparation
+
+- [ ] 2.1 Implement issue #69's shell-neutral native argument-fragment classifier with explicit Bash and PowerShell adapters.
+- [ ] 2.2 Prove all existing raw, decoded, span, path, and `DynamicSkip` results remain unchanged in both corpora.
+- [ ] 2.3 Audit duplicated Bash and PowerShell path-normalization helpers and extract only rules with identical shell semantics.
+- [ ] 2.4 Run Release build, full tests, and header verification for the behavior-preserving refactor.
+
+## 3. Structural and Projection Skeleton
+
+- [ ] 3.1 Add the locked public syntax-node hierarchy and defaults to the public API snapshot.
+- [ ] 3.2 Add the locked command-occurrence, role, ancestry, completeness, and analysis records to the public API snapshot.
+- [ ] 3.3 Add `ParsedCommand.Syntax` and `ParsedCommand.Commands` while retaining all v0.2 members.
+- [ ] 3.4 Build a library-owned traversal that emits each simple command occurrence exactly once in deterministic source order.
+- [ ] 3.5 Build the conservative `Clauses` compatibility flattener without inventing cross-structure compound operators.
+- [ ] 3.6 Adapt the existing Bash grammar to emit the structural model with no newly supported syntax.
+- [ ] 3.7 Adapt the existing PowerShell grammar to emit the structural model with no newly supported syntax.
+- [ ] 3.8 Add tests proving existing parser inputs retain their v0.2 leaf and compatibility results.
+- [ ] 3.9 Add corpus expectations for syntax shape, occurrences, roles, and completeness for existing constructs.
+
+## 4. Explicit Redirect Semantics
+
+- [ ] 4.1 Add the locked redirect operation and target-analysis types while retaining compatibility redirect members.
+- [ ] 4.2 Classify Bash descriptor duplication, close, and move as static only for the complete literal descriptor grammar.
+- [ ] 4.3 Keep variable-driven and otherwise computed Bash descriptor targets unknown or incomplete.
+- [ ] 4.4 Lex and classify Bash `&>` and `&>>` independently from background-list operators.
+- [ ] 4.5 Map existing PowerShell stream redirects into the shared explicit model without losing shell-specific stream identity.
+- [ ] 4.6 Add paired direct tests and corpus cases for static, dynamic, malformed, multiple, combined, and file redirects.
+- [ ] 4.7 Verify the explicit model removes the need for raw-prefix inference in a Netclaw integration test.
+
+## 5. Consumer Migration Baseline
+
+- [ ] 5.1 Rewrite the production-shaped consumer loop in `docs/CONSUMER_GUIDE.md` to enumerate every command occurrence.
+- [ ] 5.2 Document syntax-tree display traversal separately from authorization traversal.
+- [ ] 5.3 Document exact, finite, pattern, unknown, joined-state, redirect, and incomplete-result handling.
+- [ ] 5.4 Document record equality, hashing, `ToString()`, serialization, and `Clauses` compatibility effects.
+- [ ] 5.5 Publish a 0.3.0 prerelease containing the structural API before enabling control flow.
+- [ ] 5.6 Migrate Netclaw's existing-command analysis to the occurrence and redirect APIs behind focused regression tests.
+
+## 6. Bash For-In Vertical Slice
+
+- [ ] 6.1 Parse Bash `for name in literal...; do ...; done` into the locked structural nodes.
+- [ ] 6.2 Emit condition-free loop-body occurrences and conservative compatibility clauses.
+- [ ] 6.3 Derive exact and finite literal binding domains within the locked candidate cap.
+- [ ] 6.4 Substitute a bounded binding only where Bash quoting proves argument boundaries.
+- [ ] 6.5 Propagate and conservatively join cwd and supported binding state across zero-or-more loop execution.
+- [ ] 6.6 Cover empty iterables, separators, multiline bodies, redirects, pipelines, nested loops, and wrapper boundaries.
+- [ ] 6.7 Add adversarial cases for option injection, mutation, unquoted expansion, indirect expansion, substitutions, and cap overflow.
+- [ ] 6.8 Add sanitized Bash corpus entries and Netclaw allow/prompt/deny integration cases.
+
+## 7. PowerShell Foreach Vertical Slice
+
+- [ ] 7.1 Parse PowerShell `foreach` with literal scalar and array iterables into the locked structural nodes.
+- [ ] 7.2 Emit iterator and loop-body occurrences plus conservative compatibility clauses.
+- [ ] 7.3 Derive exact and finite string domains without treating pipeline objects as literal strings.
+- [ ] 7.4 Propagate PowerShell scope and location state according to the locked statement semantics.
+- [ ] 7.5 Cover aliases, cmdlets, native commands, nested loops, pipelines, script blocks, and wrapper boundaries.
+- [ ] 7.6 Add adversarial cases for object-valued iterables, mutation, dynamic invocation, splatting, and cap overflow.
+- [ ] 7.7 Add PowerShell corpus entries, live `pwsh` oracle coverage, and Netclaw integration cases.
+
+## 8. Proven Shared Analysis Extraction
+
+- [ ] 8.1 Compare the two working loop implementations and inventory only behaviorally identical analysis steps.
+- [ ] 8.2 Extract shared command-occurrence traversal without coupling shell token consumption.
+- [ ] 8.3 Extract the value-domain lattice, combination cap, and unknown fallback.
+- [ ] 8.4 Extract conservative sequential and branch-state join primitives used identically by both shells.
+- [ ] 8.5 Keep shell-specific iterable, quoting, scoping, expression, and parser code behind explicit adapters.
+- [ ] 8.6 Re-run both complete corpora to prove the extraction is behavior-preserving.
+
+## 9. Condition Loops and Branches
+
+- [ ] 9.1 Add Bash `while` and `until` with condition and body command occurrences.
+- [ ] 9.2 Add Bash `if` / `elif` / `else` with conservative branch-state joins.
+- [ ] 9.3 Add Bash `case` only after pattern and branch-selection uncertainty is specified.
+- [ ] 9.4 Add PowerShell `while` and `do` forms with separately specified expression boundaries.
+- [ ] 9.5 Add PowerShell `if` / `elseif` / `else` with conservative branch-state joins.
+- [ ] 9.6 Add PowerShell `switch` only after string, regex, wildcard, and script-block modes are bounded explicitly.
+- [ ] 9.7 Add paired security scenarios proving every condition and branch command remains visible.
+
+## 10. Separately Gated Syntax Concerns
+
+- [ ] 10.1 Specify heredoc delimiter quoting, expansion mode, body provenance, substitutions, and completeness before enabling heredoc bodies.
+- [ ] 10.2 Specify process-substitution command discovery and the unknown produced descriptor/path value before enabling it.
+- [ ] 10.3 Specify background-list concurrency, ordering, and shell-state boundaries before enabling single `&`.
+- [ ] 10.4 Specify C-style loop and arithmetic hidden-execution behavior before enabling either construct.
+- [ ] 10.5 Keep URL-versus-glob and environment-assignment approval behavior in executable-aware consumer issues unless a shell lexical fact is missing.
+- [ ] 10.6 Reproduce multiline quoted-argument reports against exact parser input before assigning a parser change.
+
+## 11. Verification and Release
+
+- [ ] 11.1 Add public API default-value, equality, serialization, and unknown-enum compatibility tests.
+- [ ] 11.2 Assert every supported executable region appears exactly once and every unsupported executable region makes the result unparseable.
+- [ ] 11.3 Run the complete Bash and PowerShell corpus suites plus the PII audit.
+- [ ] 11.4 Run `dotnet build -c Release`, `dotnet test -c Release`, `dotnet pack -c Release`, and header verification.
+- [ ] 11.5 Validate the public API field-for-field against the synchronized shared and PowerShell specifications.
+- [ ] 11.6 Validate Netclaw's ordinary-command, redirect, bounded-loop, and unknown-value approval matrices against the prerelease package.
+- [ ] 11.7 Update release notes and remove Netclaw's temporary descriptor workaround only after explicit redirect integration is live.
+- [ ] 11.8 Promote stable 0.3.0 only after Linux and Windows CI, package publication, and downstream acceptance succeed.

--- a/openspec/changes/v0-3-structured-shell-analysis/tasks.md
+++ b/openspec/changes/v0-3-structured-shell-analysis/tasks.md
@@ -44,8 +44,9 @@
 - [ ] 5.2 Document syntax-tree display traversal separately from authorization traversal.
 - [ ] 5.3 Document exact, finite, pattern, unknown, joined-state, redirect, and incomplete-result handling.
 - [ ] 5.4 Document record equality, hashing, `ToString()`, serialization, and `Clauses` compatibility effects.
-- [ ] 5.5 Publish a 0.3.0 prerelease containing the structural API before enabling control flow.
-- [ ] 5.6 Migrate Netclaw's existing-command analysis to the occurrence and redirect APIs behind focused regression tests.
+- [ ] 5.5 Update the README getting-started and migration examples to direct v0.3 consumers to the command-occurrence API and full consumer guide.
+- [ ] 5.6 Publish a 0.3.0 prerelease containing the structural API before enabling control flow.
+- [ ] 5.7 Migrate Netclaw's existing-command analysis to the occurrence and redirect APIs behind focused regression tests.
 
 ## 6. Bash For-In Vertical Slice
 


### PR DESCRIPTION
## Summary

- add the release-level OpenSpec proposal for ShellSyntaxTree 0.3 structured shell analysis
- define five capability deltas covering structured syntax, command occurrences, bounded values, explicit redirects, and consumer compatibility
- include non-normative C# public API mocks plus Bash and PowerShell grammar, recursive-parser, internal-node, lowering, and fail-closed sketches
- sequence contract lock, issue #69 preparation, compatibility skeleton, Bash `for ... in`, PowerShell `foreach`, and proven shared-analysis extraction
- make `docs/CONSUMER_GUIDE.md` and the README usage and migration examples explicit v0.3 deliverables
- update `IMPLEMENTATION_PLAN.md` so the active roadmap matches issue #72

## Security and compatibility boundaries

- every supported executable region must appear exactly once in the command-occurrence projection
- partial or unsupported executable structure remains fail closed
- existing v0.2 `Clause`, `Arg`, `Redirect`, `ClauseElement`, `VerbChain`, and `ParsedCommand.Clauses` facts remain available
- Bash and PowerShell retain separate lexers and structural parsers
- executable-specific option and operand semantics remain consumer-owned
- the Netclaw redirect workaround remains containment until explicit v0.3 redirect facts are integrated

## Tracker

- Relates to #72
- Builds the design and delivery framework for #71
- Preserves the narrow behavior-only scope of #69
- Related consumer workaround: netclaw-dev/netclaw#1776

This proposal does not close the roadmap or feature issues. Public type names,
analysis caps, and the initial supported-construct matrix remain explicit
contract-lock tasks before production implementation.

## Validation

- `openspec validate v0-3-structured-shell-analysis`
- `dotnet build -c Release`
- `dotnet test -c Release --no-build` — 1,017 passed
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`
- `git diff --check`
