### PR TITLE
Analyze Start-Job child process regions

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -415,7 +415,17 @@ priorities.
       resolution preferences, and retains conservative host command-resolution
       invalidation for exported functions across canonical, alias, and supported
       module-qualified identities.
-      Child process/runspace jobs and parallel
+      `Start-Job` now schedules initialization before main in an isolated child
+      process state, inherits or applies the invocation working directory, and
+      prevents child exit mutation from contaminating the host continuation.
+      Inline working-directory values retain exact value provenance, while an
+      explicit relative working directory remains unknown because PowerShell
+      resolves it from a platform-specific child startup location rather than
+      the caller location. Known but unsupported job variants retain their
+      proved child-process isolation while their body analysis stays fail
+      closed; an explicit alternate `-PSVersion` remains visible but incomplete
+      because it falls outside the pinned PowerShell 7 runtime model.
+      Child runspace jobs and parallel
       blocks; deferred breakpoint/event/completion actions; then unknown
       receiver and nested/adversarial matrices. Preserve script blocks proved
       to be data as opaque values, expose ambiguous bodies with incomplete

--- a/src/ShellSyntaxTree/Internal/Pwsh/Parsing/PwshForEachValueAnalysis.cs
+++ b/src/ShellSyntaxTree/Internal/Pwsh/Parsing/PwshForEachValueAnalysis.cs
@@ -1202,10 +1202,13 @@ internal sealed class PwshForEachValueAnalyzer
             return flow;
         }
 
+        var commandIdentityProven = IsCommandIdentityProven(
+            simple.Clause,
+            receiverInput);
         var binding = PwshExecutionRegionBindingCatalog.Bind(
             simple.Clause,
-            IsCommandIdentityProven(simple.Clause, receiverInput));
-        if (!IsSupportedSynchronousReceiver(binding) ||
+            commandIdentityProven);
+        if (!IsSupportedExecutionRegionReceiver(binding) ||
             !TryApplyExecutionRegionBindings(simple, binding, out var regions))
         {
             RecordExecutionRegions(
@@ -1213,6 +1216,12 @@ internal sealed class PwshForEachValueAnalyzer
                 simple.ExecutionRegions,
                 simple.ExecutionRegions);
             _executionRegionEffectCount++;
+            if (commandIdentityProven &&
+                binding.Receiver == PwshExecutionRegionReceiver.StartJob)
+            {
+                return flow;
+            }
+
             _childScopeEscapeRiskCount++;
             return new PwshFlowResult(
                 flow.OnSuccess is AnalysisContext success
@@ -1255,6 +1264,11 @@ internal sealed class PwshForEachValueAnalyzer
                 ? receiverInput.Invalidate(unknownCwd: false)
                 : receiverInput;
             return AnalyzeNewModule(regions[0], bodyInput, flow);
+        }
+
+        if (binding.ParameterSet == PwshExecutionRegionParameterSet.StartJobScriptBlock)
+        {
+            return AnalyzeStartJob(simple, binding, regions, receiverInput, flow);
         }
 
         var executionRegionEffectCount = _executionRegionEffectCount;
@@ -1303,6 +1317,92 @@ internal sealed class PwshForEachValueAnalyzer
         }
 
         return PwshFlowResult.Both(hostExit.WithCwd(bodyExit.WorkingDirectory));
