### PR TITLE
Correct v0.3 resolver transform contexts

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -156,15 +156,35 @@ priorities.
       literal resolver syntax from expandable syntax even when both decode to
       the same string, including standalone, adjacent-token, all-static
       mixed-quote, within-token escape, and literal-plus-expandable cases.
-      Preserve ordered literal / expandable / opaque fragments internally;
-      require exact composition when every fragment and resolver fact is
-      exact, do not change the v0.2 public API, and never infer expansion from
-      decoded text.
+      Preserve ordered literal / typed-expansion / opaque fragments plus
+      operation-specific transform eligibility, expansion identity,
+      cardinality, and opaque cause internally; require explicit
+      Bash-argument, Bash-redirect, PowerShell-native, cmdlet-Path,
+      cmdlet-LiteralPath, and PowerShell-redirect resolver contexts, and
+      aggregate adjacent fragments for complete
+      argument and redirect targets. Runtime special, positional, numeric, and
+      Unicode variables retain typed expansion identity and cardinality while
+      remaining unknown without a proved value; incomplete braced
+      interpolation is unparseable. Exact composition is required when
+      every fragment, binding fact, and resolver fact is exact. Do not change
+      the v0.2 public API or infer expansion from decoded text. The first
+      implementation was halted before commit after adversarial review proved
+      that one universal expandable bit misclassified quoted PowerShell native
+      and cmdlet paths, missed valid variable forms, accepted incomplete
+      interpolation, and split adjacent redirect targets.
+      Bash provider-looking text remains literal; only PowerShell cmdlet path
+      and redirect contexts apply provider or PSDrive semantics, overriding
+      the obsolete shared resolver rule when the canonical specifications are
+      synchronized.
+      PowerShell redirects remain a separate Path-like context that applies
+      tilde, wildcard, provider, and PSDrive semantics after quote removal;
+      unknown wildcard cardinality or drive mappings fail closed without
+      enumeration. Bash redirects instead require exactly one proved target.
 - [ ] Implement [issue #69](https://github.com/Aaronontheweb/ShellSyntaxTree/issues/69)
       against the corrected fragment contract. Preserve raw, decoded, and span
       facts plus unaffected classifications; explicitly document only
-      shell-oracle-proved compatibility corrections to false path claims and
-      avoidable `DynamicSkip` results.
+      shell-oracle-proved compatibility corrections to false exact, `Glob`,
+      `Tilde`, provider, or path claims and avoidable `DynamicSkip` results.
 - [ ] Add the structural and command-occurrence projections for the existing
       grammar before enabling any control-flow construct.
 - [ ] Deliver Bash `for ... in` and PowerShell `foreach` as the first two

--- a/openspec/changes/v0-3-structured-shell-analysis/design.md
+++ b/openspec/changes/v0-3-structured-shell-analysis/design.md
@@ -120,12 +120,27 @@ one the shell passes to the executable.
 
 Both shell front ends SHALL retain resolver-relevant value fragments through
 decoding. The internal representation is not public API, but it must preserve
-the ordered decoded text, exact source range when available, and one of these
-shell-owned dispositions for every fragment:
+the ordered decoded text, exact source range when available, one shell-owned
+disposition, and the exact set of lexical transformations eligible for every
+fragment:
 
-- `Literal`: quoting or escaping suppresses resolver transformation;
-- `Expandable`: the selected shell permits the relevant transformation;
-- `Opaque`: the parser cannot prove the produced value.
+- `Literal`: the fragment's produced text is exact without lexical expansion;
+- `Expansion`: the front end recognizes a typed shell expansion, even when its
+  runtime result is not proved;
+- `Opaque`: the front end recognizes a computed or unsupported region but
+  cannot model its produced value or boundary precisely.
+
+The disposition is not itself a universal expansion bit. Shell lexical
+transformations are operation-specific: variable interpolation, tilde
+expansion, and globbing do not share identical quote rules. Post-formation path
+semantics are a separate stage. In PowerShell, native-command arguments apply
+PowerShell's lexical quote rules, while cmdlet `-Path` binding interprets a
+quoted `~`, wildcard, provider qualifier, or PSDrive after quote removal;
+`-LiteralPath` deliberately differs again. Therefore the parser SHALL retain
+an operation-specific lexical capability map and SHALL pass an explicit
+resolver consumer/binding context. It SHALL NOT reconstruct either fact from
+decoded text, `IsSingleQuoted`, or whether the verb happens to look
+cmdlet-shaped.
 
 A representative internal shape is:
 
@@ -133,33 +148,165 @@ A representative internal shape is:
 internal enum ShellValueFragmentKind
 {
     Literal,
-    Expandable,
+    Expansion,
     Opaque,
 }
+
+[Flags]
+internal enum ShellLexicalTransform
+{
+    None = 0,
+    Variable = 1,
+    Tilde = 2,
+    Glob = 4,
+    FieldSplit = 8,
+}
+
+internal enum ShellExpansionKind
+{
+    Variable,
+    SpecialParameter,
+    PositionalParameter,
+    Tilde,
+    Glob,
+}
+
+internal enum ShellValueCardinality
+{
+    ExactlyOne,
+    ZeroOrOne,
+    ZeroOrMore,
+    Unknown,
+}
+
+internal enum ShellOpaqueCause
+{
+    None,
+    CommandSubstitution,
+    PowerShellSubexpression,
+    Splat,
+    Unsupported,
+}
+
+internal readonly record struct ShellExpansionReference(
+    ShellExpansionKind Kind,
+    string? Name);
 
 internal readonly record struct ShellValueFragment(
     string Value,
     ShellValueFragmentKind Kind,
+    ShellLexicalTransform AllowedTransforms,
+    ShellExpansionReference? Expansion,
+    ShellValueCardinality Cardinality,
+    ShellOpaqueCause OpaqueCause,
     int? SourceStart,
     int? SourceLength);
 
 internal readonly record struct ShellValue(
     string Decoded,
     IReadOnlyList<ShellValueFragment> Fragments);
+
+internal enum ShellResolutionConsumer
+{
+    BashArgument,
+    BashRedirect,
+    PowerShellNativeArgument,
+    PowerShellCmdletPath,
+    PowerShellCmdletLiteralPath,
+    PowerShellRedirect,
+}
 ```
 
 This mock is non-normative: an equivalent boundary map or compact segment
-representation is acceptable. A single aggregate `IsLiteral` flag is not
-acceptable because one authored word can contain both expandable and escaped
-regions. The resolver transforms only eligible `Expandable` regions and
-preserves `Literal` regions byte-for-byte. When every fragment, supported
-transformation, and the required cwd or home fact is exact, it must compose and
-resolve the exact result even when literal and expandable fragments are mixed;
+representation is acceptable. A single aggregate `IsLiteral` flag, a three-way
+kind without operation-specific capabilities and typed expansion metadata, or
+a resolver call without consumer/binding context is not acceptable. One
+authored word can contain both expansion and escaped regions, and one decoded
+PowerShell value can have
+different correct meanings for a native executable, `-Path`, and
+`-LiteralPath`. Lexical expansion transforms only eligible regions. Provider,
+PSDrive, wildcard-binding, and filesystem normalization rules then apply to the
+exact composed value only when the explicit consumer context permits them.
+When every fragment, supported transformation, binding fact, and required cwd
+or home fact is exact, the resolver must compose and resolve the exact result
+even when literal and expansion fragments are mixed;
 it cannot choose `DynamicSkip` merely because retaining provenance requires
-more work. `DynamicSkip` is reserved for an `Opaque` fragment, an incomplete
-boundary, an unknown required fact, or an unsupported transformation that
-prevents an exact path claim. The resolver never infers expansion solely from
-the decoded string.
+more work. `DynamicSkip` is reserved for a recognized expansion whose value or
+cardinality is unproved, an `Opaque` fragment, an incomplete boundary, an
+unknown required fact, or an unsupported transformation that prevents an exact
+path claim. The resolver never infers expansion solely from the decoded string.
+
+In the representative shape, `Literal` carries `AllowedTransforms=None`, no
+expansion reference, `ExactlyOne`, and `OpaqueCause=None`. `Expansion` carries
+at least one transform plus a typed reference; the bounded analyzer may still
+produce `Unknown` when no value proof exists. `Opaque` carries a non-`None`
+cause and retains any authored later-stage transform and cardinality facts that
+remain knowable. Thus `"$@"` records a special-parameter expansion with
+`ZeroOrMore` cardinality rather than losing the reason one exact argument
+cannot be claimed. The flags describe authored eligibility and shell ordering,
+not a license to recursively rescan produced text. Provider and PSDrive
+handling are intentionally absent from the flag set because they are
+post-formation consumer semantics. They are owned by PowerShell cmdlet path and
+redirect contexts; Bash arguments and redirects never strip a provider-looking
+prefix.
+
+PowerShell parameter binding SHALL retain at least `Path` versus `LiteralPath`
+internally rather than collapsing both to `treatAsPath=true`. Positional cmdlet
+paths use the verb table's explicit binding mode. `LiteralPath` suppresses
+wildcard interpretation but still applies quoted tilde, provider-qualifier,
+and PSDrive semantics; it is not an "all post-formation transforms off" mode.
+Native arguments never gain
+cmdlet provider or PSDrive semantics merely because their decoded text has the
+same shape. When the parser cannot prove the consumer or binding mode, it
+fails closed instead of selecting the more permissive interpretation.
+
+Runtime-variable recognition is part of the shell front end, not the resolver.
+Bash special and positional parameters, including the boundary-sensitive
+`"$@"`, and PowerShell special, numeric, scoped, braced, and Unicode-named
+variables must retain a typed expansion reference and cardinality. Unless the
+bounded analyzer has a proof, their analyzed value domain remains `Unknown`;
+the parser does not collapse the fragment into literal text or discard why it
+is unknown. A recognized interpolation start that the bounded resolver cannot
+evaluate is never silently reclassified as literal text. An unterminated
+braced interpolation is a syntax error for the whole parse, even when the
+outer quote closes cleanly.
+
+Fragment aggregation applies to redirect targets as well as ordinary
+arguments. Adjacent fragments after a redirect operator form the one target
+the shell consumes; the parser must not expose a resolved prefix as the
+redirect and leave the suffix as an unrelated argument. Bash and PowerShell
+redirects retain separate consumer contexts. In particular, Bash redirect-word
+expansion must prove exactly one target; it cannot reuse ordinary argument
+splitting or glob cardinality rules. Here-string data remains on the separate
+redirect-analysis path specified below.
+
+`PowerShellRedirect` is its own Path-like post-formation consumer. After value
+formation it applies tilde, wildcard, FileSystem provider, and PSDrive
+semantics even when the authored value was quoted. A wildcard target remains
+unknown without filesystem enumeration. A PSDrive target remains unknown
+without a proved drive-to-provider mapping. Neither case is reported as a
+static non-path target merely because the parser lacks the runtime fact.
+
+The redesign is grounded in live GNU Bash 5.2.21 and PowerShell 7.6.4
+observations on Linux:
+
+| Probe | Observed shell behavior | Contract consequence |
+|---|---|---|
+| Bash `cat "${HOME"` and PowerShell `Get-Content "${HOME"` | Bash reports an unmatched quote/interpolation boundary; the PowerShell parser reports two syntax errors | Unterminated braced interpolation makes the whole parse unparseable |
+| Each shell receives its escaped-dollar spelling of `${HOME` | Each receives the literal string `${HOME` without a parse error | An escaped interpolation start remains literal and complete |
+| PowerShell variables `$?`, `$1`, and `$é` | Each produces a runtime value | Their typed expansions remain `Unknown` without a bounded proof, never literal filenames |
+| Native `printf` receives quoted `~` and `FileSystem::/tmp` | It receives both strings byte-for-byte | Quoted native values do not gain cmdlet tilde or provider semantics |
+| Bash `printf` receives `filesystem::/safe`, quoted or unquoted | It receives the provider-looking string byte-for-byte in both forms | Bash never applies PowerShell provider semantics |
+| `Resolve-Path "~"` and `Get-Item "FileSystem::/tmp"` | They resolve to the home directory and `/tmp` | Cmdlet path binding applies after quote removal |
+| `Resolve-Path -Path "*.txt"`, `Test-Path -LiteralPath "*.txt"`, and native `printf "*.txt"` in a directory containing `a.txt` | `-Path` matches once; `-LiteralPath` is false; native `printf` receives `*.txt` | `Path`, `LiteralPath`, and native contexts remain distinct without filesystem enumeration by this library |
+| Native PowerShell receives unquoted and quoted `*.txt` in a directory containing `a.txt` | The unquoted form receives `a.txt`; the quoted form receives `*.txt` | Unquoted native wildcard cardinality is unknown without enumeration; quoting produces one exact literal value |
+| Each shell redirects to its escaped-dollar spelling of `$HOME".txt"` | Each creates exactly one file named `$HOME.txt` | Adjacent redirect fragments form one target |
+| Bash redirects unquoted and quoted `*.txt` in a directory with multiple `.txt` files | The unquoted form is an ambiguous redirect; the quoted form creates the literal file `*.txt` | `BashRedirect` requires one proved target and retains quote-sensitive glob eligibility |
+| PowerShell redirects quoted `~`, `*.txt`, `FileSystem::...`, and a FileSystem PSDrive path | Tilde, wildcard, provider, and drive semantics apply after quote removal | `PowerShellRedirect` is Path-like but remains separate from cmdlet and native argument contexts |
+
+Task 2.2 converts these probes into deterministic shell-oracle regressions on
+the implementation branch; the design corpus records their desired semantic
+shape before the v0.2 compatibility leaves can express it.
 
 Issue #69's shared native argument classifier consumes these proved fragments
 through explicit Bash and PowerShell adapters. It may own adjacency, decoded
@@ -328,8 +475,9 @@ corpus remains sanitized under the existing PII audit.
   structural parsers separate; extract only duplication demonstrated by both
   working slices.
 - **[Decoded values erase expansion provenance]** -> Retain ordered internal
-  literal, expandable, and opaque fragments; never let a resolver reconstruct
-  those facts from decoded text alone.
+  literal, typed-expansion, and opaque fragments with transform, cardinality,
+  and cause facts; never let a resolver reconstruct those facts from decoded
+  text alone.
 - **[Partial trees invite partial authorization]** -> Keep
   `IsUnparseable=true`, return empty `Commands` and `Clauses`, and keep any
   partial syntax diagnostic-only.

--- a/openspec/changes/v0-3-structured-shell-analysis/proposal.md
+++ b/openspec/changes/v0-3-structured-shell-analysis/proposal.md
@@ -22,9 +22,15 @@ fail-closed behavior for incomplete analysis.
 - Add conservative value and shell-state analysis that distinguishes exact,
   finite, bounded-symbolic, and unknown facts without executing commands or
   enumerating the filesystem.
-- Preserve resolver-relevant lexical fragments through decoding so escaped or
-  quoted literal syntax cannot be mistaken for expandable syntax with the same
-  decoded text.
+- Preserve resolver-relevant lexical fragments, typed expansion identity and
+  cardinality, operation-specific transform eligibility, opaque cause, and
+  consumer/binding context through decoding so escaped or
+  quoted literal syntax cannot be mistaken for expandable syntax, while
+  PowerShell native arguments, cmdlet paths, and literal paths retain their
+  distinct semantics for the same decoded text. Runtime-only variable forms
+  retain typed expansion identity and cardinality while their value remains
+  unknown without proof; incomplete interpolation fails closed, and adjacent
+  redirect fragments retain one target boundary.
 - Add explicit redirect operation and target facts so consumers do not infer
   descriptor duplication, close, move, combined output, or dynamic targets
   from raw strings and `DynamicSkip` alone.
@@ -77,10 +83,11 @@ public records also changes generated equality, hashing, `ToString()`, and
 default serialization and therefore requires explicit migration notes.
 
 The implementation also corrects a v0.2 security defect at an internal
-boundary: decoded token text currently loses whether resolver-sensitive bytes
-were literal or expandable. The correction fixes false path claims and
-avoidable `DynamicSkip` results while retaining the shipped public API, raw
-spelling, decoded logical values, and source spans.
+boundary: decoded token text currently loses lexical provenance and
+consumer/binding context. The correction fixes oracle-proved false exact,
+`Glob`, `Tilde`, provider, path, and avoidable `DynamicSkip` classifications
+while retaining the shipped public API, raw spelling, decoded logical values,
+and source spans.
 
 Netclaw is the validating consumer. Its 0.25.4 redirect workaround remains the
 short-term containment; a v0.3 integration must switch authorization traversal

--- a/openspec/changes/v0-3-structured-shell-analysis/specs/bounded-shell-analysis/spec.md
+++ b/openspec/changes/v0-3-structured-shell-analysis/specs/bounded-shell-analysis/spec.md
@@ -2,11 +2,15 @@
 
 ### Requirement: Decoded values retain resolver provenance
 The parser SHALL retain enough shell-specific lexical provenance to distinguish
-resolver-sensitive literal, expandable, and opaque fragments after escape and
-quote decoding. It SHALL NOT infer whether text expands solely from the
-decoded string. Literal fragments SHALL remain literal and eligible expandable
-fragments SHALL be transformed under the existing bounded rules. When every
-fragment, supported transformation, and required cwd or home fact is exact,
+resolver-sensitive literal, recognized-expansion, and opaque fragments after escape and
+quote decoding, including the operation-specific transformations each exact
+fragment permits. It SHALL NOT infer whether text expands solely from the
+decoded string or one aggregate literal/expandable bit. Lexical transformations
+SHALL apply only to eligible fragments. Consumer-level path interpretation
+SHALL receive explicit shell, argument-versus-redirect,
+native-versus-cmdlet, and PowerShell `Path`-versus-`LiteralPath` context.
+When every fragment, supported
+transformation, binding fact, and required cwd or home fact is exact,
 the parser SHALL compose the exact shell value and SHALL return the exact
 compatibility path result for a path position. It SHALL NOT return `DynamicSkip`
 solely because one value contains both literal and expandable fragments. An
@@ -60,6 +64,74 @@ retain their existing meanings.
 #### Scenario: Opaque fragment remains fail closed
 - **WHEN** an adjacent native argument contains a command substitution, subexpression, splat, or another opaque fragment
 - **THEN** the parser does not synthesize an exact path from the remaining decoded text
+
+#### Scenario: Runtime variables remain unknown without a proved value
+- **WHEN** Bash parses a special, positional, or argument-vector parameter such as `$?`, `$1`, or `"$@"` in a policy-relevant value
+- **WHEN** PowerShell parses a special, numeric, or Unicode-named variable such as `$?`, `$^`, `$$`, `$1`, or `$é`
+- **THEN** the front end retains the typed expansion identity and cardinality while the analyzed value is unknown
+- **THEN** glob or literal-path classification is not inferred from its decoded punctuation
+- **THEN** a boundary-sensitive expansion such as `"$@"` does not become one exact argument
+
+#### Scenario: Unterminated braced interpolation is unparseable
+- **WHEN** either shell parses a quoted value whose `${...}` interpolation never closes
+- **THEN** the whole parsed command is unparseable even when the outer quote closes
+- **THEN** the incomplete region is not reported as a literal or exact path
+
+#### Scenario: Escaped braced interpolation start remains literal
+- **WHEN** either shell parses its escaped-dollar spelling of quoted `${HOME`
+- **THEN** the shell value is the exact literal `${HOME`
+- **THEN** it remains parseable and resolves as a literal path when authored in a path position
+
+#### Scenario: PowerShell quoted tilde depends on consumer context
+- **WHEN** PowerShell parses a quoted `~` in a native file operand and in a cmdlet `Path` operand
+- **THEN** the native operand remains the literal filename `~`
+- **THEN** the cmdlet operand resolves through the configured home fact
+- **THEN** both results retain the same raw and decoded spelling without sharing resolver context
+
+#### Scenario: PowerShell unquoted native expansion remains eligible
+- **WHEN** PowerShell parses unquoted `~` or `*.txt` in a native file operand
+- **THEN** tilde remains eligible for native expansion
+- **THEN** the wildcard remains unknown without filesystem enumeration rather than becoming a quoted literal
+- **THEN** correcting quoted operands does not suppress expansion for unquoted operands
+
+#### Scenario: PowerShell provider semantics are cmdlet owned
+- **WHEN** PowerShell parses quoted `FileSystem::C:\logs\x` for a native executable and for a cmdlet path
+- **THEN** the native operand retains the provider-looking text literally
+- **THEN** the cmdlet path applies FileSystem provider semantics
+- **THEN** a non-FileSystem PSDrive in cmdlet path context is not reported as a filesystem path
+
+#### Scenario: Bash provider-looking text remains literal
+- **WHEN** Bash parses quoted or unquoted `filesystem::/safe` in a path position
+- **THEN** the shell value retains every character literally
+- **THEN** the compatibility path resolves under the configured cwd as `<cwd>/filesystem::/safe`
+- **THEN** no PowerShell provider prefix is stripped
+
+#### Scenario: PowerShell Path and LiteralPath differ
+- **WHEN** the same quoted wildcard is bound to `-Path`, `-LiteralPath`, and a native file operand
+- **THEN** `-Path` retains wildcard semantics
+- **THEN** `-LiteralPath` and the quoted native operand retain an exact literal value
+- **THEN** `-LiteralPath` still applies quoted tilde, provider-qualifier, and PSDrive semantics
+- **THEN** the parser does not enumerate the filesystem for any form
+
+#### Scenario: Adjacent redirect fragments form one target
+- **WHEN** either shell parses its escaped-dollar spelling of `> $HOME".txt"`
+- **THEN** the redirect target retains one ordered fragment sequence and the exact literal shell value `$HOME.txt`
+- **THEN** the suffix is not emitted as an unrelated argument
+- **THEN** redirect path interpretation receives its explicit shell-specific context
+- **THEN** a Bash redirect whose expansion cannot prove exactly one target fails closed rather than reusing ordinary argument cardinality rules
+
+#### Scenario: Bash redirect wildcard cardinality is quote-sensitive
+- **WHEN** Bash parses unquoted `> *.txt`
+- **THEN** the target is unknown without filesystem enumeration because expansion may produce zero, one, or multiple paths
+- **WHEN** Bash parses quoted `> "*.txt"`
+- **THEN** the target is the exact literal filename `*.txt`
+
+#### Scenario: PowerShell redirect is a Path-like consumer
+- **WHEN** PowerShell parses a quoted redirect target containing `~`, a wildcard, a FileSystem provider qualifier, or a PSDrive
+- **THEN** redirect binding applies those Path-like semantics after value formation
+- **THEN** a wildcard remains unknown without filesystem enumeration
+- **THEN** a PSDrive remains unknown without a proved drive-to-provider mapping
+- **THEN** quoted syntax does not turn either target into native-style literal text
 
 ### Requirement: Shell values use explicit proof domains
 The analysis SHALL classify a policy-relevant shell value as exact, finite,

--- a/openspec/changes/v0-3-structured-shell-analysis/specs/consumer-compatibility/spec.md
+++ b/openspec/changes/v0-3-structured-shell-analysis/specs/consumer-compatibility/spec.md
@@ -5,6 +5,15 @@
 authored simple command that may execute for a fully parseable result, including
 nested condition, iterator, branch, body, and substitution commands.
 
+Existing raw spelling, decoded values, source spans, and unaffected v0.2 leaf
+classifications SHALL remain compatible. A paired real-shell oracle MAY
+correct a v0.2 `Arg`, `Redirect`, or `ClauseElement` path or expansion
+classification that is false because lexical provenance or consumer/binding
+context was lost. This includes false exact paths, false `Glob` or `Tilde`
+claims, and avoidable `DynamicSkip` results. Every such correction SHALL be
+documented and corpus-pinned; compatibility does not require preserving a
+security defect.
+
 #### Scenario: Old consumer sees loop body command
 - **WHEN** Bash fully parses `for f in a b; do rm "$f"; done`
 - **THEN** the compatibility clauses include the authored `rm` command
@@ -19,6 +28,12 @@ nested condition, iterator, branch, body, and substitution commands.
 - **WHEN** a fully parseable simple command appears in syntax, command, and compatibility projections
 - **THEN** all three projections reference the identical in-memory `Clause` instance
 - **THEN** serialization is not required to preserve that reference identity
+
+#### Scenario: Oracle-proved false path or expansion claim is corrected
+- **WHEN** v0.2 resolves escaped literal syntax as expandable text, treats runtime punctuation as a glob, collapses `Path` and `LiteralPath`, or applies cmdlet path semantics to a native argument
+- **THEN** v0.3 preserves its raw spelling, decoded value, and source span
+- **THEN** the compatibility leaf reports the oracle-proved literal path or fails closed
+- **THEN** release notes identify the classification correction
 
 ### Requirement: Unparseable results are never authorization evidence
 When `ParsedCommand.IsUnparseable=true`, `Commands` and `Clauses` SHALL be

--- a/openspec/changes/v0-3-structured-shell-analysis/tasks.md
+++ b/openspec/changes/v0-3-structured-shell-analysis/tasks.md
@@ -13,10 +13,10 @@
 
 ## 2. Resolver Provenance Correction and Shared Preparation
 
-- [ ] 2.1 Implement shell-specific lexical fragment provenance that distinguishes literal, expandable, and opaque resolver input without changing the public API.
-- [ ] 2.2 Add paired Bash and PowerShell shell-oracle regressions for standalone escapes, adjacent escaped values, all-static mixed quoting, within-token escapes, and genuine literal-plus-expandable values; require exact compatibility path results when every fragment and required resolver fact is exact, otherwise fail closed.
+- [ ] 2.1 Implement shell-specific lexical fragment provenance that distinguishes literal, typed recognized-expansion, and opaque resolver input; retains transform eligibility, expansion identity, cardinality, and opaque cause; aggregates complete argument and redirect-target fragment runs; and passes explicit Bash-argument, Bash-redirect, PowerShell-native, cmdlet-Path, cmdlet-LiteralPath, and PowerShell-redirect resolver context without changing the public API.
+- [ ] 2.2 Add paired Bash and PowerShell shell-oracle regressions for standalone escapes, adjacent escaped values, all-static mixed quoting, within-token escapes, genuine literal-plus-expandable values, adjacent and wildcard redirect targets, runtime special/positional/numeric/Unicode variables, incomplete and escaped-literal braced interpolation, Bash provider-looking literals, and PowerShell native-versus-cmdlet, Path-versus-LiteralPath, and redirect-context divergence; require exact compatibility path results when every fragment, binding fact, and required resolver fact is exact, otherwise fail closed.
 - [ ] 2.3 Implement issue #69's shell-neutral native argument-fragment classifier with explicit Bash and PowerShell adapters that preserve the new provenance.
-- [ ] 2.4 Prove raw spelling, decoded logical values, source spans, and unaffected classifications remain unchanged; document each oracle-proved path or `DynamicSkip` compatibility correction.
+- [ ] 2.4 Prove raw spelling, decoded logical values, source spans, and unaffected classifications remain unchanged; document each oracle-proved false exact, `Glob`, `Tilde`, provider, path, or avoidable `DynamicSkip` compatibility correction.
 - [ ] 2.5 Audit duplicated Bash and PowerShell path-normalization helpers and extract only rules with identical shell semantics.
 - [ ] 2.6 Run Release build, full tests, header verification, and the adversarial security corpus for the completed preparation.
 

--- a/tests/ShellSyntaxTree.Tests/DesignCorpus/README.md
+++ b/tests/ShellSyntaxTree.Tests/DesignCorpus/README.md
@@ -37,8 +37,20 @@ record data separately from executable substitutions and path-relevant
 redirects. Constructs deliberately deferred beyond stable v0.3 remain in the
 corpus as unparseable security boundaries.
 
-Resolver-provenance cases additionally pin selected current `Arg` fields. They
-record the v0.2 false path claim until its production slice lands, while the
-desired effective value records the literal shell value proved by the paired
-real-shell oracle. Those cases then move into the executable corpus instead of
-being treated as behavior that issue #69 must preserve.
+Resolver-provenance cases additionally pin selected current and desired v0.2
+compatibility leaves. Besides `Arg`, a case may assert clause argument,
+redirect, and element counts plus one complete `Redirect` and `ClauseElement`
+shape. This records the v0.2 false path claim until its production slice lands
+and proves that a corrected redirect does not leave a suffix argument behind.
+The desired effective value records the literal shell value proved by the
+paired real-shell oracle. Those cases then move into the executable corpus
+instead of being treated as behavior that issue #69 must preserve.
+
+The provenance matrix deliberately separates shell value formation from path
+consumer semantics. PowerShell cases use identical quoted values across native
+file operands, cmdlet `Path`, and cmdlet `LiteralPath` positions to prove that
+tilde, wildcard, provider, and PSDrive behavior cannot be recovered from the
+decoded string alone. Runtime-variable cases remain `Unknown`; incomplete
+braced interpolation makes the whole parse unparseable. Paired redirect cases
+require adjacent fragments to become one redirect target rather than a target
+prefix plus an unrelated argument.

--- a/tests/ShellSyntaxTree.Tests/DesignCorpus/V03DesignCorpusTests.cs
+++ b/tests/ShellSyntaxTree.Tests/DesignCorpus/V03DesignCorpusTests.cs
@@ -91,6 +91,14 @@ public class V03DesignCorpusTests
                     Assert.Equal(expected.IsPath, argument.IsPath);
                     Assert.Equal(expected.Resolved, argument.Resolved);
                 }
+
+                if (designCase.Current.CompatibilityClause is not null)
+                {
+                    AssertCompatibilityClause(
+                        designCase.Id,
+                        designCase.Current.CompatibilityClause,
+                        actual);
+                }
             }
         }
     }
@@ -125,6 +133,7 @@ public class V03DesignCorpusTests
             Assert.Contains(SecurityInvariant.PartialTreeDiagnosticOnly, desired.SecurityInvariants);
             Assert.Empty(desired.Commands);
             Assert.Empty(desired.Compatibility.Verbs);
+            Assert.Null(desired.CompatibilityClause);
         }
         else
         {
@@ -196,6 +205,101 @@ public class V03DesignCorpusTests
                 designCase.Id,
                 desired.Argument,
                 desired.Compatibility.Verbs.Count);
+        }
+
+        if (desired.CompatibilityClause is not null)
+        {
+            ValidateCompatibilityClauseExpectation(
+                designCase.Id,
+                desired.CompatibilityClause,
+                desired.Compatibility.Verbs.Count);
+        }
+    }
+
+    private static void AssertCompatibilityClause(
+        string caseId,
+        CompatibilityClauseExpectation expected,
+        ParsedCommand actual)
+    {
+        ValidateCompatibilityClauseExpectation(caseId, expected, actual.Clauses.Count);
+        var clause = Assert.IsType<Clause>(actual.Clauses[expected.ClauseIndex]);
+
+        if (expected.ArgumentCount is not null)
+        {
+            Assert.Equal(expected.ArgumentCount.Value, clause.Args.Count);
+        }
+
+        if (expected.RedirectCount is not null)
+        {
+            Assert.Equal(expected.RedirectCount.Value, clause.Redirects.Count);
+        }
+
+        if (expected.ElementCount is not null)
+        {
+            Assert.Equal(expected.ElementCount.Value, clause.Elements.Count);
+        }
+
+        if (expected.Redirect is not null)
+        {
+            var redirect = Assert.IsType<Redirect>(clause.Redirects[expected.Redirect.RedirectIndex]);
+            Assert.Equal(expected.Redirect.Direction, redirect.Direction);
+            Assert.Equal(expected.Redirect.Target, redirect.Target);
+            Assert.Equal(expected.Redirect.IsDynamicSkip, redirect.IsDynamicSkip);
+        }
+
+        if (expected.Element is not null)
+        {
+            var element = Assert.IsType<ClauseElement>(clause.Elements[expected.Element.ElementIndex]);
+            Assert.Equal(expected.Element.Raw, element.Raw);
+            Assert.Equal(expected.Element.Value, element.Value);
+            Assert.Equal(expected.Element.Role, element.Role);
+            Assert.Equal(expected.Element.SourceStart, element.SourceStart);
+            Assert.Equal(expected.Element.SourceLength, element.SourceLength);
+            Assert.Equal(
+                expected.Element.PrecedingVerbElementCount,
+                element.PrecedingVerbElementCount);
+            Assert.Equal(expected.Element.Kind, element.Kind);
+            Assert.Equal(expected.Element.IsFlag, element.IsFlag);
+            Assert.Equal(expected.Element.IsPath, element.IsPath);
+            Assert.Equal(expected.Element.Resolved, element.Resolved);
+        }
+    }
+
+    private static void ValidateCompatibilityClauseExpectation(
+        string caseId,
+        CompatibilityClauseExpectation expected,
+        int clauseCount)
+    {
+        Assert.InRange(expected.ClauseIndex, 0, clauseCount - 1);
+
+        if (expected.ArgumentCount is not null)
+        {
+            Assert.True(expected.ArgumentCount >= 0, $"{caseId}: argument count must be non-negative.");
+        }
+
+        if (expected.RedirectCount is not null)
+        {
+            Assert.True(expected.RedirectCount >= 0, $"{caseId}: redirect count must be non-negative.");
+        }
+
+        if (expected.ElementCount is not null)
+        {
+            Assert.True(expected.ElementCount >= 0, $"{caseId}: element count must be non-negative.");
+        }
+
+        if (expected.Redirect is not null)
+        {
+            Assert.NotNull(expected.RedirectCount);
+            Assert.InRange(expected.Redirect.RedirectIndex, 0, expected.RedirectCount.Value - 1);
+            Assert.False(string.IsNullOrWhiteSpace(expected.Redirect.Target));
+        }
+
+        if (expected.Element is not null)
+        {
+            Assert.NotNull(expected.ElementCount);
+            Assert.InRange(expected.Element.ElementIndex, 0, expected.ElementCount.Value - 1);
+            Assert.False(string.IsNullOrWhiteSpace(expected.Element.Raw));
+            Assert.False(string.IsNullOrWhiteSpace(expected.Element.Value));
         }
     }
 
@@ -301,6 +405,8 @@ public sealed record CurrentBehaviorExpectation
     public string? ReasonContains { get; init; }
 
     public ArgumentExpectation? Argument { get; init; }
+
+    public CompatibilityClauseExpectation? CompatibilityClause { get; init; }
 }
 
 public sealed record ArgumentExpectation
@@ -327,6 +433,8 @@ public sealed record DesiredDesignExpectation
     public IReadOnlyList<DesignCommandExpectation> Commands { get; init; } = [];
 
     public ArgumentExpectation? Argument { get; init; }
+
+    public CompatibilityClauseExpectation? CompatibilityClause { get; init; }
 
     public CompatibilityExpectation Compatibility { get; init; } = new();
 
@@ -385,6 +493,57 @@ public sealed record CompatibilityExpectation
     public IReadOnlyList<string> Verbs { get; init; } = [];
 
     public bool PreservesAuthoredDynamicValues { get; init; }
+}
+
+public sealed record CompatibilityClauseExpectation
+{
+    public int ClauseIndex { get; init; }
+
+    public int? ArgumentCount { get; init; }
+
+    public int? RedirectCount { get; init; }
+
+    public int? ElementCount { get; init; }
+
+    public CompatibilityRedirectExpectation? Redirect { get; init; }
+
+    public CompatibilityElementExpectation? Element { get; init; }
+}
+
+public sealed record CompatibilityRedirectExpectation
+{
+    public int RedirectIndex { get; init; }
+
+    public RedirectDirection Direction { get; init; }
+
+    public string Target { get; init; } = "";
+
+    public bool IsDynamicSkip { get; init; }
+}
+
+public sealed record CompatibilityElementExpectation
+{
+    public int ElementIndex { get; init; }
+
+    public string Raw { get; init; } = "";
+
+    public string Value { get; init; } = "";
+
+    public ClauseElementRole Role { get; init; }
+
+    public int? SourceStart { get; init; }
+
+    public int? SourceLength { get; init; }
+
+    public int PrecedingVerbElementCount { get; init; }
+
+    public ArgKind Kind { get; init; }
+
+    public bool IsFlag { get; init; }
+
+    public bool IsPath { get; init; }
+
+    public string? Resolved { get; init; }
 }
 
 public sealed record DesignRedirectExpectation

--- a/tests/ShellSyntaxTree.Tests/DesignCorpus/v0.3/bash.json
+++ b/tests/ShellSyntaxTree.Tests/DesignCorpus/v0.3/bash.json
@@ -713,6 +713,375 @@
         "compatibility": { "verbs": ["echo"], "preservesAuthoredDynamicValues": false },
         "securityInvariants": ["AllCommandsVisible", "LiteralExpansionProvenancePreserved"]
       }
+    },
+    {
+      "id": "bash-runtime-special-parameter-path",
+      "concern": "Runtime special parameter punctuation cannot become a glob path",
+      "input": "cat \"$?\"",
+      "current": {
+        "isUnparseable": false,
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "\"$?\"", "kind": "Glob", "isPath": true }
+      },
+      "desired": {
+        "syntax": [
+          { "id": "root", "kind": "Block", "slot": "Root" },
+          { "id": "cat", "kind": "SimpleCommand", "parent": "root", "slot": "Statement", "commandIndex": 0 }
+        ],
+        "commands": [{
+          "authoredVerb": "cat",
+          "immediateRole": "Ordinary",
+          "ancestry": ["root"],
+          "isComplete": true,
+          "effectiveValues": [{ "sourceElement": "\"$?\"", "kind": "Unknown", "isPolicySensitive": true }]
+        }],
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "\"$?\"", "kind": "DynamicSkip", "isPath": false },
+        "compatibility": { "verbs": ["cat"], "preservesAuthoredDynamicValues": true },
+        "securityInvariants": ["AllCommandsVisible", "UnknownPolicyValueFailsClosed"]
+      },
+      "notes": "The released parser mistakes runtime $? punctuation for a quoted glob."
+    },
+    {
+      "id": "bash-runtime-positional-parameter-path",
+      "concern": "Runtime positional parameters cannot become literal paths",
+      "input": "cat \"$1\"",
+      "current": {
+        "isUnparseable": false,
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "\"$1\"", "kind": "Literal", "isPath": true, "resolved": "/work/$1" }
+      },
+      "desired": {
+        "syntax": [
+          { "id": "root", "kind": "Block", "slot": "Root" },
+          { "id": "cat", "kind": "SimpleCommand", "parent": "root", "slot": "Statement", "commandIndex": 0 }
+        ],
+        "commands": [{
+          "authoredVerb": "cat",
+          "immediateRole": "Ordinary",
+          "ancestry": ["root"],
+          "isComplete": true,
+          "effectiveValues": [{ "sourceElement": "\"$1\"", "kind": "Unknown", "isPolicySensitive": true }]
+        }],
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "\"$1\"", "kind": "DynamicSkip", "isPath": false },
+        "compatibility": { "verbs": ["cat"], "preservesAuthoredDynamicValues": true },
+        "securityInvariants": ["AllCommandsVisible", "UnknownPolicyValueFailsClosed"]
+      },
+      "notes": "The positional value depends on the runtime invocation and cannot be treated as the filename $1."
+    },
+    {
+      "id": "bash-runtime-argument-vector-boundary",
+      "concern": "Quoted dollar-at can produce zero or multiple arguments",
+      "input": "cat \"$@\"",
+      "current": {
+        "isUnparseable": false,
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "\"$@\"", "kind": "Literal", "isPath": true, "resolved": "/work/$@" }
+      },
+      "desired": {
+        "syntax": [
+          { "id": "root", "kind": "Block", "slot": "Root" },
+          { "id": "cat", "kind": "SimpleCommand", "parent": "root", "slot": "Statement", "commandIndex": 0 }
+        ],
+        "commands": [{
+          "authoredVerb": "cat",
+          "immediateRole": "Ordinary",
+          "ancestry": ["root"],
+          "isComplete": true,
+          "effectiveValues": [{ "sourceElement": "\"$@\"", "kind": "Unknown", "isPolicySensitive": true }]
+        }],
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "\"$@\"", "kind": "DynamicSkip", "isPath": false },
+        "compatibility": { "verbs": ["cat"], "preservesAuthoredDynamicValues": true },
+        "securityInvariants": ["AllCommandsVisible", "UnknownPolicyValueFailsClosed"]
+      },
+      "notes": "Quoted $@ has runtime-dependent cardinality, so one authored token cannot be claimed as one exact path."
+    },
+    {
+      "id": "bash-unterminated-braced-interpolation",
+      "concern": "An outer closing quote does not complete an open braced interpolation",
+      "input": "cat \"${HOME\"",
+      "current": { "isUnparseable": false },
+      "desired": {
+        "isUnparseable": true,
+        "syntax": [{ "id": "root", "kind": "Unsupported", "slot": "Root" }],
+        "securityInvariants": ["PartialTreeDiagnosticOnly", "UnknownPolicyValueFailsClosed"]
+      },
+      "notes": "Real Bash rejects this syntax; no exact or compatibility path may be exposed."
+    },
+    {
+      "id": "bash-adjacent-redirect-target-fragments",
+      "concern": "Adjacent escaped and quoted redirect fragments form one target",
+      "input": "echo ok > \\$HOME\".txt\"",
+      "current": {
+        "isUnparseable": false,
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "\".txt\"", "kind": "Literal", "isPath": true, "resolved": "/work/.txt" },
+        "compatibilityClause": {
+          "clauseIndex": 0,
+          "argumentCount": 1,
+          "redirectCount": 1,
+          "elementCount": 4,
+          "redirect": { "redirectIndex": 0, "direction": "Out", "target": "/home/test", "isDynamicSkip": false },
+          "element": {
+            "elementIndex": 2,
+            "raw": "> \\$HOME",
+            "value": "$HOME",
+            "role": "Redirect",
+            "sourceStart": 8,
+            "sourceLength": 8,
+            "precedingVerbElementCount": 2,
+            "kind": "Tilde",
+            "isFlag": false,
+            "isPath": true,
+            "resolved": "/home/test"
+          }
+        }
+      },
+      "desired": {
+        "syntax": [
+          { "id": "root", "kind": "Block", "slot": "Root" },
+          { "id": "echo", "kind": "SimpleCommand", "parent": "root", "slot": "Statement", "commandIndex": 0 }
+        ],
+        "commands": [{
+          "authoredVerb": "echo",
+          "immediateRole": "Ordinary",
+          "ancestry": ["root"],
+          "isComplete": true,
+          "redirects": [{
+            "operation": "FileOutput",
+            "target": { "sourceElement": "\\$HOME\".txt\"", "kind": "Exact", "values": ["$HOME.txt"], "isPolicySensitive": true },
+            "isPathRelevant": true,
+            "isComplete": true
+          }]
+        }],
+        "compatibilityClause": {
+          "clauseIndex": 0,
+          "argumentCount": 0,
+          "redirectCount": 1,
+          "elementCount": 3,
+          "redirect": { "redirectIndex": 0, "direction": "Out", "target": "/work/$HOME.txt", "isDynamicSkip": false },
+          "element": {
+            "elementIndex": 2,
+            "raw": "> \\$HOME\".txt\"",
+            "value": "$HOME.txt",
+            "role": "Redirect",
+            "sourceStart": 8,
+            "sourceLength": 14,
+            "precedingVerbElementCount": 2,
+            "kind": "Literal",
+            "isFlag": false,
+            "isPath": true,
+            "resolved": "/work/$HOME.txt"
+          }
+        },
+        "compatibility": { "verbs": ["echo"], "preservesAuthoredDynamicValues": false },
+        "securityInvariants": ["AllCommandsVisible", "LiteralExpansionProvenancePreserved", "StaticRedirectNotDynamic"]
+      },
+      "notes": "The released parser resolves the $HOME prefix as the redirect and emits the quoted suffix as an unrelated argument."
+    },
+    {
+      "id": "bash-provider-looking-unquoted-path",
+      "concern": "Bash does not interpret an unquoted PowerShell provider-looking prefix",
+      "input": "cat filesystem::/safe",
+      "current": {
+        "isUnparseable": false,
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "filesystem::/safe", "kind": "Literal", "isPath": true, "resolved": "/safe" }
+      },
+      "desired": {
+        "syntax": [
+          { "id": "root", "kind": "Block", "slot": "Root" },
+          { "id": "cat", "kind": "SimpleCommand", "parent": "root", "slot": "Statement", "commandIndex": 0 }
+        ],
+        "commands": [{
+          "authoredVerb": "cat",
+          "immediateRole": "Ordinary",
+          "ancestry": ["root"],
+          "isComplete": true,
+          "effectiveValues": [{ "sourceElement": "filesystem::/safe", "kind": "Exact", "values": ["filesystem::/safe"], "isPolicySensitive": true }]
+        }],
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "filesystem::/safe", "kind": "Literal", "isPath": true, "resolved": "/work/filesystem::/safe" },
+        "compatibility": { "verbs": ["cat"], "preservesAuthoredDynamicValues": false },
+        "securityInvariants": ["AllCommandsVisible", "LiteralExpansionProvenancePreserved", "ShellSpecificOptionSemantics"]
+      },
+      "notes": "The shared v0.2 resolver incorrectly strips a PowerShell provider prefix from Bash argv."
+    },
+    {
+      "id": "bash-provider-looking-quoted-path",
+      "concern": "Quoting does not introduce PowerShell provider semantics into Bash",
+      "input": "cat \"filesystem::/safe\"",
+      "current": {
+        "isUnparseable": false,
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "\"filesystem::/safe\"", "kind": "Literal", "isPath": true, "resolved": "/safe" }
+      },
+      "desired": {
+        "syntax": [
+          { "id": "root", "kind": "Block", "slot": "Root" },
+          { "id": "cat", "kind": "SimpleCommand", "parent": "root", "slot": "Statement", "commandIndex": 0 }
+        ],
+        "commands": [{
+          "authoredVerb": "cat",
+          "immediateRole": "Ordinary",
+          "ancestry": ["root"],
+          "isComplete": true,
+          "effectiveValues": [{ "sourceElement": "\"filesystem::/safe\"", "kind": "Exact", "values": ["filesystem::/safe"], "isPolicySensitive": true }]
+        }],
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "\"filesystem::/safe\"", "kind": "Literal", "isPath": true, "resolved": "/work/filesystem::/safe" },
+        "compatibility": { "verbs": ["cat"], "preservesAuthoredDynamicValues": false },
+        "securityInvariants": ["AllCommandsVisible", "LiteralExpansionProvenancePreserved", "ShellSpecificOptionSemantics"]
+      }
+    },
+    {
+      "id": "bash-escaped-open-brace-literal-path",
+      "concern": "An escaped interpolation start remains literal rather than incomplete",
+      "input": "cat \"\\${HOME\"",
+      "current": {
+        "isUnparseable": false,
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "\"\\${HOME\"", "kind": "DynamicSkip", "isPath": false }
+      },
+      "desired": {
+        "syntax": [
+          { "id": "root", "kind": "Block", "slot": "Root" },
+          { "id": "cat", "kind": "SimpleCommand", "parent": "root", "slot": "Statement", "commandIndex": 0 }
+        ],
+        "commands": [{
+          "authoredVerb": "cat",
+          "immediateRole": "Ordinary",
+          "ancestry": ["root"],
+          "isComplete": true,
+          "effectiveValues": [{ "sourceElement": "\"\\${HOME\"", "kind": "Exact", "values": ["${HOME"], "isPolicySensitive": true }]
+        }],
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "\"\\${HOME\"", "kind": "Literal", "isPath": true, "resolved": "/work/${HOME" },
+        "compatibility": { "verbs": ["cat"], "preservesAuthoredDynamicValues": false },
+        "securityInvariants": ["AllCommandsVisible", "LiteralExpansionProvenancePreserved"]
+      }
+    },
+    {
+      "id": "bash-unquoted-wildcard-redirect",
+      "concern": "Unquoted redirect wildcard cannot prove exactly one target",
+      "input": "echo ok > *.txt",
+      "current": {
+        "isUnparseable": false,
+        "compatibilityClause": {
+          "clauseIndex": 0,
+          "argumentCount": 0,
+          "redirectCount": 1,
+          "elementCount": 3,
+          "redirect": { "redirectIndex": 0, "direction": "Out", "target": "*.txt", "isDynamicSkip": false },
+          "element": {
+            "elementIndex": 2,
+            "raw": "> *.txt",
+            "value": "*.txt",
+            "role": "Redirect",
+            "sourceStart": 8,
+            "sourceLength": 7,
+            "precedingVerbElementCount": 2,
+            "kind": "Glob",
+            "isFlag": false,
+            "isPath": true
+          }
+        }
+      },
+      "desired": {
+        "syntax": [
+          { "id": "root", "kind": "Block", "slot": "Root" },
+          { "id": "echo", "kind": "SimpleCommand", "parent": "root", "slot": "Statement", "commandIndex": 0 }
+        ],
+        "commands": [{
+          "authoredVerb": "echo",
+          "immediateRole": "Ordinary",
+          "ancestry": ["root"],
+          "isComplete": true,
+          "redirects": [{
+            "operation": "FileOutput",
+            "target": { "sourceElement": "*.txt", "kind": "Unknown", "isPolicySensitive": true },
+            "isPathRelevant": true,
+            "isComplete": true
+          }]
+        }],
+        "compatibilityClause": {
+          "clauseIndex": 0,
+          "argumentCount": 0,
+          "redirectCount": 1,
+          "elementCount": 3,
+          "redirect": { "redirectIndex": 0, "direction": "Out", "target": "*.txt", "isDynamicSkip": true },
+          "element": {
+            "elementIndex": 2,
+            "raw": "> *.txt",
+            "value": "*.txt",
+            "role": "Redirect",
+            "sourceStart": 8,
+            "sourceLength": 7,
+            "precedingVerbElementCount": 2,
+            "kind": "DynamicSkip",
+            "isFlag": false,
+            "isPath": false
+          }
+        },
+        "compatibility": { "verbs": ["echo"], "preservesAuthoredDynamicValues": true },
+        "securityInvariants": ["AllCommandsVisible", "UnknownPolicyValueFailsClosed", "NoFilesystemEnumeration", "ShellSpecificOptionSemantics"]
+      }
+    },
+    {
+      "id": "bash-quoted-wildcard-redirect",
+      "concern": "Quoted redirect wildcard is one literal target",
+      "input": "echo ok > \"*.txt\"",
+      "current": {
+        "isUnparseable": false,
+        "compatibilityClause": {
+          "clauseIndex": 0,
+          "argumentCount": 0,
+          "redirectCount": 1,
+          "elementCount": 3,
+          "redirect": { "redirectIndex": 0, "direction": "Out", "target": "\"*.txt\"", "isDynamicSkip": false },
+          "element": {
+            "elementIndex": 2,
+            "raw": "> \"*.txt\"",
+            "value": "*.txt",
+            "role": "Redirect",
+            "sourceStart": 8,
+            "sourceLength": 9,
+            "precedingVerbElementCount": 2,
+            "kind": "Glob",
+            "isFlag": false,
+            "isPath": true
+          }
+        }
+      },
+      "desired": {
+        "syntax": [
+          { "id": "root", "kind": "Block", "slot": "Root" },
+          { "id": "echo", "kind": "SimpleCommand", "parent": "root", "slot": "Statement", "commandIndex": 0 }
+        ],
+        "commands": [{
+          "authoredVerb": "echo",
+          "immediateRole": "Ordinary",
+          "ancestry": ["root"],
+          "isComplete": true,
+          "redirects": [{
+            "operation": "FileOutput",
+            "target": { "sourceElement": "\"*.txt\"", "kind": "Exact", "values": ["*.txt"], "isPolicySensitive": true },
+            "isPathRelevant": true,
+            "isComplete": true
+          }]
+        }],
+        "compatibilityClause": {
+          "clauseIndex": 0,
+          "argumentCount": 0,
+          "redirectCount": 1,
+          "elementCount": 3,
+          "redirect": { "redirectIndex": 0, "direction": "Out", "target": "/work/*.txt", "isDynamicSkip": false },
+          "element": {
+            "elementIndex": 2,
+            "raw": "> \"*.txt\"",
+            "value": "*.txt",
+            "role": "Redirect",
+            "sourceStart": 8,
+            "sourceLength": 9,
+            "precedingVerbElementCount": 2,
+            "kind": "Literal",
+            "isFlag": false,
+            "isPath": true,
+            "resolved": "/work/*.txt"
+          }
+        },
+        "compatibility": { "verbs": ["echo"], "preservesAuthoredDynamicValues": false },
+        "securityInvariants": ["AllCommandsVisible", "LiteralExpansionProvenancePreserved", "NoFilesystemEnumeration", "ShellSpecificOptionSemantics"]
+      }
     }
   ]
 }

--- a/tests/ShellSyntaxTree.Tests/DesignCorpus/v0.3/powershell.json
+++ b/tests/ShellSyntaxTree.Tests/DesignCorpus/v0.3/powershell.json
@@ -684,6 +684,815 @@
         "compatibility": { "verbs": ["Write-Output"], "preservesAuthoredDynamicValues": false },
         "securityInvariants": ["AllCommandsVisible", "LiteralExpansionProvenancePreserved"]
       }
+    },
+    {
+      "id": "pwsh-runtime-question-parameter-path",
+      "concern": "Runtime status punctuation cannot become a glob path",
+      "input": "Get-Content \"$?\"",
+      "current": {
+        "isUnparseable": false,
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "\"$?\"", "kind": "Glob", "isPath": true }
+      },
+      "desired": {
+        "syntax": [
+          { "id": "root", "kind": "Block", "slot": "Root" },
+          { "id": "get", "kind": "SimpleCommand", "parent": "root", "slot": "Statement", "commandIndex": 0 }
+        ],
+        "commands": [{
+          "authoredVerb": "Get-Content",
+          "immediateRole": "Ordinary",
+          "ancestry": ["root"],
+          "isComplete": true,
+          "effectiveValues": [{ "sourceElement": "\"$?\"", "kind": "Unknown", "isPolicySensitive": true }]
+        }],
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "\"$?\"", "kind": "DynamicSkip", "isPath": false },
+        "compatibility": { "verbs": ["Get-Content"], "preservesAuthoredDynamicValues": true },
+        "securityInvariants": ["AllCommandsVisible", "UnknownPolicyValueFailsClosed"]
+      },
+      "notes": "The released parser mistakes runtime $? punctuation for a quoted glob."
+    },
+    {
+      "id": "pwsh-runtime-caret-parameter-path",
+      "concern": "Runtime first-token state cannot become a literal path",
+      "input": "Get-Content \"$^\"",
+      "current": {
+        "isUnparseable": false,
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "\"$^\"", "kind": "Literal", "isPath": true, "resolved": "C:/work/$^" }
+      },
+      "desired": {
+        "syntax": [
+          { "id": "root", "kind": "Block", "slot": "Root" },
+          { "id": "get", "kind": "SimpleCommand", "parent": "root", "slot": "Statement", "commandIndex": 0 }
+        ],
+        "commands": [{
+          "authoredVerb": "Get-Content",
+          "immediateRole": "Ordinary",
+          "ancestry": ["root"],
+          "isComplete": true,
+          "effectiveValues": [{ "sourceElement": "\"$^\"", "kind": "Unknown", "isPolicySensitive": true }]
+        }],
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "\"$^\"", "kind": "DynamicSkip", "isPath": false },
+        "compatibility": { "verbs": ["Get-Content"], "preservesAuthoredDynamicValues": true },
+        "securityInvariants": ["AllCommandsVisible", "UnknownPolicyValueFailsClosed"]
+      }
+    },
+    {
+      "id": "pwsh-runtime-dollar-parameter-path",
+      "concern": "Runtime last-token state cannot become a literal path",
+      "input": "Get-Content \"$$\"",
+      "current": {
+        "isUnparseable": false,
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "\"$$\"", "kind": "Literal", "isPath": true, "resolved": "C:/work/$$" }
+      },
+      "desired": {
+        "syntax": [
+          { "id": "root", "kind": "Block", "slot": "Root" },
+          { "id": "get", "kind": "SimpleCommand", "parent": "root", "slot": "Statement", "commandIndex": 0 }
+        ],
+        "commands": [{
+          "authoredVerb": "Get-Content",
+          "immediateRole": "Ordinary",
+          "ancestry": ["root"],
+          "isComplete": true,
+          "effectiveValues": [{ "sourceElement": "\"$$\"", "kind": "Unknown", "isPolicySensitive": true }]
+        }],
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "\"$$\"", "kind": "DynamicSkip", "isPath": false },
+        "compatibility": { "verbs": ["Get-Content"], "preservesAuthoredDynamicValues": true },
+        "securityInvariants": ["AllCommandsVisible", "UnknownPolicyValueFailsClosed"]
+      }
+    },
+    {
+      "id": "pwsh-runtime-numeric-variable-path",
+      "concern": "Numeric variable names remain runtime-produced",
+      "input": "Get-Content \"$1\"",
+      "current": {
+        "isUnparseable": false,
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "\"$1\"", "kind": "Literal", "isPath": true, "resolved": "C:/work/$1" }
+      },
+      "desired": {
+        "syntax": [
+          { "id": "root", "kind": "Block", "slot": "Root" },
+          { "id": "get", "kind": "SimpleCommand", "parent": "root", "slot": "Statement", "commandIndex": 0 }
+        ],
+        "commands": [{
+          "authoredVerb": "Get-Content",
+          "immediateRole": "Ordinary",
+          "ancestry": ["root"],
+          "isComplete": true,
+          "effectiveValues": [{ "sourceElement": "\"$1\"", "kind": "Unknown", "isPolicySensitive": true }]
+        }],
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "\"$1\"", "kind": "DynamicSkip", "isPath": false },
+        "compatibility": { "verbs": ["Get-Content"], "preservesAuthoredDynamicValues": true },
+        "securityInvariants": ["AllCommandsVisible", "UnknownPolicyValueFailsClosed"]
+      }
+    },
+    {
+      "id": "pwsh-runtime-unicode-variable-path",
+      "concern": "Unicode variable names remain runtime-produced",
+      "input": "Get-Content \"$é\"",
+      "current": {
+        "isUnparseable": false,
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "\"$é\"", "kind": "Literal", "isPath": true, "resolved": "C:/work/$é" }
+      },
+      "desired": {
+        "syntax": [
+          { "id": "root", "kind": "Block", "slot": "Root" },
+          { "id": "get", "kind": "SimpleCommand", "parent": "root", "slot": "Statement", "commandIndex": 0 }
+        ],
+        "commands": [{
+          "authoredVerb": "Get-Content",
+          "immediateRole": "Ordinary",
+          "ancestry": ["root"],
+          "isComplete": true,
+          "effectiveValues": [{ "sourceElement": "\"$é\"", "kind": "Unknown", "isPolicySensitive": true }]
+        }],
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "\"$é\"", "kind": "DynamicSkip", "isPath": false },
+        "compatibility": { "verbs": ["Get-Content"], "preservesAuthoredDynamicValues": true },
+        "securityInvariants": ["AllCommandsVisible", "UnknownPolicyValueFailsClosed"]
+      }
+    },
+    {
+      "id": "pwsh-unterminated-braced-interpolation",
+      "concern": "An outer closing quote does not complete an open braced interpolation",
+      "input": "Get-Content \"${HOME\"",
+      "current": { "isUnparseable": false },
+      "desired": {
+        "isUnparseable": true,
+        "syntax": [{ "id": "root", "kind": "Unsupported", "slot": "Root" }],
+        "securityInvariants": ["PartialTreeDiagnosticOnly", "UnknownPolicyValueFailsClosed"]
+      },
+      "notes": "Real PowerShell reports parser errors; no exact or compatibility path may be exposed."
+    },
+    {
+      "id": "pwsh-cmdlet-quoted-tilde-path",
+      "concern": "Cmdlet path binding interprets quoted tilde after value formation",
+      "input": "Get-Content \"~\"",
+      "current": {
+        "isUnparseable": false,
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "\"~\"", "kind": "Tilde", "isPath": true, "resolved": "C:/Users/user" }
+      },
+      "desired": {
+        "syntax": [
+          { "id": "root", "kind": "Block", "slot": "Root" },
+          { "id": "get", "kind": "SimpleCommand", "parent": "root", "slot": "Statement", "commandIndex": 0 }
+        ],
+        "commands": [{
+          "authoredVerb": "Get-Content",
+          "immediateRole": "Ordinary",
+          "ancestry": ["root"],
+          "isComplete": true,
+          "effectiveValues": [{ "sourceElement": "\"~\"", "kind": "Exact", "values": ["~"], "isPolicySensitive": true }]
+        }],
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "\"~\"", "kind": "Tilde", "isPath": true, "resolved": "C:/Users/user" },
+        "compatibility": { "verbs": ["Get-Content"], "preservesAuthoredDynamicValues": false },
+        "securityInvariants": ["AllCommandsVisible", "ShellSpecificOptionSemantics"]
+      }
+    },
+    {
+      "id": "pwsh-native-quoted-tilde-path",
+      "concern": "Quoted tilde remains literal for a native file operand",
+      "input": "curl --output \"~\" https://example.invalid",
+      "current": {
+        "isUnparseable": false,
+        "argument": { "clauseIndex": 0, "argumentIndex": 1, "raw": "\"~\"", "kind": "Tilde", "isPath": true, "resolved": "C:/Users/user" }
+      },
+      "desired": {
+        "syntax": [
+          { "id": "root", "kind": "Block", "slot": "Root" },
+          { "id": "curl", "kind": "SimpleCommand", "parent": "root", "slot": "Statement", "commandIndex": 0 }
+        ],
+        "commands": [{
+          "authoredVerb": "curl",
+          "immediateRole": "Ordinary",
+          "ancestry": ["root"],
+          "isComplete": true,
+          "effectiveValues": [{ "sourceElement": "\"~\"", "kind": "Exact", "values": ["~"], "isPolicySensitive": true }]
+        }],
+        "argument": { "clauseIndex": 0, "argumentIndex": 1, "raw": "\"~\"", "kind": "Literal", "isPath": true, "resolved": "C:/work/~" },
+        "compatibility": { "verbs": ["curl"], "preservesAuthoredDynamicValues": false },
+        "securityInvariants": ["AllCommandsVisible", "LiteralExpansionProvenancePreserved", "ShellSpecificOptionSemantics"]
+      },
+      "notes": "The shell value is identical to the cmdlet case, but the native consumer context suppresses tilde expansion because it was quoted."
+    },
+    {
+      "id": "pwsh-cmdlet-filesystem-provider-path",
+      "concern": "Cmdlet path binding applies the FileSystem provider qualifier",
+      "input": "Get-Content \"FileSystem::C:\\logs\\x.txt\"",
+      "current": {
+        "isUnparseable": false,
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "\"FileSystem::C:\\logs\\x.txt\"", "kind": "Literal", "isPath": true, "resolved": "C:/logs/x.txt" }
+      },
+      "desired": {
+        "syntax": [
+          { "id": "root", "kind": "Block", "slot": "Root" },
+          { "id": "get", "kind": "SimpleCommand", "parent": "root", "slot": "Statement", "commandIndex": 0 }
+        ],
+        "commands": [{
+          "authoredVerb": "Get-Content",
+          "immediateRole": "Ordinary",
+          "ancestry": ["root"],
+          "isComplete": true,
+          "effectiveValues": [{ "sourceElement": "\"FileSystem::C:\\logs\\x.txt\"", "kind": "Exact", "values": ["FileSystem::C:\\logs\\x.txt"], "isPolicySensitive": true }]
+        }],
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "\"FileSystem::C:\\logs\\x.txt\"", "kind": "Literal", "isPath": true, "resolved": "C:/logs/x.txt" },
+        "compatibility": { "verbs": ["Get-Content"], "preservesAuthoredDynamicValues": false },
+        "securityInvariants": ["AllCommandsVisible", "ShellSpecificOptionSemantics"]
+      }
+    },
+    {
+      "id": "pwsh-native-provider-looking-path",
+      "concern": "Native arguments do not inherit cmdlet provider semantics",
+      "input": "curl --output \"FileSystem::report.txt\" https://example.invalid",
+      "current": {
+        "isUnparseable": false,
+        "argument": { "clauseIndex": 0, "argumentIndex": 1, "raw": "\"FileSystem::report.txt\"", "kind": "Literal", "isPath": true, "resolved": "C:/work/report.txt" }
+      },
+      "desired": {
+        "syntax": [
+          { "id": "root", "kind": "Block", "slot": "Root" },
+          { "id": "curl", "kind": "SimpleCommand", "parent": "root", "slot": "Statement", "commandIndex": 0 }
+        ],
+        "commands": [{
+          "authoredVerb": "curl",
+          "immediateRole": "Ordinary",
+          "ancestry": ["root"],
+          "isComplete": true,
+          "effectiveValues": [{ "sourceElement": "\"FileSystem::report.txt\"", "kind": "Exact", "values": ["FileSystem::report.txt"], "isPolicySensitive": true }]
+        }],
+        "argument": { "clauseIndex": 0, "argumentIndex": 1, "raw": "\"FileSystem::report.txt\"", "kind": "Literal", "isPath": true, "resolved": "C:/work/FileSystem::report.txt" },
+        "compatibility": { "verbs": ["curl"], "preservesAuthoredDynamicValues": false },
+        "securityInvariants": ["AllCommandsVisible", "LiteralExpansionProvenancePreserved", "ShellSpecificOptionSemantics"]
+      },
+      "notes": "The released resolver strips FileSystem:: even though curl receives those characters literally."
+    },
+    {
+      "id": "pwsh-cmdlet-nonfilesystem-psdrive",
+      "concern": "A non-FileSystem PSDrive is not reported as a filesystem path",
+      "input": "Get-Content \"Env:\\PATH\"",
+      "current": {
+        "isUnparseable": false,
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "\"Env:\\PATH\"", "kind": "Literal", "isPath": false }
+      },
+      "desired": {
+        "syntax": [
+          { "id": "root", "kind": "Block", "slot": "Root" },
+          { "id": "get", "kind": "SimpleCommand", "parent": "root", "slot": "Statement", "commandIndex": 0 }
+        ],
+        "commands": [{
+          "authoredVerb": "Get-Content",
+          "immediateRole": "Ordinary",
+          "ancestry": ["root"],
+          "isComplete": true,
+          "effectiveValues": [{ "sourceElement": "\"Env:\\PATH\"", "kind": "Exact", "values": ["Env:\\PATH"], "isPolicySensitive": true }]
+        }],
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "\"Env:\\PATH\"", "kind": "Literal", "isPath": false },
+        "compatibility": { "verbs": ["Get-Content"], "preservesAuthoredDynamicValues": false },
+        "securityInvariants": ["AllCommandsVisible", "ShellSpecificOptionSemantics"]
+      }
+    },
+    {
+      "id": "pwsh-cmdlet-path-quoted-wildcard",
+      "concern": "Cmdlet Path binding retains wildcard semantics after quote removal",
+      "input": "Get-Content -Path \"*.txt\"",
+      "current": {
+        "isUnparseable": false,
+        "argument": { "clauseIndex": 0, "argumentIndex": 1, "raw": "\"*.txt\"", "kind": "Glob", "isPath": true }
+      },
+      "desired": {
+        "syntax": [
+          { "id": "root", "kind": "Block", "slot": "Root" },
+          { "id": "get", "kind": "SimpleCommand", "parent": "root", "slot": "Statement", "commandIndex": 0 }
+        ],
+        "commands": [{
+          "authoredVerb": "Get-Content",
+          "immediateRole": "Ordinary",
+          "ancestry": ["root"],
+          "isComplete": true,
+          "effectiveValues": [{ "sourceElement": "\"*.txt\"", "kind": "Exact", "values": ["*.txt"], "isPolicySensitive": true }]
+        }],
+        "argument": { "clauseIndex": 0, "argumentIndex": 1, "raw": "\"*.txt\"", "kind": "Glob", "isPath": true },
+        "compatibility": { "verbs": ["Get-Content"], "preservesAuthoredDynamicValues": false },
+        "securityInvariants": ["AllCommandsVisible", "NoFilesystemEnumeration", "ShellSpecificOptionSemantics"]
+      }
+    },
+    {
+      "id": "pwsh-cmdlet-literalpath-quoted-wildcard",
+      "concern": "Cmdlet LiteralPath binding suppresses wildcard semantics",
+      "input": "Get-Content -LiteralPath \"*.txt\"",
+      "current": {
+        "isUnparseable": false,
+        "argument": { "clauseIndex": 0, "argumentIndex": 1, "raw": "\"*.txt\"", "kind": "Glob", "isPath": true }
+      },
+      "desired": {
+        "syntax": [
+          { "id": "root", "kind": "Block", "slot": "Root" },
+          { "id": "get", "kind": "SimpleCommand", "parent": "root", "slot": "Statement", "commandIndex": 0 }
+        ],
+        "commands": [{
+          "authoredVerb": "Get-Content",
+          "immediateRole": "Ordinary",
+          "ancestry": ["root"],
+          "isComplete": true,
+          "effectiveValues": [{ "sourceElement": "\"*.txt\"", "kind": "Exact", "values": ["*.txt"], "isPolicySensitive": true }]
+        }],
+        "argument": { "clauseIndex": 0, "argumentIndex": 1, "raw": "\"*.txt\"", "kind": "Literal", "isPath": true, "resolved": "C:/work/*.txt" },
+        "compatibility": { "verbs": ["Get-Content"], "preservesAuthoredDynamicValues": false },
+        "securityInvariants": ["AllCommandsVisible", "NoFilesystemEnumeration", "ShellSpecificOptionSemantics"]
+      },
+      "notes": "The released parser collapses -Path and -LiteralPath into the same glob classification."
+    },
+    {
+      "id": "pwsh-native-quoted-wildcard-path",
+      "concern": "Quoted wildcard remains literal for a native file operand",
+      "input": "curl --output \"*.txt\" https://example.invalid",
+      "current": {
+        "isUnparseable": false,
+        "argument": { "clauseIndex": 0, "argumentIndex": 1, "raw": "\"*.txt\"", "kind": "Glob", "isPath": true }
+      },
+      "desired": {
+        "syntax": [
+          { "id": "root", "kind": "Block", "slot": "Root" },
+          { "id": "curl", "kind": "SimpleCommand", "parent": "root", "slot": "Statement", "commandIndex": 0 }
+        ],
+        "commands": [{
+          "authoredVerb": "curl",
+          "immediateRole": "Ordinary",
+          "ancestry": ["root"],
+          "isComplete": true,
+          "effectiveValues": [{ "sourceElement": "\"*.txt\"", "kind": "Exact", "values": ["*.txt"], "isPolicySensitive": true }]
+        }],
+        "argument": { "clauseIndex": 0, "argumentIndex": 1, "raw": "\"*.txt\"", "kind": "Literal", "isPath": true, "resolved": "C:/work/*.txt" },
+        "compatibility": { "verbs": ["curl"], "preservesAuthoredDynamicValues": false },
+        "securityInvariants": ["AllCommandsVisible", "LiteralExpansionProvenancePreserved", "NoFilesystemEnumeration", "ShellSpecificOptionSemantics"]
+      }
+    },
+    {
+      "id": "pwsh-adjacent-redirect-target-fragments",
+      "concern": "Adjacent escaped and quoted redirect fragments form one target",
+      "input": "Write-Output ok > `$HOME\".txt\"",
+      "current": {
+        "isUnparseable": false,
+        "argument": { "clauseIndex": 0, "argumentIndex": 1, "raw": "\".txt\"", "kind": "Literal", "isPath": true, "resolved": "C:/work/.txt" },
+        "compatibilityClause": {
+          "clauseIndex": 0,
+          "argumentCount": 2,
+          "redirectCount": 1,
+          "elementCount": 4,
+          "redirect": { "redirectIndex": 0, "direction": "Out", "target": "C:/Users/user", "isDynamicSkip": false },
+          "element": {
+            "elementIndex": 2,
+            "raw": "> `$HOME",
+            "value": "$HOME",
+            "role": "Redirect",
+            "sourceStart": 16,
+            "sourceLength": 8,
+            "precedingVerbElementCount": 1,
+            "kind": "Tilde",
+            "isFlag": false,
+            "isPath": true,
+            "resolved": "C:/Users/user"
+          }
+        }
+      },
+      "desired": {
+        "syntax": [
+          { "id": "root", "kind": "Block", "slot": "Root" },
+          { "id": "write", "kind": "SimpleCommand", "parent": "root", "slot": "Statement", "commandIndex": 0 }
+        ],
+        "commands": [{
+          "authoredVerb": "Write-Output",
+          "immediateRole": "Ordinary",
+          "ancestry": ["root"],
+          "isComplete": true,
+          "redirects": [{
+            "operation": "FileOutput",
+            "target": { "sourceElement": "`$HOME\".txt\"", "kind": "Exact", "values": ["$HOME.txt"], "isPolicySensitive": true },
+            "isPathRelevant": true,
+            "isComplete": true
+          }]
+        }],
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "ok", "kind": "Literal", "isPath": false },
+        "compatibilityClause": {
+          "clauseIndex": 0,
+          "argumentCount": 1,
+          "redirectCount": 1,
+          "elementCount": 3,
+          "redirect": { "redirectIndex": 0, "direction": "Out", "target": "C:/work/$HOME.txt", "isDynamicSkip": false },
+          "element": {
+            "elementIndex": 2,
+            "raw": "> `$HOME\".txt\"",
+            "value": "$HOME.txt",
+            "role": "Redirect",
+            "sourceStart": 16,
+            "sourceLength": 14,
+            "precedingVerbElementCount": 1,
+            "kind": "Literal",
+            "isFlag": false,
+            "isPath": true,
+            "resolved": "C:/work/$HOME.txt"
+          }
+        },
+        "compatibility": { "verbs": ["Write-Output"], "preservesAuthoredDynamicValues": false },
+        "securityInvariants": ["AllCommandsVisible", "LiteralExpansionProvenancePreserved", "StaticRedirectNotDynamic"]
+      },
+      "notes": "The released parser resolves the $HOME prefix as the redirect and emits the quoted suffix as an unrelated argument."
+    },
+    {
+      "id": "pwsh-native-unquoted-tilde-path",
+      "concern": "Unquoted tilde remains eligible for native expansion",
+      "input": "curl --output ~ https://example.invalid",
+      "current": {
+        "isUnparseable": false,
+        "argument": { "clauseIndex": 0, "argumentIndex": 1, "raw": "~", "kind": "Tilde", "isPath": true, "resolved": "C:/Users/user" }
+      },
+      "desired": {
+        "syntax": [
+          { "id": "root", "kind": "Block", "slot": "Root" },
+          { "id": "curl", "kind": "SimpleCommand", "parent": "root", "slot": "Statement", "commandIndex": 0 }
+        ],
+        "commands": [{
+          "authoredVerb": "curl",
+          "immediateRole": "Ordinary",
+          "ancestry": ["root"],
+          "isComplete": true,
+          "effectiveValues": [{ "sourceElement": "~", "kind": "Exact", "values": ["C:/Users/user"], "isPolicySensitive": true }]
+        }],
+        "argument": { "clauseIndex": 0, "argumentIndex": 1, "raw": "~", "kind": "Tilde", "isPath": true, "resolved": "C:/Users/user" },
+        "compatibility": { "verbs": ["curl"], "preservesAuthoredDynamicValues": false },
+        "securityInvariants": ["AllCommandsVisible", "ShellSpecificOptionSemantics"]
+      }
+    },
+    {
+      "id": "pwsh-native-unquoted-wildcard-path",
+      "concern": "Unquoted native wildcard remains dynamic without enumeration",
+      "input": "curl --output *.txt https://example.invalid",
+      "current": {
+        "isUnparseable": false,
+        "argument": { "clauseIndex": 0, "argumentIndex": 1, "raw": "*.txt", "kind": "Glob", "isPath": true }
+      },
+      "desired": {
+        "syntax": [
+          { "id": "root", "kind": "Block", "slot": "Root" },
+          { "id": "curl", "kind": "SimpleCommand", "parent": "root", "slot": "Statement", "commandIndex": 0 }
+        ],
+        "commands": [{
+          "authoredVerb": "curl",
+          "immediateRole": "Ordinary",
+          "ancestry": ["root"],
+          "isComplete": true,
+          "effectiveValues": [{ "sourceElement": "*.txt", "kind": "Unknown", "isPolicySensitive": true }]
+        }],
+        "argument": { "clauseIndex": 0, "argumentIndex": 1, "raw": "*.txt", "kind": "Glob", "isPath": true },
+        "compatibility": { "verbs": ["curl"], "preservesAuthoredDynamicValues": true },
+        "securityInvariants": ["AllCommandsVisible", "UnknownPolicyValueFailsClosed", "NoFilesystemEnumeration", "ShellSpecificOptionSemantics"]
+      }
+    },
+    {
+      "id": "pwsh-cmdlet-literalpath-quoted-tilde",
+      "concern": "LiteralPath still applies quoted tilde semantics",
+      "input": "Get-Content -LiteralPath \"~\"",
+      "current": {
+        "isUnparseable": false,
+        "argument": { "clauseIndex": 0, "argumentIndex": 1, "raw": "\"~\"", "kind": "Tilde", "isPath": true, "resolved": "C:/Users/user" }
+      },
+      "desired": {
+        "syntax": [
+          { "id": "root", "kind": "Block", "slot": "Root" },
+          { "id": "get", "kind": "SimpleCommand", "parent": "root", "slot": "Statement", "commandIndex": 0 }
+        ],
+        "commands": [{
+          "authoredVerb": "Get-Content",
+          "immediateRole": "Ordinary",
+          "ancestry": ["root"],
+          "isComplete": true,
+          "effectiveValues": [{ "sourceElement": "\"~\"", "kind": "Exact", "values": ["~"], "isPolicySensitive": true }]
+        }],
+        "argument": { "clauseIndex": 0, "argumentIndex": 1, "raw": "\"~\"", "kind": "Tilde", "isPath": true, "resolved": "C:/Users/user" },
+        "compatibility": { "verbs": ["Get-Content"], "preservesAuthoredDynamicValues": false },
+        "securityInvariants": ["AllCommandsVisible", "ShellSpecificOptionSemantics"]
+      }
+    },
+    {
+      "id": "pwsh-cmdlet-literalpath-provider",
+      "concern": "LiteralPath still applies a FileSystem provider qualifier",
+      "input": "Get-Content -LiteralPath \"FileSystem::C:\\logs\\x.txt\"",
+      "current": {
+        "isUnparseable": false,
+        "argument": { "clauseIndex": 0, "argumentIndex": 1, "raw": "\"FileSystem::C:\\logs\\x.txt\"", "kind": "Literal", "isPath": true, "resolved": "C:/logs/x.txt" }
+      },
+      "desired": {
+        "syntax": [
+          { "id": "root", "kind": "Block", "slot": "Root" },
+          { "id": "get", "kind": "SimpleCommand", "parent": "root", "slot": "Statement", "commandIndex": 0 }
+        ],
+        "commands": [{
+          "authoredVerb": "Get-Content",
+          "immediateRole": "Ordinary",
+          "ancestry": ["root"],
+          "isComplete": true,
+          "effectiveValues": [{ "sourceElement": "\"FileSystem::C:\\logs\\x.txt\"", "kind": "Exact", "values": ["FileSystem::C:\\logs\\x.txt"], "isPolicySensitive": true }]
+        }],
+        "argument": { "clauseIndex": 0, "argumentIndex": 1, "raw": "\"FileSystem::C:\\logs\\x.txt\"", "kind": "Literal", "isPath": true, "resolved": "C:/logs/x.txt" },
+        "compatibility": { "verbs": ["Get-Content"], "preservesAuthoredDynamicValues": false },
+        "securityInvariants": ["AllCommandsVisible", "ShellSpecificOptionSemantics"]
+      }
+    },
+    {
+      "id": "pwsh-escaped-open-brace-literal-path",
+      "concern": "An escaped interpolation start remains literal rather than incomplete",
+      "input": "Get-Content \"`${HOME\"",
+      "current": {
+        "isUnparseable": false,
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "\"`${HOME\"", "kind": "DynamicSkip", "isPath": false }
+      },
+      "desired": {
+        "syntax": [
+          { "id": "root", "kind": "Block", "slot": "Root" },
+          { "id": "get", "kind": "SimpleCommand", "parent": "root", "slot": "Statement", "commandIndex": 0 }
+        ],
+        "commands": [{
+          "authoredVerb": "Get-Content",
+          "immediateRole": "Ordinary",
+          "ancestry": ["root"],
+          "isComplete": true,
+          "effectiveValues": [{ "sourceElement": "\"`${HOME\"", "kind": "Exact", "values": ["${HOME"], "isPolicySensitive": true }]
+        }],
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "\"`${HOME\"", "kind": "Literal", "isPath": true, "resolved": "C:/work/${HOME" },
+        "compatibility": { "verbs": ["Get-Content"], "preservesAuthoredDynamicValues": false },
+        "securityInvariants": ["AllCommandsVisible", "LiteralExpansionProvenancePreserved"]
+      }
+    },
+    {
+      "id": "pwsh-redirect-quoted-tilde",
+      "concern": "PowerShell redirect applies tilde semantics after quote removal",
+      "input": "Write-Output ok > \"~\"",
+      "current": {
+        "isUnparseable": false,
+        "compatibilityClause": {
+          "clauseIndex": 0,
+          "argumentCount": 1,
+          "redirectCount": 1,
+          "elementCount": 3,
+          "redirect": { "redirectIndex": 0, "direction": "Out", "target": "C:/Users/user", "isDynamicSkip": false },
+          "element": {
+            "elementIndex": 2,
+            "raw": "> \"~\"",
+            "value": "~",
+            "role": "Redirect",
+            "sourceStart": 16,
+            "sourceLength": 5,
+            "precedingVerbElementCount": 1,
+            "kind": "Tilde",
+            "isFlag": false,
+            "isPath": true,
+            "resolved": "C:/Users/user"
+          }
+        }
+      },
+      "desired": {
+        "syntax": [
+          { "id": "root", "kind": "Block", "slot": "Root" },
+          { "id": "write", "kind": "SimpleCommand", "parent": "root", "slot": "Statement", "commandIndex": 0 }
+        ],
+        "commands": [{
+          "authoredVerb": "Write-Output",
+          "immediateRole": "Ordinary",
+          "ancestry": ["root"],
+          "isComplete": true,
+          "redirects": [{
+            "operation": "FileOutput",
+            "target": { "sourceElement": "\"~\"", "kind": "Exact", "values": ["C:/Users/user"], "isPolicySensitive": true },
+            "isPathRelevant": true,
+            "isComplete": true
+          }]
+        }],
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "ok", "kind": "Literal", "isPath": false },
+        "compatibilityClause": {
+          "clauseIndex": 0,
+          "argumentCount": 1,
+          "redirectCount": 1,
+          "elementCount": 3,
+          "redirect": { "redirectIndex": 0, "direction": "Out", "target": "C:/Users/user", "isDynamicSkip": false },
+          "element": {
+            "elementIndex": 2,
+            "raw": "> \"~\"",
+            "value": "~",
+            "role": "Redirect",
+            "sourceStart": 16,
+            "sourceLength": 5,
+            "precedingVerbElementCount": 1,
+            "kind": "Tilde",
+            "isFlag": false,
+            "isPath": true,
+            "resolved": "C:/Users/user"
+          }
+        },
+        "compatibility": { "verbs": ["Write-Output"], "preservesAuthoredDynamicValues": false },
+        "securityInvariants": ["AllCommandsVisible", "ShellSpecificOptionSemantics"]
+      }
+    },
+    {
+      "id": "pwsh-redirect-quoted-wildcard",
+      "concern": "PowerShell redirect wildcard remains unknown even when quoted",
+      "input": "Write-Output ok > \"*.txt\"",
+      "current": {
+        "isUnparseable": false,
+        "compatibilityClause": {
+          "clauseIndex": 0,
+          "argumentCount": 1,
+          "redirectCount": 1,
+          "elementCount": 3,
+          "redirect": { "redirectIndex": 0, "direction": "Out", "target": "\"*.txt\"", "isDynamicSkip": false },
+          "element": {
+            "elementIndex": 2,
+            "raw": "> \"*.txt\"",
+            "value": "*.txt",
+            "role": "Redirect",
+            "sourceStart": 16,
+            "sourceLength": 9,
+            "precedingVerbElementCount": 1,
+            "kind": "Glob",
+            "isFlag": false,
+            "isPath": true
+          }
+        }
+      },
+      "desired": {
+        "syntax": [
+          { "id": "root", "kind": "Block", "slot": "Root" },
+          { "id": "write", "kind": "SimpleCommand", "parent": "root", "slot": "Statement", "commandIndex": 0 }
+        ],
+        "commands": [{
+          "authoredVerb": "Write-Output",
+          "immediateRole": "Ordinary",
+          "ancestry": ["root"],
+          "isComplete": true,
+          "redirects": [{
+            "operation": "FileOutput",
+            "target": { "sourceElement": "\"*.txt\"", "kind": "Unknown", "isPolicySensitive": true },
+            "isPathRelevant": true,
+            "isComplete": true
+          }]
+        }],
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "ok", "kind": "Literal", "isPath": false },
+        "compatibilityClause": {
+          "clauseIndex": 0,
+          "argumentCount": 1,
+          "redirectCount": 1,
+          "elementCount": 3,
+          "redirect": { "redirectIndex": 0, "direction": "Out", "target": "\"*.txt\"", "isDynamicSkip": true },
+          "element": {
+            "elementIndex": 2,
+            "raw": "> \"*.txt\"",
+            "value": "*.txt",
+            "role": "Redirect",
+            "sourceStart": 16,
+            "sourceLength": 9,
+            "precedingVerbElementCount": 1,
+            "kind": "DynamicSkip",
+            "isFlag": false,
+            "isPath": false
+          }
+        },
+        "compatibility": { "verbs": ["Write-Output"], "preservesAuthoredDynamicValues": true },
+        "securityInvariants": ["AllCommandsVisible", "UnknownPolicyValueFailsClosed", "NoFilesystemEnumeration", "ShellSpecificOptionSemantics"]
+      }
+    },
+    {
+      "id": "pwsh-redirect-filesystem-provider",
+      "concern": "PowerShell redirect applies a FileSystem provider qualifier",
+      "input": "Write-Output ok > \"FileSystem::C:\\logs\\x.txt\"",
+      "current": {
+        "isUnparseable": false,
+        "compatibilityClause": {
+          "clauseIndex": 0,
+          "argumentCount": 1,
+          "redirectCount": 1,
+          "elementCount": 3,
+          "redirect": { "redirectIndex": 0, "direction": "Out", "target": "C:/logs/x.txt", "isDynamicSkip": false },
+          "element": {
+            "elementIndex": 2,
+            "raw": "> \"FileSystem::C:\\logs\\x.txt\"",
+            "value": "FileSystem::C:\\logs\\x.txt",
+            "role": "Redirect",
+            "sourceStart": 16,
+            "sourceLength": 29,
+            "precedingVerbElementCount": 1,
+            "kind": "Literal",
+            "isFlag": false,
+            "isPath": true,
+            "resolved": "C:/logs/x.txt"
+          }
+        }
+      },
+      "desired": {
+        "syntax": [
+          { "id": "root", "kind": "Block", "slot": "Root" },
+          { "id": "write", "kind": "SimpleCommand", "parent": "root", "slot": "Statement", "commandIndex": 0 }
+        ],
+        "commands": [{
+          "authoredVerb": "Write-Output",
+          "immediateRole": "Ordinary",
+          "ancestry": ["root"],
+          "isComplete": true,
+          "redirects": [{
+            "operation": "FileOutput",
+            "target": { "sourceElement": "\"FileSystem::C:\\logs\\x.txt\"", "kind": "Exact", "values": ["C:/logs/x.txt"], "isPolicySensitive": true },
+            "isPathRelevant": true,
+            "isComplete": true
+          }]
+        }],
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "ok", "kind": "Literal", "isPath": false },
+        "compatibilityClause": {
+          "clauseIndex": 0,
+          "argumentCount": 1,
+          "redirectCount": 1,
+          "elementCount": 3,
+          "redirect": { "redirectIndex": 0, "direction": "Out", "target": "C:/logs/x.txt", "isDynamicSkip": false },
+          "element": {
+            "elementIndex": 2,
+            "raw": "> \"FileSystem::C:\\logs\\x.txt\"",
+            "value": "FileSystem::C:\\logs\\x.txt",
+            "role": "Redirect",
+            "sourceStart": 16,
+            "sourceLength": 29,
+            "precedingVerbElementCount": 1,
+            "kind": "Literal",
+            "isFlag": false,
+            "isPath": true,
+            "resolved": "C:/logs/x.txt"
+          }
+        },
+        "compatibility": { "verbs": ["Write-Output"], "preservesAuthoredDynamicValues": false },
+        "securityInvariants": ["AllCommandsVisible", "ShellSpecificOptionSemantics"]
+      }
+    },
+    {
+      "id": "pwsh-redirect-unknown-psdrive",
+      "concern": "PowerShell redirect cannot guess an unproved PSDrive provider mapping",
+      "input": "Write-Output ok > \"ZZ:\\drive.txt\"",
+      "current": {
+        "isUnparseable": false,
+        "compatibilityClause": {
+          "clauseIndex": 0,
+          "argumentCount": 1,
+          "redirectCount": 1,
+          "elementCount": 3,
+          "redirect": { "redirectIndex": 0, "direction": "Out", "target": "\"ZZ:\\drive.txt\"", "isDynamicSkip": false },
+          "element": {
+            "elementIndex": 2,
+            "raw": "> \"ZZ:\\drive.txt\"",
+            "value": "ZZ:\\drive.txt",
+            "role": "Redirect",
+            "sourceStart": 16,
+            "sourceLength": 17,
+            "precedingVerbElementCount": 1,
+            "kind": "Literal",
+            "isFlag": false,
+            "isPath": false
+          }
+        }
+      },
+      "desired": {
+        "syntax": [
+          { "id": "root", "kind": "Block", "slot": "Root" },
+          { "id": "write", "kind": "SimpleCommand", "parent": "root", "slot": "Statement", "commandIndex": 0 }
+        ],
+        "commands": [{
+          "authoredVerb": "Write-Output",
+          "immediateRole": "Ordinary",
+          "ancestry": ["root"],
+          "isComplete": true,
+          "redirects": [{
+            "operation": "FileOutput",
+            "target": { "sourceElement": "\"ZZ:\\drive.txt\"", "kind": "Unknown", "isPolicySensitive": true },
+            "isPathRelevant": true,
+            "isComplete": true
+          }]
+        }],
+        "argument": { "clauseIndex": 0, "argumentIndex": 0, "raw": "ok", "kind": "Literal", "isPath": false },
+        "compatibilityClause": {
+          "clauseIndex": 0,
+          "argumentCount": 1,
+          "redirectCount": 1,
+          "elementCount": 3,
+          "redirect": { "redirectIndex": 0, "direction": "Out", "target": "\"ZZ:\\drive.txt\"", "isDynamicSkip": true },
+          "element": {
+            "elementIndex": 2,
+            "raw": "> \"ZZ:\\drive.txt\"",
+            "value": "ZZ:\\drive.txt",
+            "role": "Redirect",
+            "sourceStart": 16,
+            "sourceLength": 17,
+            "precedingVerbElementCount": 1,
+            "kind": "DynamicSkip",
+            "isFlag": false,
+            "isPath": false
+          }
+        },
+        "compatibility": { "verbs": ["Write-Output"], "preservesAuthoredDynamicValues": true },
+        "securityInvariants": ["AllCommandsVisible", "UnknownPolicyValueFailsClosed", "ShellSpecificOptionSemantics"]
+      }
     }
   ]
 }


