### PR TITLE
Record 0.3.0-alpha publication

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -499,10 +499,9 @@ priorities.
       set does not support `-AsJob`.
 - [ ] Complete the stable-v0.3 Bash `for ... in` and PowerShell `foreach`
       vertical slices without gating release on a shared-analysis refactor.
-- [ ] Publish `0.3.0-alpha` for the Netclaw migration gate. The release branch
-      sets matching package metadata, release notes, and the bare SemVer tag
-      contract. Mark this complete only after the tag workflow publishes the
-      package and GitHub prerelease.
+- [x] Publish `0.3.0-alpha` for the Netclaw migration gate. The bare SemVer tag
+      published the NuGet package, symbol package, and GitHub prerelease from
+      the reviewed merge commit after Linux and Windows CI passed.
 - [ ] Build on the delivered bounded Bash heredoc grammar and quoted-delimiter
       adjacency by exposing public body/delimiter/expansion/completeness facts,
       then add a separately tested Bash `<<<` here-string redirect slice.

--- a/openspec/changes/v0-3-structured-shell-analysis/tasks.md
+++ b/openspec/changes/v0-3-structured-shell-analysis/tasks.md
@@ -89,7 +89,7 @@
 - [ ] 5.3 Document exact, finite, pattern, unknown, joined-state, redirect, and incomplete-result handling.
 - [ ] 5.4 Document record equality, hashing, `ToString()`, serialization, and `Clauses` compatibility effects.
 - [ ] 5.5 Update the README getting-started and migration examples to direct v0.3 consumers to the command-occurrence API and full consumer guide.
-- [ ] 5.6 Publish a 0.3.0 prerelease containing the contracted structural,
+- [x] 5.6 Publish a 0.3.0 prerelease containing the contracted structural,
   substitution, redirect, Bash `for`, and PowerShell `foreach` behavior before
   the downstream migration gate.
 - [ ] 5.7 Migrate Netclaw's existing-command analysis to the occurrence and redirect APIs behind focused regression tests.
@@ -235,8 +235,8 @@
 
 - [ ] 11.1 Add public API default-value, equality, serialization, and unknown-enum compatibility tests.
 - [ ] 11.2 Assert every supported executable region appears exactly once and every unsupported executable region makes the result unparseable.
-- [ ] 11.3 Run the complete Bash and PowerShell corpus suites plus the PII audit.
-- [ ] 11.4 Run `dotnet build -c Release`, `dotnet test -c Release`, `dotnet pack -c Release`, and header verification.
+- [x] 11.3 Run the complete Bash and PowerShell corpus suites plus the PII audit.
+- [x] 11.4 Run `dotnet build -c Release`, `dotnet test -c Release`, `dotnet pack -c Release`, and header verification.
 - [ ] 11.5 Validate the public API field-for-field against the synchronized shared and PowerShell specifications.
 - [ ] 11.6 Validate Netclaw's ordinary-command, redirect, bounded-loop, and unknown-value approval matrices against the prerelease package.
 - [ ] 11.7 Update release notes and remove Netclaw's temporary descriptor workaround only after explicit redirect integration is live.


### PR DESCRIPTION
## Summary

- mark the 0.3.0-alpha publication task complete
- record the successful corpus, PII, build, test, pack, and header gates
- keep all downstream, stable-release, and remaining implementation tasks open

## Evidence

- Release PR #117 merged after Linux and Windows CI
- Publish workflow 31266742779 succeeded
- NuGet lists ShellSyntaxTree 0.3.0-alpha
- GitHub prerelease contains the package and symbol assets
- Strict OpenSpec validation passed
- Adversarial review: GO on immutable staged hash 3d9408d38f84f1a93df32cd821b10d813a62f75d2ed351e40fa9c697cec8de28