+    }
+
+    private PwshFlowResult AnalyzeStartJob(
+        SimpleCommandSyntax simple,
+        PwshExecutionRegionBindingResult binding,
+        IReadOnlyList<ExecutionRegionSyntax> regions,
+        AnalysisContext receiverInput,
+        PwshFlowResult hostFlow)
+    {
+        var executionRegionEffectCount = _executionRegionEffectCount;
+        var nonRegionStateMutationCount = _nonRegionStateMutationCount;
+        var locationStateMutationCount = _locationStateMutationCount;
+        var childScopeEscapeRiskCount = _childScopeEscapeRiskCount;
+        try
+        {
+            var child = CreateStartJobInput(simple, binding, receiverInput);
+            if (TryAnalyzeRegionPhase(
+                    regions,
+                    ExecutionRegionPhase.Initialization,
+                    child,
+                    out var initialized))
+            {
+                TryAnalyzeRegionPhase(
+                    regions,
+                    ExecutionRegionPhase.Main,
+                    initialized,
+                    out _);
+            }
+        }
+        finally
+        {
+            _executionRegionEffectCount = executionRegionEffectCount + regions.Count;
+            _nonRegionStateMutationCount = nonRegionStateMutationCount;
+            _locationStateMutationCount = locationStateMutationCount;
+            _childScopeEscapeRiskCount = childScopeEscapeRiskCount;
+        }
+
+        return hostFlow;
+    }
+
+    private AnalysisContext CreateStartJobInput(
+        SimpleCommandSyntax simple,
+        PwshExecutionRegionBindingResult binding,
+        AnalysisContext receiverInput)
+    {
+        var child = receiverInput
+            .Invalidate(unknownCwd: false, invalidateCommandResolution: false)
+            .WithoutBindings();
+        if (binding.WorkingDirectoryElementIndex is not int elementIndex)
+        {
+            return child;
+        }
+
+        if (!TryGetElementValue(
+                simple,
+                elementIndex,
+                binding.WorkingDirectoryValueOffset,
+                out var targetValue))
+        {
+            return child.WithCwd(workingDirectory: null);
+        }
+
+        if (receiverInput.TryEvaluateValue(targetValue, out var domain) &&
+            domain.Kind == ShellValueDomainKind.Exact &&
+            domain.Values.Count == 1)
+        {
+            targetValue = ShellValue.Literal(domain.Values[0]);
+        }
+
+        var options = new PwshParserOptions
+        {
+            HomeDirectory = _options.HomeDirectory,
+            WorkingDirectory = receiverInput.WorkingDirectory,
+            InitialStateMode = _options.InitialStateMode,
+        };
+        var resolved = PwshResolver.Resolve(
+            targetValue,
+            treatAsPath: true,
+            options,
+            workingDirectoryUnknown: true,
+            ShellResolutionConsumer.PowerShellCmdletPath);
+        return child.WithCwd(
+            resolved.IsPath &&
+            resolved.Resolved is not null
+                ? resolved.Resolved
+                : null);
     }
 
     private PwshFlowResult AnalyzeInProcessInvokeCommand(
@@ -1557,19 +1657,37 @@ internal sealed class PwshForEachValueAnalyzer
         return true;
     }
 
-    private static bool IsSupportedSynchronousReceiver(
-        PwshExecutionRegionBindingResult binding) =>
-        binding.Status == PwshExecutionRegionBindingStatus.ProvedExecution &&
-        (binding.ParameterSet is PwshExecutionRegionParameterSet.MeasureExpression or
-            PwshExecutionRegionParameterSet.TraceExpression or
-            PwshExecutionRegionParameterSet.InvokeInProcess or
-            PwshExecutionRegionParameterSet.NewModuleScriptBlock or
-            PwshExecutionRegionParameterSet.ForEachScriptBlock or
-            PwshExecutionRegionParameterSet.WhereScriptBlock) &&
-        AllBindingsAreCompleteAndSynchronous(binding.Bindings);
+    private static bool IsSupportedExecutionRegionReceiver(
+        PwshExecutionRegionBindingResult binding)
+    {
+        if (binding.Status != PwshExecutionRegionBindingStatus.ProvedExecution)
+        {
+            return false;
+        }
 
-    private static bool AllBindingsAreCompleteAndSynchronous(
-        IReadOnlyList<PwshExecutionRegionBinding> bindings)
+        return binding.ParameterSet switch
+        {
+            PwshExecutionRegionParameterSet.StartJobScriptBlock =>
+                !binding.HasExplicitPSVersion &&
+                AllBindingsAreCompleteWithTiming(
+                    binding.Bindings,
+                    ExecutionRegionTiming.Concurrent),
+            PwshExecutionRegionParameterSet.MeasureExpression or
+                PwshExecutionRegionParameterSet.TraceExpression or
+                PwshExecutionRegionParameterSet.InvokeInProcess or
+                PwshExecutionRegionParameterSet.NewModuleScriptBlock or
+                PwshExecutionRegionParameterSet.ForEachScriptBlock or
+                PwshExecutionRegionParameterSet.WhereScriptBlock =>
+                AllBindingsAreCompleteWithTiming(
+                    binding.Bindings,
+                    ExecutionRegionTiming.Synchronous),
+            _ => false,
+        };
+    }
+
+    private static bool AllBindingsAreCompleteWithTiming(
+        IReadOnlyList<PwshExecutionRegionBinding> bindings,
+        ExecutionRegionTiming timing)
     {
         if (bindings.Count == 0)
         {
@@ -1579,7 +1697,7 @@ internal sealed class PwshForEachValueAnalyzer
         for (var index = 0; index < bindings.Count; index++)
         {
             if (!bindings[index].IsComplete ||
-                bindings[index].Timing != ExecutionRegionTiming.Synchronous)
+                bindings[index].Timing != timing)
             {
                 return false;
             }
@@ -2253,16 +2371,40 @@ internal sealed class PwshForEachValueAnalyzer
         AnalysisContext input,
         out ShellValueDomain domain)
     {
+        if (TryGetElementValue(simple, elementIndex, 0, out var value))
+        {
+            return input.TryEvaluateValue(value, out domain);
+        }
+
+        domain = ShellValueDomain.Unknown;
+        return false;
+    }
+
+    private bool TryGetElementValue(
+        SimpleCommandSyntax simple,
+        int elementIndex,
+        int valueOffset,
+        out ShellValue value)
+    {
         var source = _factsFactory(simple);
         foreach (var provenance in source.ValueProvenance)
         {
             if (provenance.ClauseElementIndex == elementIndex)
             {
-                return input.TryEvaluateValue(provenance.Value, out domain);
+                if (valueOffset < 0 || valueOffset > provenance.Value.Decoded.Length)
+                {
+                    value = ShellValue.Literal(string.Empty);
+                    return false;
+                }
+
+                value = valueOffset == 0
+                    ? provenance.Value
+                    : provenance.Value.Slice(valueOffset);
+                return true;
             }
         }
 
-        domain = ShellValueDomain.Unknown;
+        value = ShellValue.Literal(string.Empty);
         return false;
     }
 

--- a/src/ShellSyntaxTree/Internal/Pwsh/Verbs/PwshExecutionRegionBindingCatalog.cs
+++ b/src/ShellSyntaxTree/Internal/Pwsh/Verbs/PwshExecutionRegionBindingCatalog.cs
@@ -94,6 +94,12 @@ internal sealed record PwshExecutionRegionBindingResult
 
     internal bool HasNoNewScope { get; init; }
 
+    internal int? WorkingDirectoryElementIndex { get; init; }
+
+    internal int WorkingDirectoryValueOffset { get; init; }
+
+    internal bool HasExplicitPSVersion { get; init; }
+
     internal IReadOnlyList<PwshExecutionRegionBinding> Bindings { get; init; } =
         Array.Empty<PwshExecutionRegionBinding>();
 }
