### PR TITLE
Analyze local Invoke-Command regions

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -402,8 +402,13 @@ priorities.
       pin current-scope mutation, empty input, explicit input, phase order, and
       the differing no-input behavior of the two cmdlets. Ordinary assignment
       state transfer remains an atomic task 7.5b follow-up; task 7.5b is not
-      complete. Continue with in-process `Invoke-Command`; child
-      process/runspace jobs and parallel
+      complete. In-process `Invoke-Command` now distinguishes default child
+      variable/command scope from `-NoNewScope` current-scope flow while
+      propagating shared location and retaining synchronous/once region facts.
+      Pipelines with any supported synchronous execution region plus another
+      stateful stage withhold body facts that downstream initialization or
+      per-object interleaving can invalidate.
+      Child process/runspace jobs and parallel
       blocks; deferred breakpoint/event/completion actions; then unknown
       receiver and nested/adversarial matrices. Preserve script blocks proved
       to be data as opaque values, expose ambiguous bodies with incomplete

--- a/src/ShellSyntaxTree/Internal/Pwsh/Parsing/PwshForEachValueAnalysis.cs
+++ b/src/ShellSyntaxTree/Internal/Pwsh/Parsing/PwshForEachValueAnalysis.cs
@@ -988,7 +988,7 @@ internal sealed class PwshForEachValueAnalyzer
     private long _locationStateMutationCount;
     private long _childScopeEscapeRiskCount;
     private bool _pipelineStageMayReceiveInput;
-    private bool _pipelineCallbacksMayInterleave;
+    private bool _pipelineStageEffectsMayReachRegionBodies;
 
     private PwshForEachValueAnalyzer(
         PwshParserOptions options,
@@ -1220,6 +1220,15 @@ internal sealed class PwshForEachValueAnalyzer
                 flow);
         }
 
+        if (binding.ParameterSet == PwshExecutionRegionParameterSet.InvokeInProcess)
+        {
+            return AnalyzeInProcessInvokeCommand(
+                binding,
+                regions[0],
+                regionInput,
+                flow);
+        }
+
         var executionRegionEffectCount = _executionRegionEffectCount;
         var nonRegionStateMutationCount = _nonRegionStateMutationCount;
         var bodyFlow = AnalyzeExecutionRegionBody(regions[0].Body, regionInput);
@@ -1228,6 +1237,48 @@ internal sealed class PwshForEachValueAnalyzer
         return bodyFlow.JoinedState is AnalysisContext bodyExit
             ? PwshFlowResult.Both(bodyExit)
             : flow;
