### PR TITLE
Implement Bash loop effective cwd transfers

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -283,35 +283,21 @@ priorities.
       leaves preserve authored dynamic operands. Loop binding and cwd
       mutation fail closed, loops reached after recognized prior shell-state
       mutation fail closed, and occurrence cwd remains Unknown.
-- [ ] Design and implement structure-aware Bash abstract-state analysis before
-      enabling cwd-changing loop bodies or claiming the complete `for ... in`
-      vertical slice. The parse-order attribution model cannot soundly publish
-      occurrence cwd across pipelines, conditional lists, substitutions, and
-      repeated iterations. The design now requires internal success/failure
-      flow partitions, failure-aware `cd`, conservative `lastpipe` / `pipefail`,
-      ordered duplicate-preserving loop plans, inherited but isolated
-      decoded-wrapper state, and dynamic fail-closed compatibility attribution
-      whenever cwd joins to Unknown. The analyzer now owns persistent loop
-      bindings, ordered and empty iteration, occurrence-fact joins, unreachable
-      flow partitions, substitution inheritance, and explicit decoded-wrapper
-      remapping of loop plans and argument provenance. Unknown-cardinality
-      loops use bounded fixed-point widening, and a 4096-transition global
-      budget fails nested cross-products atomically. Static bodies retain an
-      exact incoming cwd when no transfer can change it. Keep OpenSpec task 6.5
-      open for full effective-argv transfer and removal of the temporary loop
-      mutation rejection, then add the Netclaw approval matrix. An adversarial
-      pre-implementation review halted the first loop-state draft: parser-time
-      binding frames could not model zero-iteration persistence, correlated
-      nested iterables, special Bash variables, or candidate-derived `cd`
-      options. The corrected contract now requires an explicit
-      `BashInitialStateMode`, a conservative supported scalar-name boundary,
-      analyzer-owned persistent bindings, parameterized ordered plans, complete
-      argument provenance/effective-argv transfer, occurrence-fact joins, and
-      unreachable flow partitions. Implement that contract before enabling any
-      cwd-changing loop body. Corpus-pin `HOME`, `RANDOM`, `LINENO`, `PATH`,
-      `CDPATH`, `IFS`, 32/33 ordered visits, zero iterations, nested
-      correlation, wrapped transfers, wrapper mapping, substitutions, and
-      pipelines across these two analyzer slices.
+- [x] Design and implement structure-aware Bash abstract-state analysis for the
+      complete bounded `for ... in` state slice. The analyzer owns
+      success/failure partitions, failure-aware cwd transfer, conservative
+      pipeline state, ordered duplicate-preserving loop plans, persistent loop
+      bindings, empty iteration, occurrence-fact joins, substitution isolation,
+      and explicit decoded-wrapper remapping. Unknown-cardinality loops use
+      bounded fixed-point widening, a 4096-transition global budget fails nested
+      cross-products atomically, and complete effective argv is re-evaluated for
+      every visit. Loop-derived `cd` options, terminators, invalid/multiple
+      operands, recursive exact `command` / `builtin` dispatch, physical-path
+      compatibility sanitation, and post-loop binding mutation are pinned by
+      unit tests, native Bash oracles, the design corpus, and executable corpus.
+      All unmodeled mutations, dynamic dispatch, and control transfers remain
+      fail closed. Next add the Netclaw approval matrix before calling the Bash
+      consumer integration complete.
 - [ ] Complete PowerShell `$()` discovery in `foreach` expressions and add the
       Netclaw approval-matrix cases. The simple-command slice is delivered for
       ordinary, adjacent, quoted, here-string, redirect, standalone,

--- a/openspec/changes/v0-3-structured-shell-analysis/design.md
+++ b/openspec/changes/v0-3-structured-shell-analysis/design.md
@@ -526,6 +526,19 @@ required for `cd "$f"`: a candidate may be `-P`, `--`, `-`, or an operand even
 though the authored expansion was not lexed as an option. Operand-only string
 substitution is not an acceptable shortcut.
 
+Static dispatch is interpreted from the same ordered element stream. Exact
+`command -p`, `command --`, and `builtin --` wrappers may recurse to `cd` or
+`chdir`; `command -v` / `-V` is a nonmutating query. Invalid or dynamic wrapper
+grammar does not dispatch. If a rebound physical option changes which authored
+element is the operand, every compatibility resolution made unsafe by that
+visit is cleared by element coordinate in both `Clause.Args` and
+`Clause.Elements`. The first operand ends option recognition; every later word
+is a second operand and therefore an exact failure. Unknown quoted one-word
+values may conservatively produce unknown cwd on success, but unquoted field
+splitting or globbing of a tracked loop binding leaves argv cardinality
+unproved and fails the region atomically. Ambient dynamic values retain the
+older compatibility contract's conservative unknown-state behavior.
+
 An unreachable success or failure partition stays unreachable. `&&` and `||`
 must not replace a missing input partition with `JoinedState` to manufacture
 facts for a structurally present but unreachable continuation. Such commands

--- a/openspec/changes/v0-3-structured-shell-analysis/specs/bounded-shell-analysis/spec.md
+++ b/openspec/changes/v0-3-structured-shell-analysis/specs/bounded-shell-analysis/spec.md
@@ -319,7 +319,18 @@ argument's complete shell-value provenance for each concrete visit. Effective
 argument facts at one authored occurrence SHALL join across reachable visits.
 State transfers such as `cd` SHALL parse the complete effective argv, including
 candidate-derived options and option terminators, rather than substituting only
-an operand. A transfer such as `break`, `continue`, `return`, `exit`, or `exec`,
+an operand. Exact `command` options `-p` and `--` and the exact `builtin --`
+delimiter SHALL be recursively unwrapped; `command -v` / `-V` SHALL remain a
+nonmutating query, while invalid or dynamic wrapper grammar SHALL fail closed.
+When effective option grammar makes an authored path resolution unsafe, the
+compatibility `Arg` and corresponding `ClauseElement` resolutions SHALL both be
+cleared without rewriting their authored spelling or flag classification.
+Option recognition SHALL stop at the first operand. An exact invalid option or
+second operand SHALL have no success partition, and a tracked loop-binding
+expansion whose argv cardinality is not proved SHALL make the containing region
+unparseable. Ambient dynamic values retain the compatibility contract's
+conservative unknown-state behavior. A
+transfer such as `break`, `continue`, `return`, `exit`, or `exec`,
 including recursively wrapped builtin forms, SHALL make the containing region
 unparseable until the analyzer implements that transfer explicitly. `eval`,
 `source` / `.`, execution-bearing `trap`, and mutation of tracked bindings
@@ -387,6 +398,23 @@ partition merely to publish exact continuation facts.
 - **THEN** the first visit treats `-P` as a `cd` option rather than a path operand
 - **THEN** the second visit treats `/tmp` as the operand under the resulting option grammar
 - **THEN** no state transfer reuses the authored `$f` flag classification
+
+#### Scenario: Loop-derived physical option sanitizes compatibility paths
+- **WHEN** isolated-mode Bash analyzes `for f in -P; do cd "$f" ./sub && cat file.txt; done`
+- **THEN** the effective argv is `cd -P ./sub`
+- **THEN** both compatibility projections clear the authored `/work/sub` resolution
+- **THEN** the reached `cat` has unknown cwd and no exact relative-path resolution
+- **WHEN** the loop candidate is `--` instead
+- **THEN** `./sub` remains the exact logical operand and the reached path resolves under `/work/sub`
+
+#### Scenario: Exact dispatch wrappers preserve cwd transfer grammar
+- **WHEN** a loop body invokes `command -p -- builtin -- cd "$f"`
+- **THEN** the analyzer recursively proves the wrapper grammar
+- **THEN** it interprets only the words after `cd` as the effective transfer argv
+- **WHEN** `command -v` or `command -V` is used
+- **THEN** the wrapper is a query and does not mutate cwd
+- **WHEN** a wrapper option is invalid or dynamic
+- **THEN** the loop remains fail closed
 
 #### Scenario: Empty-loop failure continuation is unreachable
 - **WHEN** isolated-mode Bash parses `for f in; do false; done || cat relative.txt`