@@ -447,6 +453,14 @@ internal static class PwshExecutionRegionBindingCatalog
             HasExplicitInputObject = arguments.HasNamed("InputObject"),
             HasNoNewScope = receiver == PwshExecutionRegionReceiver.InvokeCommand &&
                 arguments.IsSwitchEnabled("NoNewScope"),
+            WorkingDirectoryElementIndex = receiver == PwshExecutionRegionReceiver.StartJob
+                ? arguments.FirstNamedArgumentElementIndex("WorkingDirectory")
+                : null,
+            WorkingDirectoryValueOffset = receiver == PwshExecutionRegionReceiver.StartJob
+                ? arguments.FirstNamedArgumentValueOffset("WorkingDirectory")
+                : 0,
+            HasExplicitPSVersion = receiver == PwshExecutionRegionReceiver.StartJob &&
+                arguments.HasNamed("PSVersion"),
             Bindings = bindings.OrderBy(binding => binding.HostClauseElementIndex).ToArray(),
         };
     }
@@ -850,7 +864,8 @@ internal static class PwshExecutionRegionBindingCatalog
                 {
                     result.NamedArguments.Add(new BoundArgument(
                         index, -1, true, resolution.CanonicalName,
-                        HasTrailingComma(element), parameter.InlineValue!));
+                        HasTrailingComma(element), parameter.InlineValue!,
+                        element.Value.Length - parameter.InlineValue!.Length));
                     if (HasTrailingComma(element)
                         && !AcceptsScriptBlockArray(resolution.CanonicalName!))
                     {
@@ -864,7 +879,8 @@ internal static class PwshExecutionRegionBindingCatalog
                 {
                     result.NamedArguments.Add(new BoundArgument(
                         index, -1, false, resolution.CanonicalName, false,
-                        parameter.InlineValue!));
+                        parameter.InlineValue!,
+                        element.Value.Length - parameter.InlineValue!.Length));
                     continue;
                 }
 
@@ -938,11 +954,11 @@ internal static class PwshExecutionRegionBindingCatalog
             return new ParsedParameter(value.Substring(1), false, false, true, false, null);
         }
 
-        var inlineValue = value.Substring(colon + 1).Trim();
+        var inlineValue = value.Substring(colon + 1);
         return new ParsedParameter(
             value.Substring(1, colon - 1),
             inlineValue.Length > 0,
-            LooksLikeScriptBlock(inlineValue),
+            LooksLikeScriptBlock(inlineValue.Trim()),
             true,
             true,
             inlineValue);
@@ -1549,7 +1565,8 @@ internal static class PwshExecutionRegionBindingCatalog
         bool IsScriptBlock,
         string? ParameterName,
         bool HasTrailingComma,