### PR DESCRIPTION
## Why

Implementation exposed that the original Literal / Expandable / Opaque fragment bit was too coarse for shell-accurate, fail-closed resolution. This amendment stops the flawed implementation path and specifies the missing distinctions before production code lands.

## What changed

- separates fragment kind, lexical transform eligibility, typed expansion identity/cardinality, opaque cause, and consumer context
- distinguishes Bash arguments and redirects from PowerShell native arguments, cmdlet Path/LiteralPath parameters, and redirects
- permits narrow compatibility corrections only where shell-oracle evidence proves the old exact/path classification false
- aggregates adjacent redirect fragments into one compatibility target
- expands the design corpus to 34 Bash and 47 PowerShell cases
- pins compatibility-leaf argument, redirect, element, value, span, path, and resolution expectations
- records real Bash 5.2 and PowerShell 7.6 oracle behavior

There are no production-code or public-API changes in this PR.

## Validation

- `dotnet build -c Release`
- `dotnet test -c Release --no-build` (1,019 tests)
- `openspec validate v0-3-structured-shell-analysis --strict`
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`
- `dotnet format ... --verify-no-changes` for the changed C# file
- `slopwatch analyze -d . --hook --no-baseline`
- `git diff --check`

A dedicated adversarial design review concluded **GO**, with no blocking or medium findings and no need for a larger public API redesign before implementation.