--- a/openspec/changes/v0-3-structured-shell-analysis/tasks.md
+++ b/openspec/changes/v0-3-structured-shell-analysis/tasks.md
@@ -95,15 +95,16 @@
       wrapper provenance in unit tests and the Bash corpus. Use bounded
       fixed-point widening for unknown cardinality and fail atomically after
       4096 total loop-body transitions.
-    - [ ] 6.5c.3 Re-parse each visit's complete effective argv for state
+    - [x] 6.5c.3 Re-parse each visit's complete effective argv for state
       transfers, including loop-derived `cd` options and wrapped dispatch;
       carry those transfers through the bounded fixed point, then remove only
       the temporary mutation rejections whose transfers are fully modeled.
   - The analyzer now publishes exact incoming cwd for reached loop occurrences
-    when no modeled transfer can disagree. It still rejects loop shell-state
-    mutation, nested active-binding reuse, and loops reached after recognized
-    prior shell-state mutation until 6.5c.3 reclassifies complete effective argv
-    and models the corresponding repeated transfers.
+    when no modeled transfer can disagree. Complete effective `cd` argv,
+    recursive exact `command` / `builtin` dispatch, failure-only invalid forms,
+    physical-path sanitation, and persistent post-loop binding protection are
+    implemented. It still rejects every unmodeled shell-state mutation,
+    control transfer, nested active-binding reuse, and dynamic dispatch.
 - [ ] 6.6 Cover empty iterables, separators, multiline bodies, redirects, pipelines, nested loops, and wrapper boundaries.
 - [ ] 6.7 Add adversarial cases for option injection, mutation, unquoted expansion, indirect expansion, substitutions, and cap overflow.
 - [ ] 6.8 Add sanitized Bash corpus entries and Netclaw allow/prompt/deny integration cases.

--- a/src/ShellSyntaxTree/Internal/Bash/Parsing/BashAbstractStateAnalyzer.cs
+++ b/src/ShellSyntaxTree/Internal/Bash/Parsing/BashAbstractStateAnalyzer.cs
@@ -26,6 +26,8 @@ internal sealed class BashAbstractStateAnalyzer
         new(ClauseReferenceComparer.Instance);
     private readonly Dictionary<Clause, Dictionary<int, ShellValueDomain>>
         _effectiveArguments = new(ClauseReferenceComparer.Instance);
+    private readonly Dictionary<Clause, HashSet<int>> _cwdResolutionSanitization =
+        new(ClauseReferenceComparer.Instance);
     private readonly List<BashForInAnalysisPlanReference> _rewrittenForInPlans = new();
     private bool _isComplete = true;
     private int _remainingLoopAnalysisTransitions = MaxLoopAnalysisTransitions;
@@ -133,9 +135,22 @@ internal sealed class BashAbstractStateAnalyzer
                 clearBindings: false);
         }
 
+        if (input.Bindings.HasBindings &&
+            IsPotentialPersistentBindingMutation(simple.Clause))
+        {
+            _isComplete = false;
+            return new BashFlowResult(null, null);
+        }
+
         RecordInput(simple.Clause, input);
         RecordEffectiveArguments(simple, input);
-        if (!TryGetCwdTransfer(simple.Clause, input, out var success))
+        var cwdTransfer = AnalyzeEffectiveCwdTransfer(simple, input);
+        if (cwdTransfer is BashFlowResult effectiveFlow)
+        {
+            return effectiveFlow;
+        }
+
+        if (!TryGetLegacyCwdTransfer(simple.Clause, input, out var success))
         {
             return BashFlowResult.Both(input);
         }
@@ -567,7 +582,357 @@ internal sealed class BashAbstractStateAnalyzer
         return accumulated;
     }
 
