### PR TITLE
Record Netclaw Bash v0.3 acceptance

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -320,6 +320,20 @@ priorities.
       the redirect and occurrence after abstract-state joins. Direct lexer and
       parser tests plus executable corpus cases pin the boundary. Next prove
       the paired Netclaw redirect matrix.
+- [x] Migrate Netclaw's Bash approval path to `0.3.0-alpha`. Netclaw PR
+      [#5](https://github.com/Aaronontheweb/netclaw/pull/5) enumerates every
+      `CommandOccurrence`, consumes complete ancestry, cwd, compatibility
+      argument/path, and explicit redirect facts, and removes the temporary raw
+      descriptor inference. Focused security tests and the 120-case approval
+      matrix pin ordinary commands, pipelines, wrappers, static and dynamic
+      redirects, cwd joins, symlink boundaries, POSIX shell payloads, and
+      hard-deny precedence. Unknown or incomplete occurrence and redirect facts
+      and dynamic or unresolved compatibility arguments remain fail closed.
+      Follow-up PR [#6](https://github.com/Aaronontheweb/netclaw/pull/6)
+      keeps stable macOS root aliases usable while scanning authored redirect
+      segments before lexical normalization can erase symlink traversal.
+      Bounded Bash loop approval cases and the separate PowerShell consumer
+      migration remain the next downstream gates.
 - [x] Deliver occurrence-level PowerShell explicit redirect facts while
       preserving the v0.2 compatibility projection. File output and append
       retain default, numbered, or all-streams sources; the native-only merge

--- a/openspec/changes/v0-3-structured-shell-analysis/tasks.md
+++ b/openspec/changes/v0-3-structured-shell-analysis/tasks.md
@@ -79,7 +79,15 @@
     independent occurrence facts for multiple redirects.
   - [x] 4.6b Add the paired PowerShell direct and executable-corpus cases when
     task 4.5 maps its stream model.
-- [ ] 4.7 Verify the explicit model removes the need for raw-prefix inference in a Netclaw integration test.
+- [x] 4.7 Verify the explicit model removes the need for raw-prefix inference in a Netclaw integration test.
+  - Netclaw PR
+    [#5](https://github.com/Aaronontheweb/netclaw/pull/5) consumes typed
+    descriptor duplicate, move, close, combined-output, and file-target facts.
+    It removes the temporary raw descriptor-prefix workaround and pins static,
+    computed, malformed, and future-enum forms in focused security tests.
+    Follow-up PR [#6](https://github.com/Aaronontheweb/netclaw/pull/6)
+    preserves macOS system path aliases without trusting writable symlinks or
+    allowing lexical normalization to erase authored parent traversal.
 
 ## 5. Consumer Migration Baseline
 
@@ -92,7 +100,16 @@
 - [x] 5.6 Publish a 0.3.0 prerelease containing the contracted structural,
   substitution, redirect, Bash `for`, and PowerShell `foreach` behavior before
   the downstream migration gate.
-- [ ] 5.7 Migrate Netclaw's existing-command analysis to the occurrence and redirect APIs behind focused regression tests.
+- [x] 5.7 Migrate Netclaw's existing-command analysis to the occurrence and redirect APIs behind focused regression tests.
+  - Netclaw PR
+    [#5](https://github.com/Aaronontheweb/netclaw/pull/5) migrates the Bash
+    approval path to `ParsedCommand.Commands`, complete ancestry and cwd facts,
+    compatibility argument/path facts, and explicit redirects. Unknown or
+    incomplete identity, ancestry, cwd, or redirect facts and dynamic or
+    unresolved compatibility arguments still fail closed. The 120-case
+    approval matrix and focused security tests cover
+    ordinary commands, wrappers, pipelines, cwd attribution, redirects,
+    symlinks, authored redirect-path traversal, and hard-deny precedence.
 
 ## 6. Bash For-In Vertical Slice
 
@@ -239,7 +256,10 @@
 - [x] 11.4 Run `dotnet build -c Release`, `dotnet test -c Release`, `dotnet pack -c Release`, and header verification.
 - [ ] 11.5 Validate the public API field-for-field against the synchronized shared and PowerShell specifications.
 - [ ] 11.6 Validate Netclaw's ordinary-command, redirect, bounded-loop, and unknown-value approval matrices against the prerelease package.
-- [ ] 11.7 Update release notes and remove Netclaw's temporary descriptor workaround only after explicit redirect integration is live.
+- [x] 11.7 Update release notes and remove Netclaw's temporary descriptor workaround only after explicit redirect integration is live.
+  - The `0.3.0-alpha` release notes document the explicit redirect model. The
+    workaround was removed only in the reviewed Netclaw migration after the
+    prerelease package was published.
 - [ ] 11.9 Promote stable 0.3.0 only after Linux and Windows CI, package publication, and downstream acceptance succeed.
 
 ## Post-v0.3 Backlog (Non-Gating)


### PR DESCRIPTION
Records the completed static Bash downstream migration without closing the remaining bounded-loop or PowerShell gates.

Evidence:
- Netclaw PR #5 migrated approval analysis to occurrence, ancestry, cwd, compatibility argument, and explicit redirect facts.
- Netclaw PR #6 hardened macOS alias and authored redirect traversal handling.
- The reviewed 120-case approval matrix remains fail closed for incomplete or unknown facts.

Validation:
- `openspec validate v0-3-structured-shell-analysis --strict`
- Release build and all 2,370 tests passed on this documentation branch before the final text-only evidence update.
- Header verification passed.
- Adversarial review: GO on staged diff SHA-256 `2aca9ecdc0c4d4556903dc3c3f7a7a1235763c0b9de090a6509e81145352208d`.