-        string Value);
+        string Value,
+        int ValueOffset = 0);
 
     private sealed class BoundArguments
     {
@@ -1604,6 +1621,38 @@ internal static class PwshExecutionRegionBindingCatalog
         }
 
         internal bool HasAnyNamed(params string[] names) => names.Any(HasNamed);
+
+        internal int? FirstNamedArgumentElementIndex(string parameterName)
+        {
+            foreach (var argument in NamedArguments)
+            {
+                if (string.Equals(
+                        argument.ParameterName,
+                        parameterName,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    return argument.ElementIndex;
+                }
+            }
+
+            return null;
+        }
+
+        internal int FirstNamedArgumentValueOffset(string parameterName)
+        {
+            foreach (var argument in NamedArguments)
+            {
+                if (string.Equals(
+                        argument.ParameterName,
+                        parameterName,
+                        StringComparison.OrdinalIgnoreCase))
+                {
+                    return argument.ValueOffset;
+                }
+            }
+
+            return 0;
+        }
 
         internal int CountNamed(params string[] names) => names.Count(HasNamed);
 

--- a/tests/ShellSyntaxTree.Tests/Parsing/PwshExecutionRegionBindingCatalogTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Parsing/PwshExecutionRegionBindingCatalogTests.cs
@@ -490,6 +490,62 @@ public class PwshExecutionRegionBindingCatalogTests
             Assert.Equal(ExecutionRegionTiming.Concurrent, binding.Timing));
     }
 
+    [Theory]
+    [InlineData("Start-Job -WorkingDirectory /tmp -ScriptBlock { Get-Date }", "/tmp")]
+    [InlineData("Start-Job -WorkingD /var/tmp -ScriptBlock { Get-Date }", "/var/tmp")]
+    [InlineData("Start-Job -WorkingDirectory:/opt -ScriptBlock { Get-Date }", "/opt")]
+    [InlineData(
+        "Start-Job -WorkingDirectory:' /tmp ' -ScriptBlock { Get-Date }",
+        " /tmp ")]
+    [InlineData(
+        "Start-Job -WorkingDirectory:\"x$HOME\" -ScriptBlock { Get-Date }",
+        "x$HOME")]
+    public void Start_job_retains_the_bound_working_directory_coordinate(
+        string source,
+        string expectedValue)
+    {
+        var clause = ParseClause(source);
+        var result = PwshExecutionRegionBindingCatalog.Bind(
+            clause,
+            commandIdentityProven: true);
+
+        var elementIndex = Assert.IsType<int>(result.WorkingDirectoryElementIndex);
+        Assert.EndsWith(expectedValue, clause.Elements[elementIndex].Value);
+        Assert.Equal(
+            expectedValue,
+            clause.Elements[elementIndex].Value.Substring(
+                result.WorkingDirectoryValueOffset));
+        Assert.Equal(PwshExecutionRegionBindingStatus.ProvedExecution, result.Status);
+    }
+
+    [Fact]
+    public void Non_job_receivers_do_not_publish_a_working_directory_coordinate()
+    {
+        var result = Bind("Invoke-Command -ScriptBlock { Get-Date }");
+
+        Assert.Null(result.WorkingDirectoryElementIndex);
+        Assert.Equal(0, result.WorkingDirectoryValueOffset);
+    }
+
+    [Theory]
+    [InlineData("Start-Job -PSVersion 5.1 -ScriptBlock { Get-Date }")]
+    [InlineData("Start-Job -PSVersion:5.1 -ScriptBlock { Get-Date }")]
+    public void Start_job_retains_an_explicit_child_version_boundary(string source)
+    {
+        var result = Bind(source);
+
+        Assert.True(result.HasExplicitPSVersion);
+        Assert.Equal(PwshExecutionRegionBindingStatus.ProvedExecution, result.Status);
+    }
+
+    [Fact]
+    public void Default_start_job_does_not_invent_an_explicit_child_version()
+    {
+        var result = Bind("Start-Job -ScriptBlock { Get-Date }");
+
+        Assert.False(result.HasExplicitPSVersion);
+    }
+
     [Fact]
     public void Named_primary_parameters_shift_positional_script_block_slots()
     {

--- a/tests/ShellSyntaxTree.Tests/Parsing/PwshExecutionRegionStructuralTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Parsing/PwshExecutionRegionStructuralTests.cs
@@ -180,6 +180,266 @@ public class PwshExecutionRegionStructuralTests
     }
 
     [Theory]