+    }
+
+    private PwshFlowResult AnalyzeInProcessInvokeCommand(
+        PwshExecutionRegionBindingResult binding,
+        ExecutionRegionSyntax region,
+        AnalysisContext input,
+        PwshFlowResult fallback)
+    {
+        var executionRegionEffectCount = _executionRegionEffectCount;
+        var nonRegionStateMutationCount = _nonRegionStateMutationCount;
+        var locationStateMutationCount = _locationStateMutationCount;
+        var childScopeEscapeRiskCount = _childScopeEscapeRiskCount;
+        var body = AnalyzeExecutionRegionBody(region.Body, input);
+        var locationMutated = _locationStateMutationCount > locationStateMutationCount;
+        var childScopeMayEscape =
+            _childScopeEscapeRiskCount > childScopeEscapeRiskCount;
+        _executionRegionEffectCount = executionRegionEffectCount + 1;
+        _nonRegionStateMutationCount = nonRegionStateMutationCount;
+
+        if (binding.HasNoNewScope)
+        {
+            return body.JoinedState is AnalysisContext bodyExit
+                ? PwshFlowResult.Both(bodyExit)
+                : fallback;
+        }
+
+        _childScopeEscapeRiskCount = childScopeEscapeRiskCount +
+            (childScopeMayEscape ? 1 : 0);
+        var restoredExit = AnalysisContext.JoinNullable(
+            RestoreChildScopeExit(
+                body.OnSuccess,
+                input,
+                locationMutated,
+                childScopeMayEscape),
+            RestoreChildScopeExit(
+                body.OnFailure,
+                input,
+                locationMutated,
+                childScopeMayEscape));
+        return restoredExit is AnalysisContext joined
+            ? PwshFlowResult.Both(joined)
+            : fallback;
     }
 
     private PwshFlowResult AnalyzePipelineCallbackRegions(
@@ -1362,7 +1413,7 @@ internal sealed class PwshForEachValueAnalyzer
     {
         var enclosingStageMayReceiveInput = _pipelineStageMayReceiveInput;
         _pipelineStageMayReceiveInput = false;
-        var bodyInput = _pipelineCallbacksMayInterleave
+        var bodyInput = _pipelineStageEffectsMayReachRegionBodies
             ? input.Invalidate(unknownCwd: true)
             : input;
         var flow = AnalyzeBlock(body, bodyInput);
@@ -1445,6 +1496,7 @@ internal sealed class PwshForEachValueAnalyzer
         binding.Status == PwshExecutionRegionBindingStatus.ProvedExecution &&
         (binding.ParameterSet is PwshExecutionRegionParameterSet.MeasureExpression or
             PwshExecutionRegionParameterSet.TraceExpression or
+            PwshExecutionRegionParameterSet.InvokeInProcess or
             PwshExecutionRegionParameterSet.ForEachScriptBlock or
             PwshExecutionRegionParameterSet.WhereScriptBlock) &&
         AllBindingsAreCompleteAndSynchronous(binding.Bindings);
@@ -1606,8 +1658,10 @@ internal sealed class PwshForEachValueAnalyzer
     private PwshFlowResult AnalyzePipeline(PipelineSyntax pipeline, AnalysisContext input)
     {
         var stageInput = input;
-        var enclosingCallbacksMayInterleave = _pipelineCallbacksMayInterleave;
-        _pipelineCallbacksMayInterleave |= PipelineCallbacksMayInterleave(pipeline);
+        var enclosingStageEffectsMayReachBodies =
+            _pipelineStageEffectsMayReachRegionBodies;
+        _pipelineStageEffectsMayReachRegionBodies |=
+            PipelineStageEffectsMayReachRegionBodies(pipeline);
         try
         {
             for (var stageIndex = 0; stageIndex < pipeline.Stages.Count; stageIndex++)
@@ -1644,35 +1698,43 @@ internal sealed class PwshForEachValueAnalyzer
         }
         finally
         {
-            _pipelineCallbacksMayInterleave = enclosingCallbacksMayInterleave;
+            _pipelineStageEffectsMayReachRegionBodies =
+                enclosingStageEffectsMayReachBodies;
         }
     }
 
-    private static bool PipelineCallbacksMayInterleave(PipelineSyntax pipeline)
+    private static bool PipelineStageEffectsMayReachRegionBodies(PipelineSyntax pipeline)
     {
-        var hasCallback = false;
+        var hasPipelineSensitiveRegion = false;
         var statefulStageCount = 0;
         for (var index = 0; index < pipeline.Stages.Count; index++)
         {
             var stage = pipeline.Stages[index];
-            hasCallback |= ContainsPipelineCallback(stage);
+            hasPipelineSensitiveRegion |= ContainsPipelineSensitiveExecutionRegion(stage);
             if (MayMutatePipelineState(stage))
             {
                 statefulStageCount++;
             }
         }
 
-        return hasCallback && statefulStageCount > 1;
+        return hasPipelineSensitiveRegion && statefulStageCount > 1;
     }
 
-    private static bool ContainsPipelineCallback(ShellSyntaxNode node) =>
+    private static bool ContainsPipelineSensitiveExecutionRegion(ShellSyntaxNode node) =>
         node switch
         {
-            SimpleCommandSyntax simple => IsPipelineCallback(simple),
-            ShellBlockSyntax block => BlockContains(block, ContainsPipelineCallback),
-            GroupSyntax group => ContainsPipelineCallback(group.Body),
-            CommandListSyntax list => ListContains(list, ContainsPipelineCallback),
-            PipelineSyntax pipeline => PipelineContains(pipeline, ContainsPipelineCallback),
+            SimpleCommandSyntax simple => IsPipelineSensitiveExecutionRegionHost(simple),
+            ShellBlockSyntax block => BlockContains(
+                block,
+                ContainsPipelineSensitiveExecutionRegion),
+            GroupSyntax group => ContainsPipelineSensitiveExecutionRegion(group.Body),
+            CommandListSyntax list => ListContains(
+                list,
+                ContainsPipelineSensitiveExecutionRegion),
+            PipelineSyntax pipeline => PipelineContains(
+                pipeline,
+                ContainsPipelineSensitiveExecutionRegion),
+            ExecutionRegionSyntax => true,
             _ => false,
         };
 
@@ -1690,14 +1752,17 @@ internal sealed class PwshForEachValueAnalyzer
             _ => false,
         };
 
-    private static bool IsPipelineCallback(SimpleCommandSyntax simple)
+    private static bool IsPipelineSensitiveExecutionRegionHost(SimpleCommandSyntax simple)
     {
         var binding = PwshExecutionRegionBindingCatalog.Bind(
             simple.Clause,
             commandIdentityProven: true);
         return binding.Status == PwshExecutionRegionBindingStatus.ProvedExecution &&
             binding.ParameterSet is PwshExecutionRegionParameterSet.ForEachScriptBlock or
-                PwshExecutionRegionParameterSet.WhereScriptBlock;
+                PwshExecutionRegionParameterSet.WhereScriptBlock or
+                PwshExecutionRegionParameterSet.InvokeInProcess or
+                PwshExecutionRegionParameterSet.MeasureExpression or
+                PwshExecutionRegionParameterSet.TraceExpression;
     }
 
     private static bool SimpleMayMutatePipelineState(SimpleCommandSyntax simple)
@@ -1818,19 +1883,19 @@ internal sealed class PwshForEachValueAnalyzer
         }
 
         return new PwshFlowResult(
-            RestoreDirectCallExit(
+            RestoreChildScopeExit(
                 body.OnSuccess,
                 input,
                 locationMutated,
                 childScopeMayEscape),
-            RestoreDirectCallExit(
+            RestoreChildScopeExit(
                 body.OnFailure,
                 input,
                 locationMutated,
                 childScopeMayEscape));
     }
 
-    private static AnalysisContext? RestoreDirectCallExit(
+    private static AnalysisContext? RestoreChildScopeExit(
         AnalysisContext? bodyExit,
         AnalysisContext input,
         bool locationMutated,

--- a/src/ShellSyntaxTree/Internal/Pwsh/Verbs/PwshExecutionRegionBindingCatalog.cs
+++ b/src/ShellSyntaxTree/Internal/Pwsh/Verbs/PwshExecutionRegionBindingCatalog.cs
@@ -92,6 +92,8 @@ internal sealed record PwshExecutionRegionBindingResult
 
     internal bool HasExplicitInputObject { get; init; }
 
+    internal bool HasNoNewScope { get; init; }
+
     internal IReadOnlyList<PwshExecutionRegionBinding> Bindings { get; init; } =
         Array.Empty<PwshExecutionRegionBinding>();
 }
@@ -443,6 +445,8 @@ internal static class PwshExecutionRegionBindingCatalog
             ParameterSet = parameterSet,
             CanonicalCommandName = canonicalName,
             HasExplicitInputObject = arguments.HasNamed("InputObject"),
+            HasNoNewScope = receiver == PwshExecutionRegionReceiver.InvokeCommand &&
+                arguments.IsSwitchEnabled("NoNewScope"),
             Bindings = bindings.OrderBy(binding => binding.HostClauseElementIndex).ToArray(),
         };
     }