-    private bool TryGetCwdTransfer(
+    private void RecordCwdResolutionSanitization(
+        Clause clause,
+        IReadOnlyList<int> elementIndices)
+    {
+        if (!_cwdResolutionSanitization.TryGetValue(clause, out var accumulated))
+        {
+            accumulated = new HashSet<int>();
+            _cwdResolutionSanitization.Add(clause, accumulated);
+        }
+
+        foreach (var elementIndex in elementIndices)
+        {
+            accumulated.Add(elementIndex);
+        }
+    }
+
+    private BashFlowResult? AnalyzeEffectiveCwdTransfer(
+        SimpleCommandSyntax simple,
+        BashAbstractState input)
+    {
+        var dispatchKind = BashCwdInvocationGrammar.Classify(
+            simple.Clause,
+            out var argumentElementIndices);
+        if (dispatchKind == BashDispatchKind.Query)
+        {
+            return BashFlowResult.Both(input);
+        }
+
+        if (dispatchKind != BashDispatchKind.CwdTransfer)
+        {
+            return null;
+        }
+
+        if (!TryGetCwdArgumentValues(
+                simple,
+                argumentElementIndices,
+                out var argumentValues))
+        {
+            _isComplete = false;
+            return new BashFlowResult(null, null);
+        }
+
+        foreach (var argumentValue in argumentValues)
+        {
+            if (input.Bindings.ReferencesTrackedBinding(argumentValue) &&
+                !HasProvedSingleWordCardinality(argumentValue))
+            {
+                _isComplete = false;
+                return new BashFlowResult(null, null);
+            }
+        }
+
+        var referencedBindings = input.Bindings.FindReferencedBindingNames(argumentValues);
+        var alternativeResult = input.Bindings.EnumerateExactAlternatives(
+            ShellAnalysisLimits.MaxValueCandidates,
+            referencedBindings,
+            out var bindingAlternatives);
+        if (alternativeResult == BashBindingAlternativeResult.ExceededLimit)
+        {
+            _isComplete = false;
+            return new BashFlowResult(null, null);
+        }
+
+        if (alternativeResult == BashBindingAlternativeResult.Unknown)
+        {
+            RecordCwdResolutionSanitization(simple.Clause, argumentElementIndices);
+            return new BashFlowResult(input.WithUnknownCwd(), input);
+        }
+
+        BashAbstractState? success = null;
+        BashAbstractState? failure = null;
+        foreach (var bindings in bindingAlternatives)
+        {
+            BuildEffectiveCwdArguments(
+                bindings,
+                argumentElementIndices,
+                argumentValues,
+                input,
+                out var arguments);
+
+            BashFlowResult visit;
+            if (arguments is null)
+            {
+                RecordCwdResolutionSanitization(
+                    simple.Clause,
+                    argumentElementIndices);
+                visit = new BashFlowResult(input.WithUnknownCwd(), input);
+            }
+            else
+            {
+                visit = AnalyzeExactCwdArguments(simple.Clause, input, arguments);
+            }
+
+            success = BashAbstractState.JoinNullable(success, visit.OnSuccess);
+            failure = BashAbstractState.JoinNullable(failure, visit.OnFailure);
+        }
+
+        return new BashFlowResult(success, failure);
+    }
+
+    private bool TryGetCwdArgumentValues(
+        SimpleCommandSyntax simple,
+        IReadOnlyList<int> argumentElementIndices,
+        out IReadOnlyList<ShellValue> values)
+    {
+        var ordered = new List<ShellValue>(argumentElementIndices.Count);
+        var sourceFacts = _factsFactory(simple);
+        foreach (var elementIndex in argumentElementIndices)
+        {
+            ShellValueElementProvenance? provenance = null;
+            foreach (var candidate in sourceFacts.ValueProvenance)
+            {
+                if (candidate.ClauseElementIndex == elementIndex)
+                {
+                    provenance = candidate;
+                    break;
+                }
+            }
+
+            if (provenance is null)
+            {
+                values = Array.Empty<ShellValue>();
+                return false;
+            }
+
+            ordered.Add(provenance.Value.Value);
+        }
+
+        values = ordered;
+        return true;
+    }
+
+    private void BuildEffectiveCwdArguments(
+        BashLoopBindingContext bindings,
+        IReadOnlyList<int> argumentElementIndices,
+        IReadOnlyList<ShellValue> argumentValues,
+        BashAbstractState input,
+        out IReadOnlyList<EffectiveCwdArgument>? arguments)
+    {
+        var exact = new List<EffectiveCwdArgument>(argumentElementIndices.Count);
+        for (var index = 0; index < argumentElementIndices.Count; index++)
+        {
+            var dependsOnBinding = bindings.TryAnalyzeEffectiveValue(
+                argumentValues[index],
+                out var domain);
+            if (!dependsOnBinding)
+            {
+                domain = bindings.AnalyzeWordForTransfer(argumentValues[index]);
+            }
+
+            if (domain.Kind != ShellValueDomainKind.Exact &&
+                TryResolveKnownHomeWord(argumentValues[index], input, out var homeWord))
+            {
+                domain = new ShellValueDomain
+                {
+                    Kind = ShellValueDomainKind.Exact,
+                    Values = new[] { homeWord },
+                };
+            }
+
+            if (domain.Kind != ShellValueDomainKind.Exact || domain.Values.Count != 1)
+            {
+                arguments = null;
+                return;
+            }
+
+            exact.Add(new EffectiveCwdArgument(
+                argumentElementIndices[index],
+                domain.Values[0]));
+        }
+
+        arguments = exact;
+    }
+
+    private bool TryResolveKnownHomeWord(
+        ShellValue value,
+        BashAbstractState input,
+        out string resolvedValue)
+    {
+        var resolved = BashResolver.Resolve(
+            value,
+            treatAsPath: true,
+            OptionsFor(input),
+            workingDirectoryUnknown: input.WorkingDirectory is null,
+            consumer: ShellResolutionConsumer.BashArgument);
+        if (resolved.Kind == ArgKind.Tilde && resolved.Resolved is not null)
+        {
+            resolvedValue = resolved.Resolved;
+            return true;
+        }
+
+        resolvedValue = "";
+        return false;
+    }
+
+    private static bool HasProvedSingleWordCardinality(ShellValue value)
+    {
+        foreach (var fragment in value.Fragments)
+        {
+            if (fragment.Cardinality != ShellValueCardinality.ExactlyOne ||
+                (fragment.AllowedTransforms &
+                 (ShellLexicalTransform.FieldSplit | ShellLexicalTransform.Glob)) != 0)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private BashFlowResult AnalyzeExactCwdArguments(
+        Clause clause,
+        BashAbstractState input,
+        IReadOnlyList<EffectiveCwdArgument> arguments)
+    {
+        var optionsEnded = false;
+        var physical = false;
+        EffectiveCwdArgument? operand = null;
+        foreach (var argument in arguments)
+        {
+            if (operand is not null)
+            {
+                return new BashFlowResult(null, input);
+            }
+
+            if (!optionsEnded && argument.Value == "--")
+            {
+                optionsEnded = true;
+                continue;
+            }
+
+            if (!optionsEnded &&
+                argument.Value.Length > 1 &&
+                argument.Value[0] == '-' &&
+                argument.Value != "-")
+            {
+                if (!IsSupportedCdOption(
+                        argument.Value,
+                        out var requiresPhysicalResolution))
+                {
+                    return new BashFlowResult(null, input);
+                }
+
+                physical |= requiresPhysicalResolution;
+                continue;
+            }
+
+            operand = argument;
+            if (physical)
+            {
+                RecordCwdResolutionSanitization(
+                    clause,
+                    new[] { argument.ElementIndex });
+            }
+        }
+
+        if (operand is null)
+        {
+            var home = physical || string.IsNullOrEmpty(_options.HomeDirectory)
+                ? input.WithUnknownCwd()
+                : input.WithCwd(_options.HomeDirectory, true);
+            return new BashFlowResult(home, input);
+        }
+
+        if (physical ||
+            operand.Value.Value == "-" ||
+            IsCdPathSearchCandidate(operand.Value.Value))
+        {
+            return new BashFlowResult(input.WithUnknownCwd(), input);
+        }
+
+        var resolved = BashResolver.Resolve(
+            operand.Value.Value,
+            treatAsPath: true,
+            OptionsFor(input),
+            workingDirectoryUnknown: input.WorkingDirectory is null,
+            isLiteralBytes: true);
+        var success = resolved.Resolved is null
+            ? input.WithUnknownCwd()
+            : input.WithCwd(resolved.Resolved, true);
+        return new BashFlowResult(success, input);
+    }
+
+    private static bool IsSupportedCdOption(
+        string argument,
+        out bool requiresPhysicalResolution)
+    {
+        requiresPhysicalResolution = false;
+        for (var index = 1; index < argument.Length; index++)
+        {
+            switch (argument[index])
+            {
+                case 'L':
+                case 'e':
+                    break;
+                case 'P':
+                case '@':
+                    requiresPhysicalResolution = true;
+                    break;
+                default:
+                    return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsPotentialPersistentBindingMutation(Clause clause)
+    {
+        var dispatchKind = BashCwdInvocationGrammar.Classify(clause, out _);
+        if (dispatchKind is BashDispatchKind.CwdTransfer or BashDispatchKind.Query)
+        {
+            return false;
+        }
+
+        if (clause.Verb.Tokens.Count == 0)
+        {
+            return true;
+        }
+
+        var verb = clause.Verb.Tokens[0];
+        if (verb is "pushd" or "popd")
+        {
+            return false;
+        }
+
+        if (verb is "unset" or "read" or "readarray" or "mapfile" or
+            "declare" or "typeset" or "local" or "export" or "readonly" or
+            "let" or "eval" or "." or "source" or "getopts" or "set" or
+            "trap" or "command" or "builtin")
+        {
+            return true;
+        }
+
+        if (!string.Equals(verb, "printf", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        foreach (var argument in clause.Args)
+        {
+            if (string.Equals(argument.Raw, "-v", StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private bool TryGetLegacyCwdTransfer(
         Clause clause,
         BashAbstractState input,
         out BashAbstractState success)
@@ -905,7 +1270,8 @@ internal sealed class BashAbstractStateAnalyzer
                 var dependency = FindArgumentDependency(
                     dependencies,
                     authoredArgumentIndex);
-                var clearResolution = authoredArgumentIndex == clearCdTargetIndex;
+                var clearResolution = authoredArgumentIndex == clearCdTargetIndex ||
+                    IsArgumentResolutionSanitized(clause, authoredArgumentIndex);
                 var rebased = clearResolution
                     ? null
                     : RebaseResolution(
@@ -936,7 +1302,8 @@ internal sealed class BashAbstractStateAnalyzer
             var element = clause.Elements[index];
             var dependency = FindDependency(dependencies, index);
             var clearResolution = element.Role == ClauseElementRole.Argument &&
-                argumentElementIndex++ == clearCdTargetIndex;
+                (argumentElementIndex++ == clearCdTargetIndex ||
+                 IsElementResolutionSanitized(clause, index));
             var rebased = clearResolution
                 ? null
                 : RebaseResolution(
@@ -976,6 +1343,31 @@ internal sealed class BashAbstractStateAnalyzer
             Redirects = redirects,
         };
     }
+
+    private bool IsArgumentResolutionSanitized(Clause clause, int argumentIndex)
+    {
+        var currentArgument = 0;
+        for (var elementIndex = 0;
+             elementIndex < clause.Elements.Count;
+             elementIndex++)
+        {
+            if (clause.Elements[elementIndex].Role != ClauseElementRole.Argument)
+            {
+                continue;
+            }
+
+            if (currentArgument++ == argumentIndex)
+            {
+                return IsElementResolutionSanitized(clause, elementIndex);
+            }
+        }
+
+        return false;
+    }
+
+    private bool IsElementResolutionSanitized(Clause clause, int elementIndex) =>
+        _cwdResolutionSanitization.TryGetValue(clause, out var sanitized) &&
+        sanitized.Contains(elementIndex);
 
     private IReadOnlyList<Redirect> RewriteCompatibilityRedirects(
         Clause clause,
@@ -1451,6 +1843,8 @@ internal sealed class BashAbstractStateAnalyzer
 
         return rewritten;
     }
+
+    private readonly record struct EffectiveCwdArgument(int ElementIndex, string Value);
 
     private readonly struct BashFlowResult
     {

--- a/src/ShellSyntaxTree/Internal/Bash/Parsing/BashCwdInvocationGrammar.cs
+++ b/src/ShellSyntaxTree/Internal/Bash/Parsing/BashCwdInvocationGrammar.cs
@@ -1,0 +1,141 @@
+// -----------------------------------------------------------------------
+// <copyright file="BashCwdInvocationGrammar.cs" company="Aaron Stannard">
+//      Copyright (C) 2026 - 2026 Aaron Stannard <https://github.com/Aaronontheweb>
+// </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+
+namespace ShellSyntaxTree.Internal.Bash.Parsing;
+
+internal static class BashCwdInvocationGrammar
+{
+    internal static BashDispatchKind Classify(
+        Clause clause,
+        out IReadOnlyList<int> cwdArgumentElementIndices)
+    {
+        cwdArgumentElementIndices = Array.Empty<int>();
+        var words = new List<int>();
+        for (var index = 0; index < clause.Elements.Count; index++)
+        {
+            if (clause.Elements[index].Role != ClauseElementRole.Redirect)
+            {
+                words.Add(index);
+            }
+        }
+
+        var wordIndex = 0;
+        while (wordIndex < words.Count)
+        {
+            var element = clause.Elements[words[wordIndex]];
+            if (!IsStaticWord(element))
+            {
+                return BashDispatchKind.None;
+            }
+
+            if (element.Value == "command")
+            {
+                wordIndex++;
+                var optionsEnded = false;
+                while (wordIndex < words.Count && !optionsEnded)
+                {
+                    var option = clause.Elements[words[wordIndex]];
+                    if (!IsStaticWord(option))
+                    {
+                        return BashDispatchKind.None;
+                    }
+
+                    if (option.Value == "--")
+                    {
+                        optionsEnded = true;
+                        wordIndex++;
+                        continue;
+                    }
+
+                    if (option.Value.Length <= 1 || option.Value[0] != '-')
+                    {
+                        break;
+                    }
+
+                    var query = false;
+                    for (var optionIndex = 1;
+                         optionIndex < option.Value.Length;
+                         optionIndex++)
+                    {
+                        switch (option.Value[optionIndex])
+                        {
+                            case 'p':
+                                break;
+                            case 'v':
+                            case 'V':
+                                query = true;
+                                break;
+                            default:
+                                return BashDispatchKind.None;
+                        }
+                    }
+
+                    wordIndex++;
+                    if (query)
+                    {
+                        return BashDispatchKind.Query;
+                    }
+                }
+
+                continue;
+            }
+
+            if (element.Value == "builtin")
+            {
+                wordIndex++;
+                if (wordIndex < words.Count)
+                {
+                    var option = clause.Elements[words[wordIndex]];
+                    if (!IsStaticWord(option))
+                    {
+                        return BashDispatchKind.None;
+                    }
+
+                    if (option.Value == "--")
+                    {
+                        wordIndex++;
+                    }
+                    else if (option.Value.Length > 1 && option.Value[0] == '-')
+                    {
+                        return BashDispatchKind.None;
+                    }
+                }
+
+                continue;
+            }
+
+            if (element.Value is not ("cd" or "chdir"))
+            {
+                return BashDispatchKind.None;
+            }
+
+            var arguments = new int[words.Count - wordIndex - 1];
+            for (var argumentIndex = 0;
+                 argumentIndex < arguments.Length;
+                 argumentIndex++)
+            {
+                arguments[argumentIndex] = words[wordIndex + argumentIndex + 1];
+            }
+
+            cwdArgumentElementIndices = arguments;
+            return BashDispatchKind.CwdTransfer;
+        }
+
+        return BashDispatchKind.None;
+    }
+
+    private static bool IsStaticWord(ClauseElement element) =>
+        element.Kind == ArgKind.Literal;
+}
+
+internal enum BashDispatchKind
+{
+    None,
+    Query,
+    CwdTransfer,
+}

--- a/src/ShellSyntaxTree/Internal/Bash/Parsing/BashLoopAnalysis.cs
+++ b/src/ShellSyntaxTree/Internal/Bash/Parsing/BashLoopAnalysis.cs
@@ -18,6 +18,13 @@ internal enum BashIterationCardinality
     ZeroOrMore,
 }
 
+internal enum BashBindingAlternativeResult
+{
+    Exact,
+    Unknown,
+    ExceededLimit,
+}
+
 internal sealed record BashLoopWord(
     ShellValue? Value,
     bool HasUnmodeledBraceExpansion);
@@ -71,6 +78,103 @@ internal sealed class BashLoopBindingContext
     }
 
     internal BashLoopBindingContext WithoutBindings() => new();
+
+    internal bool HasBindings => _bindings.Count > 0;
+
+    internal BashBindingAlternativeResult EnumerateExactAlternatives(
+        int maximumCount,
+        IReadOnlyList<string> bindingNames,
+        out IReadOnlyList<BashLoopBindingContext> alternatives)
+    {
+        var current = new List<BashLoopBindingContext> { new() };
+        foreach (var binding in _bindings)
+        {
+            if (!ContainsName(bindingNames, binding.Name))
+            {
+                continue;
+            }
+
+            if (binding.Domain.Kind is not (
+                    ShellValueDomainKind.Exact or ShellValueDomainKind.FiniteSet) ||
+                binding.Domain.Values.Count == 0)
+            {
+                alternatives = Array.Empty<BashLoopBindingContext>();
+                return BashBindingAlternativeResult.Unknown;
+            }
+
+            if (current.Count > maximumCount / binding.Domain.Values.Count)
+            {
+                alternatives = Array.Empty<BashLoopBindingContext>();
+                return BashBindingAlternativeResult.ExceededLimit;
+            }
+
+            var next = new List<BashLoopBindingContext>(
+                current.Count * binding.Domain.Values.Count);
+            foreach (var state in current)
+            {
+                foreach (var value in binding.Domain.Values)
+                {
+                    next.Add(state.WithBinding(
+                        binding.Name,
+                        new ShellValueDomain
+                        {
+                            Kind = ShellValueDomainKind.Exact,
+                            Values = new[] { value },
+                        }));
+                }
+            }
+
+            current = next;
+        }
+
+        alternatives = current;
+        return BashBindingAlternativeResult.Exact;
+    }
+
+    internal IReadOnlyList<string> FindReferencedBindingNames(
+        IReadOnlyList<ShellValue> values)
+    {
+        var names = new List<string>();
+        foreach (var binding in _bindings)
+        {
+            foreach (var value in values)
+            {
+                if (ReferencesBinding(value, binding.Name))
+                {
+                    names.Add(binding.Name);
+                    break;
+                }
+            }
+        }
+
+        return names;
+    }
+
+    internal bool ReferencesTrackedBinding(ShellValue value)
+    {
+        foreach (var binding in _bindings)
+        {
+            if (ReferencesBinding(value, binding.Name))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool ContainsName(IReadOnlyList<string> names, string expected)
+    {
+        foreach (var name in names)
+        {
+            if (string.Equals(name, expected, StringComparison.Ordinal))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     internal bool StateEquals(BashLoopBindingContext other)
     {
@@ -420,6 +524,22 @@ internal sealed class BashLoopBindingContext
 
         domain = CreateFiniteDomain(candidates);
         return true;
+    }
+
+    internal ShellValueDomain AnalyzeWordForTransfer(ShellValue value)
+    {
+        if (IsEntirelyLiteral(value))
+        {
+            return new ShellValueDomain
+            {
+                Kind = ShellValueDomainKind.Exact,
+                Values = new[] { value.Decoded },
+            };
+        }
+
+        return TryAnalyzeEffectiveValue(value, out var domain)
+            ? domain
+            : ShellValueDomain.Unknown;
     }
 
     private bool TryComposeCandidates(

--- a/src/ShellSyntaxTree/Internal/Bash/Parsing/BashStructuralCoordinator.cs
+++ b/src/ShellSyntaxTree/Internal/Bash/Parsing/BashStructuralCoordinator.cs
@@ -542,16 +542,23 @@ internal static partial class BashCommandParser
                 IsCommandStringWrapped = _markBashCWrapped,
             };
             var emitted = AttachAttributionArg(clause, _attribution);
+            var dispatchKind = BashCwdInvocationGrammar.Classify(
+                emitted,
+                out _);
             var isPotentialStateMutation = IsPotentialBindingMutation(emitted);
-            if (_activeLoopBindings.Count > 0 && isPotentialStateMutation)
+            var isModeledCwdTransfer = dispatchKind == BashDispatchKind.CwdTransfer;
+            if (_activeLoopBindings.Count > 0 &&
+                isPotentialStateMutation &&
+                !isModeledCwdTransfer)
             {
                 error = "Bash loop state mutation or control transfer is not supported for bounded analysis";
                 return false;
             }
 
-            _hasUnmodeledShellStateMutation |= isPotentialStateMutation;
+            _hasUnmodeledShellStateMutation |=
+                isPotentialStateMutation && !isModeledCwdTransfer;
             _hasUnmodeledVariableStateMutation |=
-                IsPotentialVariableStateMutation(emitted);
+                IsPotentialVariableStateMutation(emitted) && !isModeledCwdTransfer;
 
             if (!TryParseCommandSubstitutions(
                     substitutionFragments,
@@ -601,7 +608,7 @@ internal static partial class BashCommandParser
         {
             command = null;
             error = null;
-            if (_attribution.HasAttribution || _hasUnmodeledShellStateMutation)
+            if (_hasUnmodeledShellStateMutation)
             {
                 error = "Bash for-in after prior shell-state mutation requires structure-aware state analysis";
                 return false;
@@ -1418,6 +1425,12 @@ internal static partial class BashCommandParser
 
         private static bool IsPotentialBindingMutation(Clause clause)
         {
+            var dispatchKind = BashCwdInvocationGrammar.Classify(clause, out _);
+            if (dispatchKind == BashDispatchKind.Query)
+            {
+                return false;
+            }
+
             if (clause.Verb.Tokens.Count == 0)
             {
                 return true;
@@ -1459,8 +1472,10 @@ internal static partial class BashCommandParser
 
         private static bool IsPotentialVariableStateMutation(Clause clause)
         {
-            if (clause.Verb.Tokens.Count > 0 &&
-                clause.Verb.Tokens[0] is "cd" or "chdir" or "pushd" or "popd")
+            var dispatchKind = BashCwdInvocationGrammar.Classify(clause, out _);
+            if (dispatchKind is BashDispatchKind.CwdTransfer or BashDispatchKind.Query ||
+                clause.Verb.Tokens.Count > 0 &&
+                clause.Verb.Tokens[0] is "pushd" or "popd")
             {
                 return false;
             }

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/222_v03_nested_dispatch_cwd_mutator.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/222_v03_nested_dispatch_cwd_mutator.json
@@ -1,5 +1,5 @@
 {
-  "name": "v0.3 nested static dispatch mutator fails closed",
+  "name": "v0.3 nested static dispatch cwd transfer",
   "input": "command builtin cd /outer && cat relative.txt",
   "expected": {
     "isUnparseable": false,
@@ -16,12 +16,12 @@
         "operator": "AndIf",
         "verb": ["cat"],
         "args": [
-          { "raw": "relative.txt", "kind": "Literal", "isPath": true },
-          { "raw": "\u003Cdynamic-cwd\u003E", "kind": "DynamicSkip", "isPath": false, "isCwdAttribution": true }
+          { "raw": "relative.txt", "kind": "Literal", "isPath": true, "resolved": "/outer/relative.txt" },
+          { "raw": "/outer", "kind": "Literal", "isPath": true, "resolved": "/outer", "isCwdAttribution": true }
         ],
         "redirects": []
       }
     ]
   },
-  "notes": "Static command and builtin dispatch layers may reach a current-shell cd; the analyzer scans through every wrapper and does not retain the old cwd."
+  "notes": "Static command and builtin dispatch layers are recursively proved, so the analyzer applies the complete cd argv and retains the exact successful cwd."
 }

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/243_v03_for_effective_cd_physical_sanitization.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/243_v03_for_effective_cd_physical_sanitization.json
@@ -1,0 +1,28 @@
+{
+  "name": "v0.3 Bash effective cd physical-option sanitation",
+  "input": "for f in -P; do cd \"$f\" ./sub && cat file.txt; done",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["cd"],
+        "args": [
+          { "raw": "\"$f\"", "kind": "DynamicSkip", "isPath": false, "resolved": "__NULL__", "isFlag": false },
+          { "raw": "./sub", "kind": "Literal", "isPath": true, "resolved": "__NULL__", "isFlag": false }
+        ],
+        "redirects": []
+      },
+      {
+        "operator": "AndIf",
+        "verb": ["cat"],
+        "args": [
+          { "raw": "file.txt", "kind": "DynamicSkip", "isPath": false, "resolved": "__NULL__", "isFlag": false },
+          { "raw": "<dynamic-cwd>", "kind": "DynamicSkip", "isPath": false, "resolved": "__NULL__", "isFlag": false, "isCwdAttribution": true }
+        ],
+        "redirects": []
+      }
+    ]
+  },
+  "notes": "The rebound -P option makes physical resolution unprovable, clears the authored ./sub resolution, and propagates unknown cwd to the success continuation."
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/244_v03_for_effective_cd_terminator_control.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/244_v03_for_effective_cd_terminator_control.json
@@ -1,0 +1,28 @@
+{
+  "name": "v0.3 Bash effective cd option-terminator control",
+  "input": "for f in --; do cd \"$f\" ./sub && cat file.txt; done",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["cd"],
+        "args": [
+          { "raw": "\"$f\"", "kind": "DynamicSkip", "isPath": false, "resolved": "__NULL__", "isFlag": false },
+          { "raw": "./sub", "kind": "Literal", "isPath": true, "resolved": "/work/sub", "isFlag": false }
+        ],
+        "redirects": []
+      },
+      {
+        "operator": "AndIf",
+        "verb": ["cat"],
+        "args": [
+          { "raw": "file.txt", "kind": "Literal", "isPath": true, "resolved": "/work/sub/file.txt", "isFlag": false },
+          { "raw": "/work/sub", "kind": "Literal", "isPath": true, "resolved": "/work/sub", "isFlag": false, "isCwdAttribution": true }
+        ],
+        "redirects": []
+      }
+    ]
+  },
+  "notes": "The rebound -- terminator leaves ./sub as the sole logical operand and preserves exact downstream cwd and path facts."
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/245_v03_for_wrapped_effective_cd.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/245_v03_for_wrapped_effective_cd.json
@@ -1,0 +1,32 @@
+{
+  "name": "v0.3 Bash recursively wrapped effective cd",
+  "input": "for f in /tmp; do command -p -- builtin -- cd \"$f\" && cat file.txt; done",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["command"],
+        "args": [
+          { "raw": "-p", "kind": "Literal", "isPath": false, "resolved": "__NULL__", "isFlag": true },
+          { "raw": "--", "kind": "Literal", "isPath": false, "resolved": "__NULL__", "isFlag": true },
+          { "raw": "builtin", "kind": "Literal", "isPath": false, "resolved": "__NULL__", "isFlag": false },
+          { "raw": "--", "kind": "Literal", "isPath": false, "resolved": "__NULL__", "isFlag": true },
+          { "raw": "cd", "kind": "Literal", "isPath": false, "resolved": "__NULL__", "isFlag": false },
+          { "raw": "\"$f\"", "kind": "EnvVar", "isPath": false, "resolved": "__NULL__", "isFlag": false }
+        ],
+        "redirects": []
+      },
+      {
+        "operator": "AndIf",
+        "verb": ["cat"],
+        "args": [
+          { "raw": "file.txt", "kind": "Literal", "isPath": true, "resolved": "/tmp/file.txt", "isFlag": false },
+          { "raw": "/tmp", "kind": "Literal", "isPath": true, "resolved": "/tmp", "isFlag": false, "isCwdAttribution": true }
+        ],
+        "redirects": []
+      }
+    ]
+  },
+  "notes": "Exact command and builtin wrapper options are recursively classified before the loop-derived cd argv is interpreted."
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/246_v03_for_post_binding_mutation_rejected.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/246_v03_for_post_binding_mutation_rejected.json
@@ -1,0 +1,10 @@
+{
+  "name": "v0.3 Bash post-loop binding mutation rejected",
+  "input": "for f in a; do :; done; unset f; echo \"$f\"",
+  "expected": {
+    "isUnparseable": true,
+    "unparseableReasonContains": "invalid parser-owned facts"
+  },
+  "notes": "Loop bindings persist after done; an unsupported later unset cannot leave a stale exact effective value.",
+  "oracleExpectation": "OutOfScope"
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/247_v03_for_static_invalid_cd_failure.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/247_v03_for_static_invalid_cd_failure.json
@@ -1,0 +1,24 @@
+{
+  "name": "v0.3 Bash static invalid cd is failure-only",
+  "input": "for f in x; do cd -Z || pwd; done",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["cd"],
+        "args": [
+          { "raw": "-Z", "kind": "Literal", "isPath": false, "resolved": "__NULL__", "isFlag": true }
+        ],
+        "redirects": []
+      },
+      {
+        "operator": "OrIf",
+        "verb": ["pwd"],
+        "args": [],
+        "redirects": []
+      }
+    ]
+  },
+  "notes": "Complete static argv interpretation makes an invalid cd option failure-only, so the OR continuation retains the incoming cwd."
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/248_v03_for_option_after_operand.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/248_v03_for_option_after_operand.json
@@ -1,0 +1,25 @@
+{
+  "name": "v0.3 Bash option-shaped word after cd operand",
+  "input": "for f in --; do cd ./a \"$f\" || pwd; done",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["cd"],
+        "args": [
+          { "raw": "./a", "kind": "Literal", "isPath": true, "resolved": "/work/a", "isFlag": false },
+          { "raw": "\"$f\"", "kind": "DynamicSkip", "isPath": false, "resolved": "__NULL__", "isFlag": false }
+        ],
+        "redirects": []
+      },
+      {
+        "operator": "OrIf",
+        "verb": ["pwd"],
+        "args": [],
+        "redirects": []
+      }
+    ]
+  },
+  "notes": "Once ./a is the operand, the rebound -- is a second operand rather than an option terminator; the exact invocation is failure-only."
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/249_v03_for_unquoted_cd_arity_rejected.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/249_v03_for_unquoted_cd_arity_rejected.json
@@ -1,0 +1,10 @@
+{
+  "name": "v0.3 Bash unquoted cd argv arity rejected",
+  "input": "for f in 'a b'; do cd $f && pwd; done",
+  "expected": {
+    "isUnparseable": true,
+    "unparseableReasonContains": "invalid parser-owned facts"
+  },
+  "notes": "Unquoted loop expansion may field-split into multiple argv words, so transfer analysis fails atomically rather than inventing one unknown operand.",
+  "oracleExpectation": "OutOfScope"
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/250_v03_for_pattern_cd_arity_rejected.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/250_v03_for_pattern_cd_arity_rejected.json
@@ -1,0 +1,10 @@
+{
+  "name": "v0.3 Bash pattern-domain cd argv arity rejected",
+  "input": "for f in *.txt; do cd $f; done",
+  "expected": {
+    "isUnparseable": true,
+    "unparseableReasonContains": "invalid parser-owned facts"
+  },
+  "notes": "A pattern-domain loop binding expanded unquoted has unproved argv cardinality and fails before the analyzer takes its conservative unknown-domain shortcut.",
+  "oracleExpectation": "OutOfScope"
+}

--- a/tests/ShellSyntaxTree.Tests/DesignCorpus/v0.3/bash.json
+++ b/tests/ShellSyntaxTree.Tests/DesignCorpus/v0.3/bash.json
@@ -314,9 +314,9 @@
     {
       "id": "bash-for-empty-iterable-preserves-cwd",
       "concern": "A proved empty loop has no state transition",
-      "compatibilityProjectionLanded": false,
+      "compatibilityProjectionLanded": true,
       "input": "for f in; do cd /tmp; done; pwd",
-      "current": { "isUnparseable": true, "reasonContains": "mutation" },
+      "current": { "isUnparseable": false },
       "desired": {
         "syntax": [
           { "id": "root", "kind": "Block", "slot": "Root" },

--- a/tests/ShellSyntaxTree.Tests/Parsing/BashForInStructuralTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Parsing/BashForInStructuralTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 // -----------------------------------------------------------------------
 using System.Linq;
+using ShellSyntaxTree.Internal.Bash.Parsing;
 using Xunit;
 
 namespace ShellSyntaxTree.Tests.Parsing;
@@ -138,10 +139,6 @@ public class BashForInStructuralTests
     }
 
     [Theory]
-    [InlineData("cd /a || cd /b; for f in *.txt; do rm -- \"$f\" rel.txt; done")]
-    [InlineData("cd /a | cat; for f in *.txt; do rm -- \"$f\" rel.txt; done")]
-    [InlineData("command cd /a; for f in x; do rm -- \"$f\" rel.txt; done")]
-    [InlineData("builtin cd /a; for f in x; do rm -- \"$f\" rel.txt; done")]
     [InlineData("eval \"cd /a\"; for f in x; do rm -- \"$f\" rel.txt; done")]
     [InlineData("trap \"f=x\" DEBUG; for f in a b; do echo \"$f\"; done")]
     public void Loop_after_prior_shell_state_mutation_fails_atomically(string source)
@@ -171,6 +168,276 @@ public class BashForInStructuralTests
         Assert.False(result.IsUnparseable, result.UnparseableReason);
         var effective = Assert.Single(Assert.Single(result.Commands).EffectiveArguments);
         Assert.Equal(ShellValueDomainKind.Unknown, effective.Value.Kind);
+    }
+
+    [Fact]
+    public void Loop_derived_cd_operand_flows_through_success_continuation()
+    {
+        var result = Parse("for f in /tmp; do cd \"$f\"; done && pwd");
+
+        Assert.False(result.IsUnparseable, result.UnparseableReason);
+        AssertDomain(result.Commands[1].WorkingDirectory, ShellValueDomainKind.Exact, "/tmp");
+    }
+
+    [Fact]
+    public void Wrapped_loop_derived_cd_operand_uses_the_same_transfer_grammar()
+    {
+        var result = Parse(
+            "for f in /tmp; do command builtin cd \"$f\"; done && pwd");
+
+        Assert.False(result.IsUnparseable, result.UnparseableReason);
+        AssertDomain(result.Commands[1].WorkingDirectory, ShellValueDomainKind.Exact, "/tmp");
+    }
+
+    [Fact]
+    public void Loop_derived_cd_option_terminator_without_operand_uses_home()
+    {
+        var result = Parse("for f in --; do cd \"$f\"; done && pwd");
+
+        Assert.False(result.IsUnparseable, result.UnparseableReason);
+        AssertDomain(
+            result.Commands[1].WorkingDirectory,
+            ShellValueDomainKind.Exact,
+            "/home/test");
+    }
+
+    [Theory]
+    [InlineData("-L")]
+    [InlineData("-e")]
+    public void Logical_loop_derived_cd_option_without_operand_uses_home(
+        string candidate)
+    {
+        var result = Parse($"for f in {candidate}; do cd \"$f\"; done && pwd");
+
+        Assert.False(result.IsUnparseable, result.UnparseableReason);
+        AssertDomain(
+            result.Commands[1].WorkingDirectory,
+            ShellValueDomainKind.Exact,
+            "/home/test");
+    }
+
+    [Fact]
+    public void Invalid_loop_derived_cd_option_has_no_success_continuation()
+    {
+        var result = Parse("for f in -Z; do cd \"$f\"; done || pwd");
+
+        Assert.False(result.IsUnparseable, result.UnparseableReason);
+        AssertDomain(result.Commands[1].WorkingDirectory, ShellValueDomainKind.Exact, "/work");
+    }
+
+    [Theory]
+    [InlineData("cd -Z")]
+    [InlineData("cd ./a ./b")]
+    [InlineData("command -- cd -Z")]
+    public void Static_invalid_cd_argv_is_failure_only_inside_loop(string command)
+    {
+        var result = Parse($"for f in x; do {command} || pwd; done");
+
+        Assert.False(result.IsUnparseable, result.UnparseableReason);
+        AssertDomain(result.Commands[1].WorkingDirectory, ShellValueDomainKind.Exact, "/work");
+    }
+
+    [Fact]
+    public void Multiple_effective_cd_operands_have_no_success_continuation()
+    {
+        var result = Parse("for f in /tmp; do cd \"$f\" /other; done || pwd");
+
+        Assert.False(result.IsUnparseable, result.UnparseableReason);
+        AssertDomain(result.Commands[1].WorkingDirectory, ShellValueDomainKind.Exact, "/work");
+    }
+
+    [Fact]
+    public void Multiple_effective_cd_operands_preserve_exact_failure_paths()
+    {
+        var result = Parse(
+            "for f in /other; do cd \"$f\" ./sub || cat file.txt; done");
+
+        Assert.False(result.IsUnparseable, result.UnparseableReason);
+        AssertDomain(result.Commands[1].WorkingDirectory, ShellValueDomainKind.Exact, "/work");
+        Assert.Equal(
+            "/work/file.txt",
+            Assert.Single(
+                result.Clauses[1].Args,
+                argument => argument.Raw == "file.txt").Resolved);
+    }
+
+    [Theory]
+    [InlineData("--")]
+    [InlineData("-P")]
+    public void Option_shaped_word_after_operand_is_a_second_operand(string candidate)
+    {
+        var result = Parse(
+            $"for f in {candidate}; do cd ./a \"$f\" || pwd; done");
+
+        Assert.False(result.IsUnparseable, result.UnparseableReason);
+        AssertDomain(result.Commands[1].WorkingDirectory, ShellValueDomainKind.Exact, "/work");
+        Assert.Equal(
+            "/work/a",
+            Assert.Single(result.Clauses[0].Args, argument => argument.Raw == "./a").Resolved);
+        Assert.Equal(
+            "/work/a",
+            Assert.Single(
+                result.Clauses[0].Elements,
+                element => element.Raw == "./a").Resolved);
+    }
+
+    [Fact]
+    public void Unquoted_loop_binding_with_unknown_argv_arity_fails_atomically()
+    {
+        var result = Parse("for f in 'a b'; do cd $f && pwd; done");
+
+        Assert.True(result.IsUnparseable);
+        Assert.Empty(result.Commands);
+        Assert.Empty(result.Clauses);
+    }
+
+    [Theory]
+    [InlineData("for f in *.txt; do cd $f; done")]
+    [InlineData("for f in 'a b'; do cd \"$UNKNOWN\" $f; done")]
+    public void Every_effective_argv_word_is_preflighted_for_tracked_unknown_arity(
+        string source)
+    {
+        var result = Parse(source);
+
+        Assert.True(result.IsUnparseable);
+        Assert.Empty(result.Commands);
+        Assert.Empty(result.Clauses);
+    }
+
+    [Theory]
+    [InlineData("-P")]
+    [InlineData("-@")]
+    [InlineData("-")]
+    public void Physical_or_oldpwd_loop_derived_cd_values_keep_success_cwd_unknown(
+        string candidate)
+    {
+        var result = Parse($"for f in {candidate}; do cd \"$f\"; done && pwd");
+
+        Assert.False(result.IsUnparseable, result.UnparseableReason);
+        Assert.Equal(ShellValueDomainKind.Unknown, result.Commands[1].WorkingDirectory.Kind);
+    }
+
+    [Fact]
+    public void Modeled_cd_before_loop_no_longer_invalidates_loop_analysis()
+    {
+        var result = Parse("cd /a && for f in x; do pwd; done");
+
+        Assert.False(result.IsUnparseable, result.UnparseableReason);
+        AssertDomain(result.Commands[1].WorkingDirectory, ShellValueDomainKind.Exact, "/a");
+    }
+
+    [Theory]
+    [InlineData("command -- cd")]
+    [InlineData("command -p cd")]
+    [InlineData("builtin -- cd")]
+    [InlineData("command -p -- builtin -- cd")]
+    public void Static_dispatch_options_preserve_loop_derived_cwd_transfer(
+        string dispatch)
+    {
+        var result = Parse(
+            $"for f in /tmp; do {dispatch} \"$f\"; done && pwd");
+
+        Assert.False(result.IsUnparseable, result.UnparseableReason);
+        AssertDomain(result.Commands[1].WorkingDirectory, ShellValueDomainKind.Exact, "/tmp");
+    }
+
+    [Theory]
+    [InlineData("command -v cd")]
+    [InlineData("command -V cd")]
+    [InlineData("command -pv cd")]
+    public void Command_query_options_do_not_mutate_loop_state(string query)
+    {
+        var result = Parse($"for f in a; do {query}; done && pwd");
+
+        Assert.False(result.IsUnparseable, result.UnparseableReason);
+        AssertDomain(result.Commands[1].WorkingDirectory, ShellValueDomainKind.Exact, "/work");
+    }
+
+    [Theory]
+    [InlineData("command -Z cd")]
+    [InlineData("builtin -p cd")]
+    public void Invalid_dispatch_options_remain_rejected_in_loop(string dispatch)
+    {
+        var result = Parse($"for f in a; do {dispatch} \"$f\"; done");
+
+        Assert.True(result.IsUnparseable);
+        Assert.Empty(result.Commands);
+        Assert.Empty(result.Clauses);
+    }
+
+    [Fact]
+    public void Loop_derived_physical_option_clears_stale_operand_resolution()
+    {
+        var result = Parse(
+            "for f in -P; do cd \"$f\" ./sub && cat file.txt; done");
+
+        Assert.False(result.IsUnparseable, result.UnparseableReason);
+        var cd = result.Clauses[0];
+        Assert.Null(Assert.Single(cd.Args, argument => argument.Raw == "./sub").Resolved);
+        Assert.Null(Assert.Single(
+            cd.Elements,
+            element => element.Raw == "./sub").Resolved);
+        Assert.Equal(ShellValueDomainKind.Unknown, result.Commands[1].WorkingDirectory.Kind);
+        Assert.Null(Assert.Single(
+            result.Clauses[1].Args,
+            argument => argument.Raw == "file.txt").Resolved);
+        Assert.Contains(
+            result.Clauses[1].Args,
+            argument => argument.IsCwdAttribution && argument.Kind == ArgKind.DynamicSkip);
+    }
+
+    [Fact]
+    public void Wrapped_loop_derived_physical_option_clears_stale_operand_resolution()
+    {
+        var result = Parse(
+            "for f in -P; do command -p -- builtin -- cd \"$f\" ./sub && " +
+            "cat file.txt; done");
+
+        Assert.False(result.IsUnparseable, result.UnparseableReason);
+        Assert.Null(Assert.Single(
+            result.Clauses[0].Elements,
+            element => element.Raw == "./sub").Resolved);
+        Assert.Equal(ShellValueDomainKind.Unknown, result.Commands[1].WorkingDirectory.Kind);
+    }
+
+    [Fact]
+    public void Loop_derived_option_terminator_retains_logical_operand_resolution()
+    {
+        var result = Parse(
+            "for f in --; do cd \"$f\" ./sub && cat file.txt; done");
+
+        Assert.False(result.IsUnparseable, result.UnparseableReason);
+        Assert.Equal(
+            "/work/sub",
+            Assert.Single(result.Clauses[0].Args, argument => argument.Raw == "./sub").Resolved);
+        Assert.Equal(
+            "/work/sub",
+            Assert.Single(
+                result.Clauses[0].Elements,
+                element => element.Raw == "./sub").Resolved);
+        AssertDomain(
+            result.Commands[1].WorkingDirectory,
+            ShellValueDomainKind.Exact,
+            "/work/sub");
+        Assert.Equal(
+            "/work/sub/file.txt",
+            Assert.Single(
+                result.Clauses[1].Args,
+                argument => argument.Raw == "file.txt").Resolved);
+    }
+
+    [Theory]
+    [InlineData("unset f")]
+    [InlineData("command unset f")]
+    [InlineData("builtin unset f")]
+    public void Post_loop_binding_mutation_fails_atomically(string mutation)
+    {
+        var result = Parse(
+            $"for f in a; do :; done; {mutation}; echo \"$f\"");
+
+        Assert.True(result.IsUnparseable);
+        Assert.Empty(result.Commands);
+        Assert.Empty(result.Clauses);
     }
 
     [Fact]
@@ -426,6 +693,48 @@ public class BashForInStructuralTests
     }
 
     [Fact]
+    public void Effective_argv_binding_alternative_cap_is_exact_and_never_truncated()
+    {
+        var exact = new BashLoopBindingContext()
+            .WithBinding("a", FiniteDomain(4))
+            .WithBinding("b", FiniteDomain(8));
+        var overflow = new BashLoopBindingContext()
+            .WithBinding("a", FiniteDomain(4))
+            .WithBinding("b", FiniteDomain(9));
+
+        Assert.Equal(
+            BashBindingAlternativeResult.Exact,
+            exact.EnumerateExactAlternatives(
+                ShellAnalysisLimits.MaxValueCandidates,
+                new[] { "a", "b" },
+                out var exactAlternatives));
+        Assert.Equal(ShellAnalysisLimits.MaxValueCandidates, exactAlternatives.Count);
+        Assert.Equal(
+            BashBindingAlternativeResult.ExceededLimit,
+            overflow.EnumerateExactAlternatives(
+                ShellAnalysisLimits.MaxValueCandidates,
+                new[] { "a", "b" },
+                out var overflowAlternatives));
+        Assert.Empty(overflowAlternatives);
+    }
+
+    [Theory]
+    [InlineData("cd")]
+    [InlineData("command -- cd")]
+    public void Unreferenced_unknown_binding_does_not_poison_static_cwd_transfer(
+        string dispatch)
+    {
+        var result = Parse(
+            $"for f in \"$UNKNOWN\"; do :; done; {dispatch} /tmp && pwd");
+
+        Assert.False(result.IsUnparseable, result.UnparseableReason);
+        AssertDomain(
+            result.Commands[2].WorkingDirectory,
+            ShellValueDomainKind.Exact,
+            "/tmp");
+    }
+
+    [Fact]
     public void Pipelines_compose_with_loop_ancestry_without_synthetic_operators()
     {
         var result = Parse("for f in a b; do printf '%s' \"$f\" | sort; done");
@@ -449,7 +758,6 @@ public class BashForInStructuralTests
     [InlineData("for f in a; do printf -v f x; done")]
     [InlineData("for f in a; do eval 'f=x'; done")]
     [InlineData("for f in a; do source script.sh; done")]
-    [InlineData("for f in a; do cd /tmp; done")]
     [InlineData("for f in a b; do trap 'f=x' DEBUG; echo \"$f\"; done")]
     [InlineData("for f in a; do command unset f; echo \"$f\"; done")]
     [InlineData("for f in a; do builtin unset f; echo \"$f\"; done")]
@@ -642,6 +950,12 @@ public class BashForInStructuralTests
         }).Parse(input);
 
     private static string CommandVerb(CommandOccurrence command) => command.Clause.Verb.Joined;
+
+    private static ShellValueDomain FiniteDomain(int count) => new()
+    {
+        Kind = ShellValueDomainKind.FiniteSet,
+        Values = Enumerable.Range(0, count).Select(index => $"v{index}").ToArray(),
+    };
 
     private static void AssertDomain(
         ShellValueDomain actual,

--- a/tests/ShellSyntaxTree.Tests/Parsing/BashStructuralProjectionTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Parsing/BashStructuralProjectionTests.cs
@@ -560,27 +560,27 @@ public class BashStructuralProjectionTests
     [InlineData("builtin builtin cd /outer && cat relative.txt")]
     [InlineData("command builtin cd /outer && cat relative.txt")]
     [InlineData("builtin command cd /outer && cat relative.txt")]
-    public void Nested_dispatch_wrapped_cwd_mutation_fails_closed(string source)
+    public void Nested_dispatch_wrapped_cwd_uses_the_effective_argv(string source)
     {
         var result = Parse(source);
 
-        Assert.Equal(ShellValueDomainKind.Unknown, result.Commands[1].WorkingDirectory.Kind);
-        Assert.Null(result.Clauses[1].Args[0].Resolved);
-        Assert.Contains(result.Clauses[1].Args, argument =>
-            argument.IsCwdAttribution && argument.Kind == ArgKind.DynamicSkip);
+        Assert.Equal(
+            "/outer",
+            Assert.Single(result.Commands[1].WorkingDirectory.Values));
+        Assert.Equal("/outer/relative.txt", result.Clauses[1].Args[0].Resolved);
     }
 
     [Theory]
     [InlineData("command cd /outer && cat relative.txt")]
     [InlineData("builtin cd /outer && cat relative.txt")]
-    public void Dispatch_wrapped_cwd_mutation_fails_closed(string source)
+    public void Dispatch_wrapped_cwd_uses_the_effective_argv(string source)
     {
         var result = Parse(source);
 
-        Assert.Equal(ShellValueDomainKind.Unknown, result.Commands[1].WorkingDirectory.Kind);
-        Assert.Null(result.Clauses[1].Args[0].Resolved);
-        Assert.Contains(result.Clauses[1].Args, argument =>
-            argument.IsCwdAttribution && argument.Kind == ArgKind.DynamicSkip);
+        Assert.Equal(
+            "/outer",
+            Assert.Single(result.Commands[1].WorkingDirectory.Values));
+        Assert.Equal("/outer/relative.txt", result.Clauses[1].Args[0].Resolved);
     }
 
     [Fact]

--- a/tests/ShellSyntaxTree.Tests/Parsing/ShellValueOracleTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Parsing/ShellValueOracleTests.cs
@@ -826,6 +826,54 @@ public class ShellValueOracleTests
         Assert.NotEqual(0, result.ExitCode);
     }
 
+    [Theory]
+    [InlineData("command -- cd /tmp")]
+    [InlineData("command -p cd /tmp")]
+    [InlineData("builtin -- cd /tmp")]
+    [InlineData("command -p -- builtin -- cd /tmp")]
+    public void Bash_runtime_dispatch_wrappers_preserve_cd_in_process(string dispatch)
+    {
+        if (!IsNativeBashAvailable())
+        {
+            return;
+        }
+
+        var output = Run("bash", "--noprofile", "--norc", "-c", $"cd /; {dispatch}; pwd");
+
+        Assert.Equal("/tmp", output);
+    }
+
+    [Fact]
+    public void Bash_runtime_cd_operand_count_and_option_status_match_transfer_grammar()
+    {
+        if (!IsNativeBashAvailable())
+        {
+            return;
+        }
+
+        var output = Run(
+            "bash",
+            "--noprofile",
+            "--norc",
+            "-c",
+            "HOME=/tmp; cd /; cd --; pwd; " +
+            "cd -Z >/dev/null 2>&1 || printf 'invalid\\n'; " +
+            "cd / /tmp >/dev/null 2>&1 || printf 'multiple\\n'; " +
+            "cd /; cd /tmp -- >/dev/null 2>&1 || printf 'terminator-after-operand\\n'; " +
+            "cd /; cd /tmp -P >/dev/null 2>&1 || printf 'option-after-operand\\n'");
+
+        Assert.Equal(
+            new[]
+            {
+                "/tmp",
+                "invalid",
+                "multiple",
+                "terminator-after-operand",
+                "option-after-operand",
+            },
+            Lines(output));
+    }
+
     private static bool IsAvailable(string executable)
     {
         try


### PR DESCRIPTION
## Summary

- interpret every admitted `cd` / `chdir` from ordered, visit-local effective argv
- model invalid and multiple operands as failure-only, recursively prove `command` / `builtin` wrappers, and preserve query semantics
- sanitize stale compatibility path resolutions and reject post-loop binding mutation or tracked unknown argv arity
- expand unit, native Bash-oracle, design-corpus, and executable-corpus coverage
- complete OpenSpec task 6.5c.3 and update the implementation plan

## Validation

- `dotnet build -c Release --no-restore`
- `dotnet test -c Release --no-build` (1,666 passed)
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`
- `dotnet format --verify-no-changes --no-restore`
- `openspec validate v0-3-structured-shell-analysis --strict --no-interactive`
- Slopwatch on all modified C# files: 0 findings
- adversarial exact-stage review: GO for `da2bc1ff1bb44d579cbca19f970de9c4acfe838fa64574bc674e843809932418`