+    [InlineData("Start-Job -ScriptBlock { Get-Item child.txt }")]
+    [InlineData("sajb { Get-Item child.txt }")]
+    [InlineData("Microsoft.PowerShell.Core\\Start-Job { Get-Item child.txt }")]
+    public void Start_job_publishes_a_concurrent_once_main_region(string source)
+    {
+        var result = ParseIsolated(source);
+
+        var host = Assert.IsType<SimpleCommandSyntax>(Assert.Single(result.Syntax.Statements));
+        var region = Assert.Single(host.ExecutionRegions);
+        Assert.Equal(ExecutionRegionOrigin.CommandArgument, region.Origin);
+        Assert.Equal(ExecutionRegionPhase.Main, region.Phase);
+        Assert.Equal(ExecutionRegionTiming.Concurrent, region.Timing);
+        Assert.Equal(ExecutionRegionCardinality.Once, region.Cardinality);
+        Assert.Equal(2, result.Commands.Count);
+        Assert.All(result.Commands, command => Assert.True(command.IsComplete));
+    }
+
+    [Fact]
+    public void Start_job_keeps_authored_order_but_initializes_child_before_main()
+    {
+        var result = ParseIsolated(
+            "Start-Job -ScriptBlock { Measure-Command { Get-Date } } " +
+            "-InitializationScript { Set-Alias Measure-Command Write-Output }");
+
+        var host = Assert.IsType<SimpleCommandSyntax>(Assert.Single(result.Syntax.Statements));
+        Assert.Equal(
+            new[] { ExecutionRegionPhase.Main, ExecutionRegionPhase.Initialization },
+            host.ExecutionRegions.Select(region => region.Phase));
+        Assert.Equal(
+            new[] { "Start-Job", "Measure-Command", "Get-Date", "Set-Alias" },
+            result.Commands.Select(command => command.Clause.Verb.Tokens[0]));
+        var main = result.Commands[1];
+        Assert.False(main.IsComplete);
+    }
+
+    [Theory]
+    [InlineData("-WorkingDirectory /tmp")]
+    [InlineData("-WorkingD:/tmp")]
+    public void Start_job_applies_working_directory_before_initialization_and_isolates_exit(
+        string workingDirectoryArgument)
+    {
+        var result = ParseIsolated(
+            $"Start-Job {workingDirectoryArgument} " +
+            "-InitializationScript { Get-Item init.txt } " +
+            "-ScriptBlock { Get-Item main.txt; Set-Location / }; " +
+            "Get-Item host.txt");
+
+        var items = result.Commands
+            .Where(command => command.Clause.Verb.Tokens[0] == "Get-Item")
+            .ToArray();
+        Assert.Equal(3, items.Length);
+        Assert.Equal("/tmp", Assert.Single(items[0].WorkingDirectory.Values));
+        Assert.Equal("/tmp", Assert.Single(items[1].WorkingDirectory.Values));
+        Assert.Equal("C:/work", Assert.Single(items[2].WorkingDirectory.Values));
+        Assert.All(items, command => Assert.True(command.IsComplete));
+    }
+
+    [Theory]
+    [InlineData("-WorkingDirectory $target")]
+    [InlineData("-WorkingDirectory:$target")]
+    public void Start_job_accepts_a_bounded_host_working_directory_value(
+        string workingDirectoryArgument)
+    {
+        var result = ParseIsolated(
+            "foreach ($target in '/tmp') { }; " +
+            $"Start-Job {workingDirectoryArgument} " +
+            "-ScriptBlock { Get-Item child.txt }");
+
+        var child = Assert.Single(
+            result.Commands,
+            command => command.Clause.Verb.Tokens[0] == "Get-Item");
+        Assert.Equal(
+            new[] { "/tmp" },
+            child.WorkingDirectory.Values);
+        Assert.True(child.IsComplete);
+    }
+
+    [Theory]
+    [InlineData("~/jobs", "C:/Users/test/jobs")]
+    [InlineData("$HOME/jobs", "C:/Users/test/jobs")]
+    public void Start_job_resolves_static_host_working_directory_forms(
+        string target,
+        string expected)
+    {
+        var result = ParseIsolated(
+            $"Start-Job -WorkingDirectory {target} " +
+            "-ScriptBlock { Get-Item child.txt }");
+
+        var child = result.Commands.Last();
+        Assert.Equal(
+            new[] { expected },
+            child.WorkingDirectory.Values);
+        Assert.True(child.IsComplete);
+    }
+
+    [Theory]
+    [InlineData(".")]
+    [InlineData("..")]
+    [InlineData("jobs")]
+    [InlineData("child*")]
+    [InlineData("HKLM:/Software")]
+    [InlineData("\"x$HOME\"")]
+    [InlineData("\" $HOME \"")]
+    [InlineData("\"prefix${HOME}/x\"")]
+    public void Start_job_rejects_non_independently_rooted_working_directory_forms(
+        string target)
+    {
+        var result = ParseIsolated(
+            $"Start-Job -WorkingDirectory {target} " +
+            "-ScriptBlock { Get-Item child.txt }");
+
+        var child = result.Commands.Last();
+        Assert.Equal(ShellValueDomainKind.Unknown, child.WorkingDirectory.Kind);
+    }
+
+    [Fact]
+    public void Start_job_preserves_significant_inline_working_directory_whitespace()
+    {
+        var result = ParseIsolated(
+            "Start-Job -WorkingDirectory:' /tmp ' " +
+            "-ScriptBlock { Get-Item child.txt }");
+
+        var child = result.Commands.Last();
+        Assert.Equal(ShellValueDomainKind.Unknown, child.WorkingDirectory.Kind);
+        Assert.True(child.IsComplete);
+    }
+
+    [Theory]
+    [InlineData("-PSVersion 5.1")]
+    [InlineData("-PSVersion:5.1")]
+    public void Start_job_alternate_child_version_remains_visible_but_incomplete(
+        string versionArgument)
+    {
+        var result = ParseIsolated(
+            $"Start-Job {versionArgument} -ScriptBlock {{ Get-Item child.txt }}");
+
+        var host = Assert.IsType<SimpleCommandSyntax>(Assert.Single(result.Syntax.Statements));
+        var region = Assert.Single(host.ExecutionRegions);
+        Assert.Equal(ExecutionRegionPhase.Unknown, region.Phase);
+        Assert.Equal(ExecutionRegionTiming.Unknown, region.Timing);
+        Assert.Equal(ExecutionRegionCardinality.Unknown, region.Cardinality);
+        Assert.All(result.Commands, command => Assert.False(command.IsComplete));
+    }
+
+    [Theory]
+    [InlineData(
+        "Start-Job -PSVersion 5.1 -ScriptBlock { Set-Location / }")]
+    [InlineData(
+        "Start-Job -FilePath script.ps1 " +
+        "-InitializationScript { Set-Location / }")]
+    [InlineData(
+        "Start-Job -RunAs32 -ScriptBlock { Set-Location / }")]
+    public void Incomplete_start_job_variants_preserve_host_location_boundary(
+        string invocation)
+    {
+        var result = ParseIsolated(invocation + "; Get-Item host.txt");
+
+        var continuation = result.Commands.Last();
+        Assert.Equal("Get-Item", continuation.Clause.Verb.Tokens[0]);
+        Assert.Equal(
+            new[] { "C:/work" },
+            continuation.WorkingDirectory.Values);
+        Assert.True(continuation.IsComplete);
+    }
+
+    [Theory]
+    [InlineData(
+        "Start-Job -PSVersion 5.1 -ScriptBlock { " +
+        "Set-Alias Measure-Command Write-Output }")]
+    [InlineData(
+        "Start-Job -FilePath script.ps1 -InitializationScript { " +
+        "Set-Alias Measure-Command Write-Output }")]
+    [InlineData(
+        "Start-Job -RunAs32 -ScriptBlock { " +
+        "Set-Alias Measure-Command Write-Output }")]
+    public void Incomplete_start_job_variants_preserve_host_command_resolution_boundary(
+        string invocation)
+    {
+        var result = ParseIsolated(invocation + "; Measure-Command { Get-Date }");
+
+        var continuation = result.Commands
+            .Last(command => command.Clause.Verb.Tokens[0] == "Measure-Command");
+        Assert.True(continuation.IsComplete);
+    }
+
+    [Fact]
+    public void Start_job_does_not_inherit_host_bindings_or_export_child_bindings()
+    {
+        var result = ParseIsolated(
+            "foreach ($x in 'outer') { }; Start-Job " +
+            "-InitializationScript { foreach ($x in 'init') { }; Write-Output $x } " +
+            "-ScriptBlock { Write-Output $x; foreach ($x in 'main') { } }; " +
+            "Write-Output $x");
+
+        var writes = result.Commands
+            .Where(command => command.Clause.Verb.Tokens[0] == "Write-Output")
+            .ToArray();
+        Assert.Equal(3, writes.Length);
+        Assert.All(writes.Take(2), write =>
+        {
+            Assert.Equal(
+                ShellValueDomainKind.Unknown,
+                Assert.Single(write.EffectiveArguments).Value.Kind);
+            Assert.True(write.IsComplete);
+        });
+        Assert.Equal(
+            new[] { "outer" },
+            Assert.Single(writes[2].EffectiveArguments).Value.Values);
+        Assert.True(writes[2].IsComplete);
+    }
+
+    [Fact]
+    public void Start_job_initialization_mutation_invalidates_main_but_not_host_resolution()
+    {
+        var result = ParseIsolated(
+            "Start-Job -InitializationScript { " +
+            "Set-Alias Measure-Command Write-Output } -ScriptBlock { " +
+            "Measure-Command { Get-Date } }; Measure-Command { Get-Date }");
+
+        var measurements = result.Commands
+            .Where(command => command.Clause.Verb.Tokens[0] == "Measure-Command")
+            .ToArray();
+        Assert.Equal(2, measurements.Length);
+        Assert.False(measurements[0].IsComplete);
+        Assert.True(measurements[1].IsComplete);
+    }
+
+    [Fact]
+    public void Dynamic_start_job_working_directory_fails_closed_only_in_the_child()
+    {
+        var result = ParseIsolated(
+            "Start-Job -WorkingDirectory $target " +
+            "-ScriptBlock { Get-Item child.txt }; Get-Item host.txt");
+
+        var items = result.Commands
+            .Where(command => command.Clause.Verb.Tokens[0] == "Get-Item")
+            .ToArray();
+        Assert.Equal(2, items.Length);
+        Assert.Equal(ShellValueDomainKind.Unknown, items[0].WorkingDirectory.Kind);
+        Assert.True(items[0].IsComplete);
+        Assert.Equal(
+            new[] { "C:/work" },
+            items[1].WorkingDirectory.Values);
+        Assert.True(items[1].IsComplete);
+    }
+
+    [Fact]
+    public void Start_job_file_path_keeps_initialization_visible_but_incomplete()
+    {
+        var result = ParseIsolated(
+            "Start-Job -FilePath script.ps1 " +
+            "-InitializationScript { Get-Date }");
+
+        var host = Assert.IsType<SimpleCommandSyntax>(Assert.Single(result.Syntax.Statements));
+        var initialization = Assert.Single(host.ExecutionRegions);
+        Assert.Equal(ExecutionRegionPhase.Unknown, initialization.Phase);
+        Assert.All(result.Commands, command => Assert.False(command.IsComplete));
+    }
+
+    [Theory]
     [InlineData("New-Module { Get-Item child.txt }")]
     [InlineData("nmo -ScriptBlock { Get-Item child.txt }")]
     [InlineData("Microsoft.PowerShell.Core\\New-Module { Get-Item child.txt }")]