@@ -1571,6 +1575,33 @@ internal static class PwshExecutionRegionBindingCatalog
         }
 
         internal bool HasNamed(string name) => NamedParameters.Contains(name);
+
+        internal bool IsSwitchEnabled(string name)
+        {
+            if (!HasNamed(name))
+            {
+                return false;
+            }
+
+            foreach (var argument in NamedArguments)
+            {
+                if (!string.Equals(
+                        argument.ParameterName,
+                        name,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                return string.Equals(
+                        argument.Value,
+                        "$true",
+                        StringComparison.OrdinalIgnoreCase) ||
+                    argument.Value == "1";
+            }
+
+            return true;
+        }
 
         internal bool HasAnyNamed(params string[] names) => names.Any(HasNamed);
 

--- a/tests/ShellSyntaxTree.Tests/Parsing/PwshExecutionRegionBindingCatalogTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Parsing/PwshExecutionRegionBindingCatalogTests.cs
@@ -297,6 +297,20 @@ public class PwshExecutionRegionBindingCatalogTests
 
         Assert.Equal(PwshExecutionRegionParameterSet.InvokeInProcess, local.ParameterSet);
         Assert.True(Assert.Single(local.Bindings).IsComplete);
+        Assert.True(local.HasNoNewScope);
+        var positionalLocal = Bind("Invoke-Command { Get-Date }");
+        Assert.Equal(
+            PwshExecutionRegionParameterSet.InvokeInProcess,
+            positionalLocal.ParameterSet);
+        Assert.False(positionalLocal.HasNoNewScope);
+        Assert.False(Bind(
+            "Invoke-Command -NoNewScope:$false { Get-Date }").HasNoNewScope);
+        Assert.True(Bind(
+            "Invoke-Command -NoNewScope:$true { Get-Date }").HasNoNewScope);
+        Assert.False(Bind(
+            "Invoke-Command -NoNewScope:0 { Get-Date }").HasNoNewScope);
+        Assert.True(Bind(
+            "Invoke-Command -NoNewScope:1 { Get-Date }").HasNoNewScope);
         Assert.Equal(PwshExecutionRegionParameterSet.InvokeRemote, remote.ParameterSet);
         var remoteBinding = Assert.Single(remote.Bindings);
         Assert.Equal(ExecutionRegionTiming.Unknown, remoteBinding.Timing);

--- a/tests/ShellSyntaxTree.Tests/Parsing/PwshExecutionRegionStructuralTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Parsing/PwshExecutionRegionStructuralTests.cs
@@ -35,6 +35,150 @@ public class PwshExecutionRegionStructuralTests
         Assert.All(result.Commands, command => Assert.True(command.IsComplete));
     }
 
+    [Theory]
+    [InlineData("Invoke-Command { Get-Item child.txt }")]
+    [InlineData("icm -ScriptBlock { Get-Item child.txt }")]
+    [InlineData("Microsoft.PowerShell.Core\\Invoke-Command { Get-Item child.txt }")]
+    public void In_process_invoke_command_publishes_a_synchronous_once_region(
+        string source)
+    {
+        var result = ParseIsolated(source);
+
+        var host = Assert.IsType<SimpleCommandSyntax>(Assert.Single(result.Syntax.Statements));
+        var region = Assert.Single(host.ExecutionRegions);
+        Assert.Equal(ExecutionRegionOrigin.CommandArgument, region.Origin);
+        Assert.Equal(ExecutionRegionPhase.Main, region.Phase);
+        Assert.Equal(ExecutionRegionTiming.Synchronous, region.Timing);
+        Assert.Equal(ExecutionRegionCardinality.Once, region.Cardinality);
+        Assert.Equal(2, result.Commands.Count);
+        Assert.All(result.Commands, command => Assert.True(command.IsComplete));
+    }
+
+    [Fact]
+    public void In_process_invoke_command_isolates_bindings_but_shares_location()
+    {
+        var result = ParseIsolated(
+            "foreach ($x in 'outer') { }; Invoke-Command { " +
+            "foreach ($x in 'inner') { }; Set-Location /tmp }; " +
+            "Write-Output $x; Get-Item child.txt");
+
+        var continuation = result.Commands
+            .Where(command => command.Clause.Verb.Tokens[0] is "Write-Output" or "Get-Item")
+            .TakeLast(2)
+            .ToArray();
+        Assert.Equal(
+            new[] { "outer" },
+            Assert.Single(continuation[0].EffectiveArguments).Value.Values);
+        Assert.Equal(
+            ShellValueDomainKind.Unknown,
+            continuation[1].WorkingDirectory.Kind);
+        Assert.All(continuation, command => Assert.True(command.IsComplete));
+    }
+
+    [Fact]
+    public void In_process_invoke_command_no_new_scope_shares_supported_state()
+    {
+        var result = ParseIsolated(
+            "foreach ($x in 'outer') { }; Invoke-Command -NoNewScope { " +
+            "foreach ($x in 'inner') { }; Set-Location /tmp }; " +
+            "Write-Output $x; Get-Item child.txt");
+
+        var continuation = result.Commands
+            .Where(command => command.Clause.Verb.Tokens[0] is "Write-Output" or "Get-Item")
+            .TakeLast(2)
+            .ToArray();
+        Assert.Equal(
+            new[] { "inner" },
+            Assert.Single(continuation[0].EffectiveArguments).Value.Values);
+        Assert.Equal(
+            ShellValueDomainKind.Unknown,
+            continuation[1].WorkingDirectory.Kind);
+        Assert.All(continuation, command => Assert.True(command.IsComplete));
+    }
+
+    [Fact]
+    public void In_process_invoke_command_explicit_false_no_new_scope_isolates_state()
+    {
+        var result = ParseIsolated(
+            "foreach ($x in 'outer') { }; " +
+            "Invoke-Command -NoNewScope:$false { foreach ($x in 'inner') { } }; " +
+            "Write-Output $x");
+
+        var continuation = result.Commands.Last();
+        Assert.Equal(
+            new[] { "outer" },
+            Assert.Single(continuation.EffectiveArguments).Value.Values);
+        Assert.True(continuation.IsComplete);
+    }
+
+    [Theory]
+    [InlineData("Invoke-Command -ComputerName server -ScriptBlock { Get-Date }")]
+    [InlineData("Invoke-Command -AsJob -ScriptBlock { Get-Date }")]
+    [InlineData("Invoke-Command -NoNewScope:$scope -ScriptBlock { Get-Date }")]
+    public void Unproved_invoke_command_shapes_remain_unknown(string source)
+    {
+        var result = ParseIsolated(source);
+
+        var host = Assert.IsType<SimpleCommandSyntax>(Assert.Single(result.Syntax.Statements));
+        var region = Assert.Single(host.ExecutionRegions);
+        Assert.Equal(ExecutionRegionPhase.Unknown, region.Phase);
+        Assert.Equal(ExecutionRegionTiming.Unknown, region.Timing);
+        Assert.Equal(ExecutionRegionCardinality.Unknown, region.Cardinality);
+        Assert.All(result.Commands, command => Assert.False(command.IsComplete));
+    }
+
+    [Fact]
+    public void In_process_invoke_command_child_scope_isolates_alias_mutation()
+    {
+        var result = ParseIsolated(
+            "Invoke-Command { Set-Alias Measure-Command Write-Output }; " +
+            "Measure-Command { Get-Date }");
+
+        var host = result.Syntax.Statements
+            .OfType<CommandListSyntax>()
+            .SelectMany(list => list.Items)
+            .Select(item => item.Command)
+            .OfType<SimpleCommandSyntax>()
+            .Last();
+        Assert.Equal(
+            ExecutionRegionPhase.Main,
+            Assert.Single(host.ExecutionRegions).Phase);
+        Assert.True(result.Commands.Last().IsComplete);
+    }
+
+    [Fact]
+    public void In_process_invoke_command_no_new_scope_propagates_alias_mutation()
+    {
+        var result = ParseIsolated(
+            "Invoke-Command -NoNewScope { Set-Alias Measure-Command Write-Output }; " +
+            "Measure-Command { Get-Date }");
+
+        var host = result.Syntax.Statements
+            .OfType<CommandListSyntax>()
+            .SelectMany(list => list.Items)
+            .Select(item => item.Command)
+            .OfType<SimpleCommandSyntax>()
+            .Last();
+        Assert.Equal(
+            ExecutionRegionPhase.Unknown,
+            Assert.Single(host.ExecutionRegions).Phase);
+        Assert.False(result.Commands.Last().IsComplete);
+    }
+
+    [Fact]
+    public void In_process_invoke_command_joins_body_outcomes_before_host_continuation()
+    {
+        var result = ParseIsolated(
+            "Invoke-Command { Set-Location /maybe } && Get-Item child.txt");
+
+        var continuation = result.Commands.Last();
+        Assert.Equal("Get-Item", continuation.Clause.Verb.Tokens[0]);
+        Assert.Equal(
+            ShellValueDomainKind.Unknown,
+            continuation.WorkingDirectory.Kind);
+        Assert.True(continuation.IsComplete);
+    }
+
     [Fact]
     public void Current_scope_once_receiver_propagates_binding_state()
     {
@@ -438,6 +582,37 @@ public class PwshExecutionRegionStructuralTests
         Assert.Equal(
             ShellValueDomainKind.Unknown,
             Assert.Single(callbackWrite.EffectiveArguments).Value.Kind);
+    }
+
+    [Theory]
+    [InlineData("Invoke-Command", "")]
+    [InlineData("Invoke-Command -NoNewScope", "")]
+    [InlineData(".", "")]
+    [InlineData("&", "")]
+    [InlineData("Measure-Command", "")]
+    [InlineData("Trace-Command -Name ParameterBinding -Expression", " -PSHost")]
+    public void Pipeline_stage_effects_make_synchronous_region_state_unknown(
+        string invocation,
+        string trailingArguments)
+    {
+        var result = ParseIsolated(
+            "foreach ($x in 'start') { }; " + invocation + " { " +
+            "Write-Output $x; Write-Output $x; foreach ($x in 'end') { } }" +
+            trailingArguments + " | " +
+            "Write-Output -OutVariable x");
+
+        var upstream = result.Commands
+            .Where(command => command.Clause.Verb.Tokens[0] == "Write-Output")
+            .Take(2)
+            .ToArray();
+        Assert.Equal(2, upstream.Length);
+        Assert.All(upstream, command =>
+        {
+            Assert.False(command.IsComplete);
+            Assert.Equal(
+                ShellValueDomainKind.Unknown,
+                Assert.Single(command.EffectiveArguments).Value.Kind);
+        });
     }
 
     [Fact]

--- a/tests/ShellSyntaxTree.Tests/Parsing/ShellValueOracleTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Parsing/ShellValueOracleTests.cs
@@ -1095,19 +1095,34 @@ public class ShellValueOracleTests
             "-NoProfile",
             "-NonInteractive",
             "-Command",
-            "$x='outer'; Set-Location /; " +
-            "Invoke-Command { $x='inner'; Set-Location /tmp; Set-Alias zz Get-Date }; " +
-            "\"default-x=<$x>\"; \"default-cwd=<$((Get-Location).Path)>\"; " +
+            "$start=(Get-Location).Path; " +
+            "$temp=[IO.Path]::TrimEndingDirectorySeparator(" +
+            "(Resolve-Path ([IO.Path]::GetTempPath())).Path); " +
+            "$root=[IO.Path]::TrimEndingDirectorySeparator(" +
+            "[IO.Path]::GetPathRoot($start)); " +
+            "$target=if($temp -ne $start){$temp}else{$root}; " +
+            "if(!$target -or $target -eq $start -or " +
+            "!(Test-Path -LiteralPath $target -PathType Container)){throw 'target'}; " +
+            "\"target-distinct=<$($target -ne $start)>\"; " +
+            "$x='outer'; Invoke-Command { " +
+            "$x='inner'; Set-Location $target; Set-Alias zz Get-Date }; " +
+            "\"default-x=<$x>\"; " +
+            "\"default-cwd-target=<$((Get-Location).Path -eq $target)>\"; " +
             "\"default-alias=<$([bool](Get-Alias zz -ErrorAction Ignore))>\"; " +
             "$x='outer'; Invoke-Command -NoNewScope:$false { $x='false-inner' }; " +
-            "\"false-x=<$x>\"; Set-Location /; Invoke-Command -NoNewScope:$true { " +
-            "$x='shared'; Set-Location /tmp; Set-Alias zz Get-Date }; " +
-            "\"shared-x=<$x>\"; \"shared-cwd=<$((Get-Location).Path)>\"; " +
+            "\"false-x=<$x>\"; Set-Location $start; " +
+            "Invoke-Command -NoNewScope:$true { " +
+            "$x='shared'; Set-Location $target; Set-Alias zz Get-Date }; " +
+            "\"shared-x=<$x>\"; " +
+            "\"shared-cwd-target=<$((Get-Location).Path -eq $target)>\"; " +
             "\"shared-alias=<$([bool](Get-Alias zz -ErrorAction Ignore))>\"; " +
-            "Set-Location /; Invoke-Command { " +
-            "Set-Location /definitely-missing-shellsyntaxtree " +
+            "Set-Location $start; " +
+            "$missing=Join-Path $start ('missing-'+[guid]::NewGuid().ToString('N')); " +
+            "if(Test-Path -LiteralPath $missing){throw 'missing'}; " +
+            "Invoke-Command { Set-Location $missing " +
             "-ErrorAction SilentlyContinue }; " +
-            "\"failure-status=<$?>\"; \"failure-cwd=<$((Get-Location).Path)>\"; " +
+            "\"failure-status=<$?>\"; " +
+            "\"failure-cwd-start=<$((Get-Location).Path -eq $start)>\"; " +
             "$x='start'; Invoke-Command -NoNewScope { " +
             "\"invoke-interleave=<$x>\"; \"invoke-interleave=<$x>\" } | " +
             "Write-Output -OutVariable x | Out-Null; $x; " +
@@ -1121,15 +1136,16 @@ public class ShellValueOracleTests
         Assert.Equal(
             new[]
             {
+                "target-distinct=<True>",
                 "default-x=<outer>",
-                "default-cwd=</tmp>",
+                "default-cwd-target=<True>",
                 "default-alias=<False>",
                 "false-x=<outer>",
                 "shared-x=<shared>",
-                "shared-cwd=</tmp>",
+                "shared-cwd-target=<True>",
                 "shared-alias=<True>",
                 "failure-status=<True>",
-                "failure-cwd=</>",
+                "failure-cwd-start=<True>",
                 "invoke-interleave=<>",
                 "invoke-interleave=<invoke-interleave=<>>",
                 "measure-stage=<>",

--- a/tests/ShellSyntaxTree.Tests/Parsing/ShellValueOracleTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Parsing/ShellValueOracleTests.cs
@@ -1082,6 +1082,62 @@ public class ShellValueOracleTests
             Lines(output));
     }
 
+    [Fact]
+    public void PowerShell_synchronous_regions_observe_scope_and_pipeline_stage_effects()
+    {
+        if (!IsAvailable("pwsh"))
+        {
+            return;
+        }
+
+        var output = Run(
+            "pwsh",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            "$x='outer'; Set-Location /; " +
+            "Invoke-Command { $x='inner'; Set-Location /tmp; Set-Alias zz Get-Date }; " +
+            "\"default-x=<$x>\"; \"default-cwd=<$((Get-Location).Path)>\"; " +
+            "\"default-alias=<$([bool](Get-Alias zz -ErrorAction Ignore))>\"; " +
+            "$x='outer'; Invoke-Command -NoNewScope:$false { $x='false-inner' }; " +
+            "\"false-x=<$x>\"; Set-Location /; Invoke-Command -NoNewScope:$true { " +
+            "$x='shared'; Set-Location /tmp; Set-Alias zz Get-Date }; " +
+            "\"shared-x=<$x>\"; \"shared-cwd=<$((Get-Location).Path)>\"; " +
+            "\"shared-alias=<$([bool](Get-Alias zz -ErrorAction Ignore))>\"; " +
+            "Set-Location /; Invoke-Command { " +
+            "Set-Location /definitely-missing-shellsyntaxtree " +
+            "-ErrorAction SilentlyContinue }; " +
+            "\"failure-status=<$?>\"; \"failure-cwd=<$((Get-Location).Path)>\"; " +
+            "$x='start'; Invoke-Command -NoNewScope { " +
+            "\"invoke-interleave=<$x>\"; \"invoke-interleave=<$x>\" } | " +
+            "Write-Output -OutVariable x | Out-Null; $x; " +
+            "$x='start'; Measure-Command { " +
+            "Write-Host \"measure-stage=<$x>\" } | " +
+            "Write-Output -OutVariable x | Out-Null; " +
+            "$x='start'; Trace-Command -Name ParameterBinding -Expression { " +
+            "\"trace-stage=<$x>\" } -PSHost 5>$null | " +
+            "Write-Output -OutVariable x | Out-Null; $x");
+
+        Assert.Equal(
+            new[]
+            {
+                "default-x=<outer>",
+                "default-cwd=</tmp>",
+                "default-alias=<False>",
+                "false-x=<outer>",
+                "shared-x=<shared>",
+                "shared-cwd=</tmp>",
+                "shared-alias=<True>",
+                "failure-status=<True>",
+                "failure-cwd=</>",
+                "invoke-interleave=<>",
+                "invoke-interleave=<invoke-interleave=<>>",
+                "measure-stage=<>",
+                "trace-stage=<>",
+            },
+            Lines(output));
+    }
+
     private static bool IsAvailable(string executable)
     {
         try


### PR DESCRIPTION
## Summary

- promote proved in-process Invoke-Command script blocks to synchronous, once execution regions
- distinguish default child variable and command scope from NoNewScope shared state while preserving failure-aware shared location
- evaluate literal NoNewScope switch truth and keep remote, job, dynamic, and ambiguous forms unknown or incomplete
- withhold stale region-body facts when downstream pipeline setup or per-object execution can mutate supported state

## Security model

The analyzer joins restored body success and failure exits before projecting local Invoke-Command host flow, because inner nonterminating failures can leave the host successful. Pipeline-sensitive bodies for callbacks, local Invoke, Measure, Trace, dot-source, and direct-call start from unknown state when another stateful stage can affect them. Unsupported parameter sets remain fail closed.

## Validation

- dotnet build -c Release: 0 warnings
- dotnet test -c Release --no-build: 2,129 passed
- file-header verification passed
- strict OpenSpec validation passed
- Slopwatch strict scan passed with zero findings
- adversarial review GO on frozen staged SHA-256 d1906990618c4383d926222116c3d38487813b09894350a9710ae3289a2a3b62