--- a/tests/ShellSyntaxTree.Tests/Parsing/ShellValueOracleTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Parsing/ShellValueOracleTests.cs
@@ -1176,6 +1176,158 @@ public class ShellValueOracleTests
             Lines(output));
     }
 
+    [Fact]
+    public void PowerShell_start_job_initializes_child_before_main_and_isolates_exit()
+    {
+        if (!IsAvailable("pwsh"))
+        {
+            return;
+        }
+
+        var output = Run(
+            "pwsh",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            "$start=(Get-Location).Path; " +
+            "$target=[IO.Path]::TrimEndingDirectorySeparator(" +
+            "(Resolve-Path ([IO.Path]::GetTempPath())).Path); " +
+            "$x='outer'; $job=Start-Job -WorkingDirectory $target " +
+            "-InitializationScript { " +
+            "\"init-cwd-target=<$((Get-Location).Path -eq " +
+            "[IO.Path]::TrimEndingDirectorySeparator(" +
+            "(Resolve-Path ([IO.Path]::GetTempPath())).Path))>\"; $x='init' } " +
+            "-ScriptBlock { \"main-x=<$x>\"; " +
+            "\"main-cwd-target=<$((Get-Location).Path -eq " +
+            "[IO.Path]::TrimEndingDirectorySeparator(" +
+            "(Resolve-Path ([IO.Path]::GetTempPath())).Path))>\"; " +
+            "$x='main'; Set-Location ([IO.Path]::GetPathRoot((Get-Location).Path)) }; " +
+            "Receive-Job -Job $job -Wait; Remove-Job -Job $job; " +
+            "\"host-x=<$x>\"; " +
+            "\"host-cwd-start=<$((Get-Location).Path -eq $start)>\"");
+
+        Assert.Equal(
+            new[]
+            {
+                "init-cwd-target=<True>",
+                "main-x=<init>",
+                "main-cwd-target=<True>",
+                "host-x=<outer>",
+                "host-cwd-start=<True>",
+            },
+            Lines(output));
+    }
+
+    [Fact]
+    public void PowerShell_start_job_preserves_inline_working_directory_whitespace()
+    {
+        if (!IsAvailable("pwsh"))
+        {
+            return;
+        }
+
+        var output = Run(
+            "pwsh",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            "$target=' sst-inline-space-path-91f62f1f '; " +
+            "if (Test-Path -LiteralPath $target) { throw 'path collision' }; " +
+            "try { Start-Job -WorkingDirectory:' sst-inline-space-path-91f62f1f ' " +
+            "-ScriptBlock { Get-Date } -ErrorAction Stop } " +
+            "catch { \"path-preserved=<$($_.Exception.Message.Contains($target))>\" }");
+
+        Assert.Equal("path-preserved=<True>", output);
+    }
+
+    [Fact]
+    public void PowerShell_start_job_prefixed_home_expansion_remains_relative()
+    {
+        if (!IsAvailable("pwsh"))
+        {
+            return;
+        }
+
+        var output = Run(
+            "pwsh",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            "$target=\"x$HOME\"; " +
+            "if (Test-Path -LiteralPath $target) { throw 'path collision' }; " +
+            "try { Start-Job -WorkingDirectory:\"x$HOME\" " +
+            "-ScriptBlock { Get-Date } -ErrorAction Stop } " +
+            "catch { \"path-preserved=<$($_.Exception.Message.Contains($target))>\" }");
+
+        Assert.Equal("path-preserved=<True>", output);
+    }
+
+    [Fact]
+    public void PowerShell_start_job_relative_working_directory_uses_child_startup_base()
+    {
+        if (OperatingSystem.IsWindows() || !IsAvailable("pwsh"))
+        {
+            return;
+        }
+
+        var workingDirectory = Path.Combine(
+            Path.GetTempPath(),
+            "shellsyntaxtree-oracle-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(workingDirectory);
+        try
+        {
+            var output = RunInWorkingDirectory(
+                "pwsh",
+                workingDirectory,
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                "$start=(Get-Location).Path; $homePath=(Resolve-Path $HOME).Path; " +
+                "$dot=Start-Job -WorkingDirectory . -ScriptBlock { " +
+                "(Get-Location).Path }; $dotPath=Receive-Job $dot -Wait; " +
+                "Remove-Job $dot; $parent=Start-Job -WorkingDirectory .. " +
+                "-ScriptBlock { (Get-Location).Path }; " +
+                "$parentPath=Receive-Job $parent -Wait; Remove-Job $parent; " +
+                "\"caller-distinct=<$($dotPath -ne $start)>\"; " +
+                "\"dot-home=<$($dotPath -eq $homePath)>\"; " +
+                "\"parent-home-parent=<$($parentPath -eq " +
+                "(Split-Path $homePath -Parent))>\"");
+
+            Assert.Equal(
+                new[]
+                {
+                    "caller-distinct=<True>",
+                    "dot-home=<True>",
+                    "parent-home-parent=<True>",
+                },
+                Lines(output));
+        }
+        finally
+        {
+            Directory.Delete(workingDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void Windows_start_job_psversion_selects_windows_powershell_51()
+    {
+        if (!OperatingSystem.IsWindows() || !IsAvailable("pwsh"))
+        {
+            return;
+        }
+
+        var output = Run(
+            "pwsh",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            "$job=Start-Job -PSVersion 5.1 -ScriptBlock { " +
+            "$PSVersionTable.PSVersion.ToString() }; " +
+            "Receive-Job -Job $job -Wait; Remove-Job -Job $job");
+
+        Assert.StartsWith("5.1.", output, StringComparison.Ordinal);
+    }
+
     private static bool IsAvailable(string executable)
     {
         try

--- a/tests/ShellSyntaxTree.Tests/Parsing/ShellValueOracleTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Parsing/ShellValueOracleTests.cs
@@ -1243,7 +1243,7 @@ public class ShellValueOracleTests
     [Fact]
     public void PowerShell_start_job_prefixed_home_expansion_remains_relative()
     {
-        if (!IsAvailable("pwsh"))
+        if (OperatingSystem.IsWindows() || !IsAvailable("pwsh"))
         {
             return;
         }


### PR DESCRIPTION
## Summary

- analyze `Start-Job` initialization before main while preserving authored region order
- model the isolated child-process boundary and prevent child state from contaminating host continuation
- apply exact independently rooted working directories, while relative, dynamic, glob, and non-filesystem forms remain Unknown
- preserve inline-value provenance and fail closed for alternate `-PSVersion`, FilePath, RunAs32, and other unsupported body models

This is the Start-Job sub-slice of OpenSpec task 7.5c; the broader task remains open for Parallel, remote Invoke-Command, and pinned ThreadJob work.

## Verification

- `dotnet build -c Release` — 0 warnings/errors
- `dotnet test -c Release --no-build` — 2,187 passed
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`
- `slopwatch analyze -d . --no-baseline --fail-on warning` — 0 issues
- `openspec validate v0-3-structured-shell-analysis --strict`
- adversarial review GO for staged SHA-256 `a9d86c314fff5ac8ca619f93a92ecca7bbf0b52e94139ff9ac9c947430fe6e28`
