### PR TITLE
Implement bounded Bash heredoc analysis

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -530,9 +530,21 @@ priorities.
       plus equal-record hash consistency, demonstrate that default JSON is not
       a polymorphic round-trip contract, and make every policy-sensitive
       unknown numeric enum value detectable so consumers can reject it.
-- [ ] Build on the delivered bounded Bash heredoc grammar and quoted-delimiter
-      adjacency by exposing public body/delimiter/expansion/completeness facts,
-      then add a separately tested Bash `<<<` here-string redirect slice.
+- [x] Expose public Bash heredoc body, delimiter, expansion, tab-stripping, and
+      completeness facts from the delivered bounded grammar. Direct tests pin
+      literal and expanding delimiters, every supported substitution command,
+      exact empty/LF/CRLF/tabbed body provenance, the retained v0.2 redirect,
+      and nullable source offsets for decoded `bash -c` payloads.
+- [x] Close the Bash variable-attribute hidden-execution boundary. Named
+      parameter dereferences now require a caller-proved isolated initial
+      state, with that proof propagated into substitutions and subshells.
+      Direct and recursively dispatch-wrapped `eval`, source/dot, trap,
+      variable-attribute and variable-mutating builtins, plus `printf -v`,
+      fail atomically until their state effects are modeled. Native Bash
+      oracles pin nameref-deferred and integer-assignment execution, and the
+      executable corpus carries isolated, unknown-state, and wrapper cases.
+- [ ] Add the separately tested Bash `<<<` here-string redirect slice with
+      bounded operand analysis and trailing-newline semantics.
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -280,6 +280,16 @@ mode for every later region that can observe it. In particular, a decoded
 the option is not blindly copied into the child. Cwd-only state changes retain
 the caller's initial-variable assertion.
 
+The same attribute-state proof governs every simple named-parameter
+dereference. With `BashInitialStateMode.Unknown`, `$name` and `${name}` are
+unparseable because an ambient nameref can evaluate an arithmetic array
+subscript and execute authored command text. In isolated mode, a fresh-process
+variable before reachable source mutation may remain an unknown value while
+still being proved free of recursive variable attributes. A modeled ordinary
+loop binding retains its explicit proof. Positional and special parameters
+that cannot carry variable attributes keep their existing typed cardinality
+rules.
+
 Even in isolated mode, the v0.3 bounded loop grammar accepts only ordinary
 lowercase scalar binding names matching `[a-z][a-z0-9_]*`, excluding
 `auto_resume` and `histchars`. `_`, uppercase names, and every name outside
@@ -791,12 +801,17 @@ variable values to `Unknown` rather than selecting one path.
 
 `cd` and `chdir` use the effective argument vector for the current visit.
 `pushd` and `popd` may be recognized only with unknown success cwd until the
-directory stack is modeled. Variable mutators (`read`, `unset`, `printf -v`,
-`export`, `declare`, and equivalents), `eval`, `source` / `.`, and
-execution-bearing `trap` make the complete loop region unparseable. The same is
-true for `break`, `continue`, `return`, `exit`, and `exec` until their transfers
-are implemented. Recognition recursively unwraps statically proved `command`
-and `builtin` dispatch; a wrapper must not bypass the rejection.
+directory stack is modeled. Unmodeled execution-bearing or
+attribute-mutating builtins fail the complete parse closed globally, not only
+inside loops. The stable catalog is `eval`, `source` / `.`, `trap`, `let`,
+`declare`, `typeset`, `local`, `readonly`, `export`, `unset`, `read`,
+`readarray`, `mapfile`, `getopts`, and `set`, plus `printf -v`. These forms can
+evaluate argument text, install deferred execution, or assign through
+unproved integer, nameref, or array attributes. Recognition recursively
+unwraps statically proved `command` and `builtin` dispatch; dynamic or invalid
+wrapper grammar fails closed. Ordinary `printf` without `-v` remains
+supported. `break`, `continue`, `return`, `exit`, and `exec` remain loop-region
+failures until their transfers are implemented.
 
 Substitutions and subshells inherit the current variable/cwd state but discard
 their state changes on exit. Decoded Bash command wrappers inherit invocation
@@ -1305,17 +1320,20 @@ quoted_string   := single-quoted | double-quoted
 - v0.2 recognizes heredocs (`<<EOF ... EOF`) as redirect syntax while the
   body is skipped. Stable v0.3 preserves delimiter, body, expansion mode,
   tab-stripping mode, and completeness through `HereDocumentAnalysis`.
-  The bounded grammar accepts one terminal `<<` / `<<-` redirect on a command
-  header, with optional whitespace or a trailing comment after the delimiter.
+  The bounded grammar accepts one terminal `<<` / `<<-` redirect, including a
+  literal numeric source descriptor such as `3<<EOF`, on a command header,
+  with optional whitespace or a trailing comment after the delimiter.
   Additional header tokens, pipelines, and queued heredocs are unparseable
   until their body-association grammar is modeled. Quote removal determines
   the delimiter spelling; any quoted or escaped delimiter fragment makes the
   body literal. In an expanding body, unescaped `$()` substitutions are
   executable even when their spelling is surrounded by quote characters,
   because heredoc body quotes are data rather than shell quoting syntax.
-  Escaped substitutions remain literal. Legacy backticks, arithmetic
-  expansion, line continuations that could hide a substitution boundary, and
-  incomplete substitutions make the whole result unparseable.
+  Escaped substitutions remain literal. Legacy backticks, `$((...))` and
+  obsolete `$[...]` arithmetic expansion, prompt-transformed `${name@P}` or
+  other parameter operators, line continuations that could hide a
+  substitution boundary, and incomplete substitutions make the whole result
+  unparseable.
 - Redirect targets matching the POSIX fd-dup / fd-close shorthand —
   `&N`, `&N-`, or `&-` (where `N` is one or more decimal digits) — are
   NOT path-resolved. The parser carries the raw token (e.g. `&1`) on
@@ -1365,6 +1383,9 @@ delimited `$()` command substitution in a supported simple-command argument,
 redirect value, iterable, or expanding heredoc body is recursively parsed and
 exposes its inner commands; its produced value remains `Unknown`. A nested
 substitution is recursively attached to the nearest containing simple command.
+Simple `$name` and `${name}` forms additionally require the proved
+variable-attribute state from §2; syntactic simplicity alone is not evidence
+that dereferencing a nameref cannot execute an array subscript.
 Legacy backtick substitution becomes unparseable in v0.3 until its distinct
 escape and nesting rules can be mapped without guessing. A Bash path-shaped
 glob may produce a `Pattern` only when its exact static covering directory is
@@ -1399,7 +1420,7 @@ The lexer produces tokens consumed by the parser. Token kinds:
   the quote delimiters from the token value. Example: `"hello world"`
   becomes the token value `hello world`.
 - **OPERATOR** — `&&`, `||`, `;`, `|`, `>`, `>>`, `<`, numeric-descriptor
-  forms such as `2>`, `3>>`, and `10<`, `&>`, `&>>`,
+  forms such as `2>`, `3>>`, `10<`, `3<<`, and `4<<-`, `&>`, `&>>`,
   `(`, `)`, `<<`, `<<-`.
 - **WHITESPACE** — one or more spaces, tabs, or newlines (newlines inside
   a heredoc body are not emitted as ordinary tokens; the delimiter token
@@ -1419,9 +1440,9 @@ The lexer produces tokens consumed by the parser. Token kinds:
   Expanding-heredoc substitutions use the same opaque fragment semantics but
   remain attached to the delimiter token rather than entering the ordinary
   command-token stream.
-- **UNPARSEABLE_SENTINEL** — `$((expr))` arithmetic expansion or any
-  operator-bearing parameter expansion such as `${var:-$(cmd)}` or
-  `${var//pat/repl}`. The lexer skips past
+- **UNPARSEABLE_SENTINEL** — `$((expr))` or obsolete `$[expr]` arithmetic
+  expansion, or any operator-bearing parameter expansion such as
+  `${var:-$(cmd)}`, `${var//pat/repl}`, or `${var@P}`. The lexer skips past
   the matching close (`))` or `}` respectively) and emits a sentinel
   whose reason names the rejected construct. The parser consumes this
   token by setting outer `ParsedCommand.IsUnparseable = true` (see §11).
@@ -2306,6 +2327,11 @@ Each file:
   "notes": "Optional explanation of edge case being captured."
 }
 ```
+
+An entry may set `bashInitialStateMode` to `Unknown` or
+`IsolatedNonInteractive` when the expected result depends on the caller-proved
+Bash variable-state contract. When omitted, the Bash corpus runner uses
+`IsolatedNonInteractive`. The field is rejected outside the Bash corpus.
 
 An entry may add an `elements` list to a clause to pin the complete
 `Clause.Elements` projection (`raw`, `value`, `role`, `sourceStart`,

--- a/openspec/changes/v0-3-structured-shell-analysis/design.md
+++ b/openspec/changes/v0-3-structured-shell-analysis/design.md
@@ -543,6 +543,30 @@ later scope that can observe it. A decoded `bash -c` after `export` therefore
 enters with `Unknown` initial variable state, while a cwd-only transfer retains
 the caller's variable-state assertion.
 
+This state proof applies to every simple Bash parameter dereference, not only
+to loop assignment. A syntactically simple `$name` or `${name}` can execute
+when `name` is a nameref whose target contains an arithmetic array subscript.
+For example, a prior `declare -n x='a[$(hidden)0]'` makes `${x}` evaluate the
+subscript and execute `hidden`, even though the declaration operand was quoted
+data. `Unknown` initial state therefore cannot classify a variable
+dereference as fully accounted for. `IsolatedNonInteractive` may do so only
+before any reachable unmodeled variable mutation, or for a binding whose
+ordinary-scalar attributes are modeled explicitly. The produced value may
+still be `Unknown`; variable-attribute safety and value exactness remain
+independent facts.
+
+Stable v0.3 does not add a partial expression evaluator for Bash builtins.
+Direct or statically wrapped `eval`, `source` / `.`, `trap`, `let`, `declare`,
+`typeset`, `local`, `readonly`, `export`, `unset`, `read`, `readarray`,
+`mapfile`, `getopts`, and `set` forms fail the complete parse closed, as does
+`printf -v`. These commands can execute argument text directly, evaluate
+arithmetic, install deferred execution, or assign through attributes whose
+state is not proved. Exact `command` and `builtin` dispatch wrappers are
+recursively unwrapped; dynamic or invalid wrapper grammar fails closed rather
+than bypassing the catalog. Ordinary `printf` without `-v` remains supported.
+A later additive grammar may admit individually proved query or assignment
+forms without weakening this stable boundary.
+
 PowerShell needs the same explicit boundary for different reasons.
 `PwshParserOptions.InitialStateMode` defaults to `Unknown`, which permits
 structural discovery but withholds exact or finite `foreach` binding proofs.

--- a/openspec/changes/v0-3-structured-shell-analysis/proposal.md
+++ b/openspec/changes/v0-3-structured-shell-analysis/proposal.md
@@ -29,6 +29,11 @@ fail-closed behavior for incomplete analysis.
 - Add conservative value and shell-state analysis that distinguishes exact,
   finite, bounded-symbolic, and unknown facts without executing commands or
   enumerating the filesystem.
+- Require proved Bash variable-attribute state before treating a simple
+  parameter dereference as non-executable. Stable v0.3 fails closed on
+  unmodeled shell builtins that can evaluate, assign through, or defer
+  argument text, because nameref and arithmetic attributes can otherwise turn
+  quoted data into hidden execution.
 - Preserve resolver-relevant lexical fragments, typed expansion identity and
   cardinality, operation-specific transform eligibility, opaque cause, and
   consumer/binding context through decoding so escaped or

--- a/openspec/changes/v0-3-structured-shell-analysis/specs/bounded-shell-analysis/spec.md
+++ b/openspec/changes/v0-3-structured-shell-analysis/specs/bounded-shell-analysis/spec.md
@@ -168,6 +168,62 @@ the independently proved variable-state mode.
 - **THEN** the decoded child enters with unknown initial variable state
 - **THEN** the complete result is unparseable rather than publishing an isolated scalar proof
 
+### Requirement: Bash parameter dereferences require proved attribute state
+A syntactically simple Bash `$name` or `${name}` dereference SHALL be treated
+as fully execution-accounted only when the incoming variable-attribute state
+proves that the binding cannot be an integer, nameref, array reference, or
+other recursively evaluated form. Value exactness SHALL remain independent:
+an attribute-safe variable MAY still produce an `Unknown` value.
+
+`BashInitialStateMode.Unknown` SHALL make a simple named-variable dereference
+unparseable because an ambient nameref can evaluate an authored array
+subscript. `IsolatedNonInteractive` MAY establish safe initial attributes for
+a fresh-process variable before reachable source mutation. A modeled ordinary
+loop binding MAY retain that proof. Any reachable unmodeled variable mutation
+SHALL invalidate the proof in later regions that can observe it. Positional
+and special parameters that cannot carry variable attributes remain governed
+by their existing typed cardinality rules.
+
+#### Scenario: Unknown ambient nameref fails closed
+- **WHEN** default-mode Bash parses `printf '%s' "$x"`
+- **THEN** the whole result is unparseable because ambient `x` may be a nameref
+- **THEN** the parser does not report the outer `printf` complete while hiding recursive execution
+
+#### Scenario: Fresh isolated scalar may remain unknown data
+- **WHEN** isolated-mode Bash parses `printf '%s' "$x"` before any source mutation
+- **THEN** the variable value remains unknown
+- **THEN** the dereference does not by itself make the result unparseable because fresh-process attributes are proved safe
+
+#### Scenario: Nameref mutation hides execution in a later heredoc
+- **WHEN** isolated-mode Bash parses `declare -a a; declare -n x='a[$(hidden)0]'; cat <<EOF` followed by `${x}` and `EOF`
+- **THEN** the whole result is unparseable
+- **THEN** no complete heredoc or command projection hides `hidden`
+
+### Requirement: Unmodeled execution-bearing Bash builtins fail closed globally
+Stable v0.3 SHALL fail the complete parse closed for direct or statically
+wrapped Bash builtin forms whose argument text can execute, be evaluated as
+arithmetic, install deferred execution, or assign through unproved variable
+attributes. The bounded catalog SHALL include `eval`, `source` / `.`, `trap`,
+`let`, `declare`, `typeset`, `local`, `readonly`, `export`, `unset`, `read`,
+`readarray`, `mapfile`, `getopts`, and `set`, plus `printf -v`. Exact `command`
+and `builtin` dispatch wrappers SHALL be recursively unwrapped. Dynamic or
+invalid wrapper grammar SHALL fail closed. Ordinary `printf` without `-v`
+SHALL retain its existing behavior.
+
+#### Scenario: Eval payload is not mistaken for inert data
+- **WHEN** Bash parses `eval 'rm target.txt'`
+- **THEN** the whole result is unparseable until eval payload grammar is modeled
+- **THEN** `eval` is not published as a complete occurrence that hides `rm`
+
+#### Scenario: Integer declaration can execute quoted arithmetic data
+- **WHEN** Bash parses `declare -i x='a[$(hidden)0]'`
+- **THEN** the whole result is unparseable
+- **THEN** quoting the assignment operand does not make the builtin evaluation inert
+
+#### Scenario: Exact dispatch wrapper cannot bypass the boundary
+- **WHEN** Bash parses `builtin eval 'rm target.txt'`
+- **THEN** the whole result is unparseable under the same rule as direct `eval`
+
 ### Requirement: PowerShell loop proofs require an explicit initial-runspace contract
 `PwshParserOptions.InitialStateMode` SHALL default to `Unknown`. In that mode,
 the parser MAY expose supported `foreach` structure and command occurrences,

--- a/openspec/changes/v0-3-structured-shell-analysis/specs/explicit-redirect-semantics/spec.md
+++ b/openspec/changes/v0-3-structured-shell-analysis/specs/explicit-redirect-semantics/spec.md
@@ -130,6 +130,11 @@ executable may interpret that data as code.
 - **THEN** the redirect records that leading tabs are stripped
 - **THEN** authored body provenance remains available
 
+#### Scenario: Numeric-source heredoc
+- **WHEN** Bash parses `cat 3<<EOF` followed by a supported body and delimiter
+- **THEN** descriptor `3`, heredoc operation, delimiter, body, expansion, and completeness facts are preserved
+- **THEN** the numeric descriptor does not cause the body to be tokenized as an ordinary command
+
 ### Requirement: Bash here strings are explicit data redirects
 v0.3 SHALL parse Bash `<<< word` as a `HereString` redirect. Its operand SHALL
 use the normal shell value domain, SHALL NOT be path-relevant, and SHALL account

--- a/openspec/changes/v0-3-structured-shell-analysis/specs/structured-shell-syntax/spec.md
+++ b/openspec/changes/v0-3-structured-shell-analysis/specs/structured-shell-syntax/spec.md
@@ -257,6 +257,11 @@ syntax SHALL be diagnostic evidence only.
 - **WHEN** Bash encounters a single-`&` background list in v0.3
 - **THEN** the whole result is unparseable until concurrency and state boundaries are specified
 
+#### Scenario: Unmodeled execution-bearing Bash builtin
+- **WHEN** Bash encounters a direct or statically dispatch-wrapped builtin whose arguments can execute, defer, or recursively evaluate authored text
+- **THEN** the whole result is unparseable until that builtin's state and execution semantics are modeled
+- **THEN** no complete outer occurrence hides the unmodeled executable region
+
 #### Scenario: Ordinary PowerShell script-block argument
 - **WHEN** PowerShell parses a script block for a canonical receiver proved not to execute that argument
 - **THEN** it remains an opaque dynamic argument

--- a/openspec/changes/v0-3-structured-shell-analysis/tasks.md
+++ b/openspec/changes/v0-3-structured-shell-analysis/tasks.md
@@ -42,19 +42,22 @@
 - [x] 3.7 Adapt the existing PowerShell grammar to emit the structural model with no newly supported syntax.
 - [x] 3.8 Add tests proving existing parser inputs retain their v0.2 leaf and compatibility results, except for explicitly promoted v0.3 fail-closed cases.
 - [x] 3.9 Add corpus expectations for syntax shape, occurrences, roles, and completeness for existing constructs.
-- [ ] 3.10 Implement Bash `$()` discovery in supported argument words, redirect values, iterables, and expanding heredoc bodies; retain literal/escaped spellings and fail closed on command-name substitutions, legacy backticks, or incomplete interiors.
+- [x] 3.10 Implement Bash `$()` discovery in supported argument words, redirect values, iterables, and expanding heredoc bodies; retain literal/escaped spellings and fail closed on command-name substitutions, legacy backticks, or incomplete interiors.
   - [x] 3.10a Implement the simple-command argument and redirect-target slice, including comment-safe boundaries and fail-closed unsupported interiors.
   - [x] 3.10b Implement the bounded expanding-heredoc slice with quote-removed delimiters, literal quoted/escaped bodies, tab stripping, exact provenance, and fail-closed unsupported header/body forms.
+  - [x] 3.10c Require proved Bash variable-attribute state for simple named-parameter dereferences and fail closed globally on the locked unmodeled execution-bearing builtin catalog, including exact dispatch-wrapper bypasses.
 - [ ] 3.11 Implement PowerShell `$()` discovery in supported words, redirect values, foreach expressions, call-operator dynamic identities, standalone expression statements, double-quoted strings, and expandable here-strings; never invent invocation from standalone output, retain literal/escaped spellings, and fail closed on trailing command-style arguments, call-operator script blocks, or unsupported execution-bearing `@()` / `@{}` forms.
   - [x] 3.11a Implement words, redirect values, call-operator dynamic identities, standalone statements, expandable strings/here-strings, and parent-versus-child host payload provenance; fail closed on arbitrary expression values and unsupported execution-bearing `@()` / `@{}` forms.
-- [ ] 3.12 Pin substitution parentage, authored sibling indices, innermost-first ordering, Bash-isolated versus PowerShell-current-scope state, unknown-state propagation, nesting/depth limits, and incomplete dynamic identities in direct tests.
+- [x] 3.12 Pin substitution parentage, authored sibling indices, innermost-first ordering, Bash-isolated versus PowerShell-current-scope state, unknown-state propagation, nesting/depth limits, and incomplete dynamic identities in direct tests.
   - [x] 3.12a Pin the Bash argument/redirect slice, isolated cwd behavior, wrapper provenance, and the shared structural-depth budget.
   - [x] 3.12b Pin the PowerShell simple-command slice, current-scope exact and unknown cwd propagation, parent/child wrapper provenance, expression boundaries, and the shared structural-depth budget.
   - [x] 3.12c Pin expanding-heredoc sibling/nested ordering, exact spans, isolated state, delimiter modes, escape parity, depth limits, and atomic failure.
+  - [x] 3.12d Pin default-versus-isolated parameter dereferences, nameref and integer hidden execution, reachable mutation invalidation, substitution/subshell scope boundaries, and direct/wrapped execution-bearing builtins with native Bash oracles.
 - [ ] 3.13 Promote ordinary, multiple, nested, iterator, redirect, quoted, escaped, stateful, malformed, and hidden-execution substitution cases into both executable corpora and the Netclaw approval matrix.
   - [x] 3.13a Promote the Bash ordinary, multiple, nested, redirect, quoted, escaped, stateful, malformed, and hidden-execution cases into its executable corpus.
   - [x] 3.13b Promote the PowerShell ordinary, multiple, nested, redirect, quoted, escaped, stateful, malformed, expression-boundary, and hidden-execution cases into its executable corpus.
   - [x] 3.13c Promote expanding, literal, tab-stripped, multiple, and malformed Bash heredoc cases with full structural expectations into the executable corpus.
+  - [ ] 3.13d Promote sanitized nameref, unknown-state dereference, and execution-bearing builtin failures into the Bash executable corpus and Netclaw strict matrix.
 - [x] 3.14 Add `ExecutionRegionSyntax`, its four discriminant enums,
   `SimpleCommandSyntax.ExecutionRegions`, and appended occurrence/ancestry enum
   members to the public API and snapshot without changing existing enum values.
@@ -243,10 +246,10 @@
 
 - [x] 10.1 Specify heredoc delimiter adjacency and quoting, expansion mode, body provenance, substitutions, tab stripping, completeness, and Bash here-string semantics.
 - [x] 10.2 Preserve existing `<<` / `<<-` behavior and fix quoted-delimiter adjacency without regressing the v0.2 compatibility redirect.
-- [ ] 10.3 Add explicit heredoc delimiter/body/expansion/completeness facts and surface every supported substitution command.
+- [x] 10.3 Add explicit heredoc delimiter/body/expansion/completeness facts and surface every supported substitution command.
 - [ ] 10.4 Add Bash `<<<` here-string tokenization, explicit redirect facts, bounded operand analysis, and trailing-newline semantics.
-- [ ] 10.5 Add direct, malformed, quoted/unquoted, tab-stripped, dynamic, and substitution-bearing corpus cases plus real-Bash parse-only validation.
-  - [x] 10.5a Add direct, executable-corpus, real-Bash output, and real-Bash parse-only coverage for the bounded substitution-discovery slice; explicit redirect facts and the full heredoc matrix remain pending.
+- [x] 10.5 Add direct, malformed, quoted/unquoted, tab-stripped, dynamic, and substitution-bearing corpus cases plus real-Bash parse-only validation.
+  - [x] 10.5a Add direct, executable-corpus, real-Bash output, and real-Bash parse-only coverage for the bounded substitution-discovery slice, explicit redirect facts, and the full heredoc matrix.
 
 ## 11. Verification and Release
 

--- a/src/ShellSyntaxTree/Internal/Bash/Lexing/BashLexer.cs
+++ b/src/ShellSyntaxTree/Internal/Bash/Lexing/BashLexer.cs
@@ -27,7 +27,7 @@ namespace ShellSyntaxTree.Internal.Bash.Lexing;
 ///         <see cref="OpaqueRegionScanner"/>. Both are emitted as a single
 ///         <see cref="BashTokenKind.OpaqueSubstitution"/> token.</item>
 ///   <item>Constructs SPEC §1 calls non-goals — arithmetic expansion
-///         <c>$((…))</c> and complex parameter expansion
+///         <c>$((…))</c> / <c>$[…]</c> and complex parameter expansion
 ///         <c>${var//pat/repl}</c> — emit a
 ///         <see cref="BashTokenKind.UnparseableSentinel"/>. The parser
 ///         lifts that sentinel into <c>ParsedCommand.IsUnparseable</c>.</item>
@@ -133,9 +133,9 @@ internal static class BashLexer
                 // Heredoc handling: when we just emitted `<<` or `<<-`, the
                 // *next* word is the delimiter and the body that follows the
                 // first newline must be skipped per SPEC §4.
-                if (opText == "<<" || opText == "<<-")
+                if (IsHeredocOperator(opText))
                 {
-                    i = ConsumeHeredoc(src, i, opText, tokens);
+                    i = ConsumeHeredoc(src, i, opText!, tokens);
                 }
 
                 continue;
@@ -200,6 +200,12 @@ internal static class BashLexer
                     }
 
                     i = ConsumeCommandSubstitution(src, i, tokens);
+                    continue;
+                }
+
+                if (next == '[')
+                {
+                    i = ConsumeObsoleteArithmetic(src, i, tokens);
                     continue;
                 }
 
@@ -391,8 +397,18 @@ internal static class BashLexer
 
             if (src[descriptorEnd] == '<')
             {
-                length = descriptorEnd - i + 1;
-                text = descriptor.ToString() + "<";
+                var redirectLength = 1;
+                if (descriptorEnd + 1 < src.Length && src[descriptorEnd + 1] == '<')
+                {
+                    redirectLength = descriptorEnd + 2 < src.Length &&
+                        src[descriptorEnd + 2] == '-'
+                            ? 3
+                            : 2;
+                }
+
+                length = descriptorEnd - i + redirectLength;
+                text = descriptor.ToString() +
+                    (redirectLength == 3 ? "<<-" : redirectLength == 2 ? "<<" : "<");
                 return true;
             }
         }
@@ -458,6 +474,27 @@ internal static class BashLexer
             ? index + 3
             : index + 2;
         return true;
+    }
+
+    internal static bool IsHeredocOperator(string? operatorText)
+    {
+        if (string.IsNullOrEmpty(operatorText))
+        {
+            return false;
+        }
+
+        var operatorStart = 0;
+        while (operatorStart < operatorText!.Length &&
+               operatorText[operatorStart] is >= '0' and <= '9')
+        {
+            operatorStart++;
+        }
+
+        var remaining = operatorText.Length - operatorStart;
+        return remaining >= 2 &&
+               operatorText[operatorStart] == '<' &&
+               operatorText[operatorStart + 1] == '<' &&
+               (remaining == 2 || remaining == 3 && operatorText[operatorStart + 2] == '-');
     }
 
     private static bool CanStartNumericDescriptor(IReadOnlyList<BashToken> tokens)
@@ -953,6 +990,25 @@ internal static class BashLexer
         return start + length;
     }
 
+    private static int ConsumeObsoleteArithmetic(
+        ReadOnlySpan<char> src, int start, List<BashToken> tokens)
+    {
+        var scan = OpaqueRegionScanner.Scan(src, start + 1, '[', ']');
+        var endInclusive = scan.Closed ? scan.EndIndex : src.Length - 1;
+        var length = endInclusive - start + 1;
+        var reason = scan.Closed
+            ? "obsolete arithmetic expansion '$[…]': not supported in v0.3"
+            : "unterminated obsolete arithmetic expansion '$[…]': not supported in v0.3";
+        tokens.Add(new BashToken(
+            BashTokenKind.UnparseableSentinel,
+            src.Slice(start, length).ToString(),
+            null,
+            start,
+            length,
+            reason));
+        return start + length;
+    }
+
     private static bool TryConsumeComplexParamExpansion(
         ReadOnlySpan<char> src, int start, List<BashToken> tokens, out int afterBrace)
     {
@@ -1057,42 +1113,27 @@ internal static class BashLexer
                 continue;
             }
 
-            // $( and ${...//...} terminate the word — they emit their own
-            // tokens. Simple ${VAR}, $VAR, $$ etc. are absorbed.
+            // Unsupported expansion forms terminate the word so the outer
+            // tokenizer can emit one fail-closed sentinel at their exact
+            // authored boundary. Simple ${VAR}, $VAR, $$ etc. are absorbed.
             if (c == '$' && i + 1 < src.Length)
             {
                 var next = src[i + 1];
-                if (next == '(') break;
+                if (next is '(' or '[') break;
                 if (next == '{')
                 {
-                    // Decide complex vs simple by looking for a '/' in the body.
                     var openBrace = i + 1;
                     var scan = OpaqueRegionScanner.Scan(src, openBrace, '{', '}');
                     if (!scan.Closed) break; // let outer loop emit the sentinel
 
-                    var bodyHasSlash = false;
-                    for (var k = openBrace + 1; k < scan.EndIndex; k++)
-                    {
-                        if (src[k] == '/') { bodyHasSlash = true; break; }
-                    }
-
-                    if (bodyHasSlash) break;
-
-                    if (TryAppendBashExpansion(
-                            src, ref i, value, allowFieldSplit: true, out var error))
-                    {
-                        if (error is not null)
-                        {
-                            break;
-                        }
-
-                        continue;
-                    }
+                    var body = src.Slice(openBrace + 1, scan.EndIndex - openBrace - 1);
+                    if (!IsSimpleBracedParameterName(body)) break;
                 }
 
                 if (TryAppendBashExpansion(
-                        src, ref i, value, allowFieldSplit: true, out _))
+                        src, ref i, value, allowFieldSplit: true, out var error))
                 {
+                    if (error is not null) break;
                     continue;
                 }
             }
@@ -1157,6 +1198,13 @@ internal static class BashLexer
         }
 
         var next = src[start + 1];
+        if (next == '[')
+        {
+            error = "obsolete arithmetic expansion '$[…]': not supported in v0.3";
+            index = src.Length;
+            return true;
+        }
+
         if (next == '(')
         {
             if (start + 2 < src.Length && src[start + 2] == '(')
@@ -1451,7 +1499,7 @@ internal static class BashLexer
 
         var bodyStart = j;
 
-        var stripTabs = opText == "<<-";
+        var stripTabs = opText.EndsWith("<<-", StringComparison.Ordinal);
         while (j <= src.Length)
         {
             // Read the next line: from j to the next '\n' or end-of-input.
@@ -1509,6 +1557,9 @@ internal static class BashLexer
                 tokens[delimiterIndex] = tokens[delimiterIndex] with
                 {
                     HeredocBodyValue = bodyValue,
+                    HeredocBodyStart = bodyStart,
+                    HeredocBodyLength = bodyLength,
+                    IsHeredocDelimiterQuoted = delimiterQuoted,
                     HeredocSourceEnd = lineEnd,
                 };
 
@@ -1675,31 +1726,26 @@ internal static class BashLexer
                 return false;
             }
 
-            if (character == '$' && index + 1 < bodyEnd && src[index + 1] == '(')
+            if (character == '$')
             {
-                if (index + 2 < bodyEnd && src[index + 2] == '(')
+                var afterExpansion = index;
+                if (TryAppendBashExpansion(
+                        src.Slice(0, bodyEnd),
+                        ref afterExpansion,
+                        builder,
+                        allowFieldSplit: false,
+                        out var expansionError))
                 {
-                    value = builder.Build();
-                    error = "arithmetic expansion '$((…))' not supported in heredoc body";
-                    return false;
-                }
+                    if (expansionError is not null)
+                    {
+                        value = builder.Build();
+                        error = expansionError;
+                        return false;
+                    }
 
-                var scan = ScanCommandSubstitution(src, index + 1);
-                if (!scan.Closed || scan.EndIndex >= bodyEnd)
-                {
-                    value = builder.Build();
-                    error = scan.Error ?? "unbalanced command substitution in heredoc body";
-                    return false;
+                    index = afterExpansion;
+                    continue;
                 }
-
-                var substitutionLength = scan.EndIndex - index + 1;
-                builder.AppendOpaque(
-                    src.Slice(index, substitutionLength).ToString(),
-                    ShellOpaqueCause.CommandSubstitution,
-                    index,
-                    substitutionLength);
-                index += substitutionLength;
-                continue;
             }
 
             builder.AppendLiteral(character, index, 1);

--- a/src/ShellSyntaxTree/Internal/Bash/Lexing/BashToken.cs
+++ b/src/ShellSyntaxTree/Internal/Bash/Lexing/BashToken.cs
@@ -64,6 +64,25 @@ internal readonly record struct BashToken(
     public ShellValue? HeredocBodyValue { get; init; }
 
     /// <summary>
+    /// Authored-source start of the heredoc body associated with a delimiter
+    /// token. Null for ordinary tokens and malformed heredocs.
+    /// </summary>
+    public int? HeredocBodyStart { get; init; }
+
+    /// <summary>
+    /// Authored-source length of the heredoc body associated with a delimiter
+    /// token. The span ends immediately before the terminator line and retains
+    /// leading tabs for <c>&lt;&lt;-</c> provenance.
+    /// </summary>
+    public int? HeredocBodyLength { get; init; }
+
+    /// <summary>
+    /// True when quote removal or an escape contributed to the delimiter.
+    /// Bash disables body expansion when any delimiter fragment is quoted.
+    /// </summary>
+    public bool IsHeredocDelimiterQuoted { get; init; }
+
+    /// <summary>
     /// Exclusive authored-source end of the heredoc terminator associated
     /// with a delimiter token. Null for ordinary tokens and malformed
     /// heredocs. This lets structural spans cover the body without exposing

--- a/src/ShellSyntaxTree/Internal/Bash/Parsing/BashCommandParser.cs
+++ b/src/ShellSyntaxTree/Internal/Bash/Parsing/BashCommandParser.cs
@@ -860,7 +860,7 @@ internal static partial class BashCommandParser
                     continue;
                 }
 
-                if (t.OperatorText == "<<" || t.OperatorText == "<<-")
+                if (BashLexer.IsHeredocOperator(t.OperatorText))
                 {
                     if (i + 1 >= segmentTokens.Count)
                     {

--- a/src/ShellSyntaxTree/Internal/Bash/Parsing/BashCwdInvocationGrammar.cs
+++ b/src/ShellSyntaxTree/Internal/Bash/Parsing/BashCwdInvocationGrammar.cs
@@ -10,11 +10,103 @@ namespace ShellSyntaxTree.Internal.Bash.Parsing;
 
 internal static class BashCwdInvocationGrammar
 {
+    private static readonly HashSet<string> ExecutionBearingBuiltins =
+        new(StringComparer.Ordinal)
+        {
+            ".",
+            "declare",
+            "eval",
+            "export",
+            "getopts",
+            "let",
+            "local",
+            "mapfile",
+            "read",
+            "readarray",
+            "readonly",
+            "set",
+            "source",
+            "trap",
+            "typeset",
+            "unset",
+        };
+
     internal static BashDispatchKind Classify(
         Clause clause,
         out IReadOnlyList<int> cwdArgumentElementIndices)
     {
         cwdArgumentElementIndices = Array.Empty<int>();
+        var words = CollectWords(clause);
+        var dispatch = ParseDispatch(clause, words);
+        if (dispatch.IsQuery)
+        {
+            return BashDispatchKind.Query;
+        }
+
+        if (!dispatch.IsSupported || dispatch.TargetWordIndex is null)
+        {
+            return BashDispatchKind.None;
+        }
+
+        var targetWordIndex = dispatch.TargetWordIndex.Value;
+        var target = clause.Elements[words[targetWordIndex]];
+        if (target.Value is not ("cd" or "chdir"))
+        {
+            return BashDispatchKind.None;
+        }
+
+        var arguments = new int[words.Count - targetWordIndex - 1];
+        for (var argumentIndex = 0; argumentIndex < arguments.Length; argumentIndex++)
+        {
+            arguments[argumentIndex] = words[targetWordIndex + argumentIndex + 1];
+        }
+
+        cwdArgumentElementIndices = arguments;
+        return BashDispatchKind.CwdTransfer;
+    }
+
+    internal static BashExecutionBoundaryKind ClassifyExecutionBoundary(Clause clause)
+    {
+        var words = CollectWords(clause);
+        var dispatch = ParseDispatch(clause, words);
+        if (!dispatch.IsSupported)
+        {
+            return dispatch.HasWrapper
+                ? BashExecutionBoundaryKind.UnsupportedDispatch
+                : BashExecutionBoundaryKind.Allowed;
+        }
+
+        if (dispatch.IsQuery)
+        {
+            return BashExecutionBoundaryKind.Query;
+        }
+
+        if (dispatch.TargetWordIndex is not { } targetWordIndex)
+        {
+            return BashExecutionBoundaryKind.Allowed;
+        }
+
+        var target = clause.Elements[words[targetWordIndex]];
+        if (ExecutionBearingBuiltins.Contains(target.Value))
+        {
+            return BashExecutionBoundaryKind.ExecutionBearingBuiltin;
+        }
+
+        if (target.Value == "printf" && targetWordIndex + 1 < words.Count)
+        {
+            var firstArgument = clause.Elements[words[targetWordIndex + 1]];
+            if (!IsStaticWord(firstArgument) ||
+                firstArgument.Value.StartsWith("-v", StringComparison.Ordinal))
+            {
+                return BashExecutionBoundaryKind.ExecutionBearingBuiltin;
+            }
+        }
+
+        return BashExecutionBoundaryKind.Allowed;
+    }
+
+    private static IReadOnlyList<int> CollectWords(Clause clause)
+    {
         var words = new List<int>();
         for (var index = 0; index < clause.Elements.Count; index++)
         {
@@ -24,17 +116,26 @@ internal static class BashCwdInvocationGrammar
             }
         }
 
+        return words;
+    }
+
+    private static BashDispatchAnalysis ParseDispatch(
+        Clause clause,
+        IReadOnlyList<int> words)
+    {
         var wordIndex = 0;
+        var hasWrapper = false;
         while (wordIndex < words.Count)
         {
             var element = clause.Elements[words[wordIndex]];
             if (!IsStaticWord(element))
             {
-                return BashDispatchKind.None;
+                return new BashDispatchAnalysis(false, false, hasWrapper, null);
             }
 
             if (element.Value == "command")
             {
+                hasWrapper = true;
                 wordIndex++;
                 var optionsEnded = false;
                 while (wordIndex < words.Count && !optionsEnded)
@@ -42,7 +143,7 @@ internal static class BashCwdInvocationGrammar
                     var option = clause.Elements[words[wordIndex]];
                     if (!IsStaticWord(option))
                     {
-                        return BashDispatchKind.None;
+                        return new BashDispatchAnalysis(false, false, true, null);
                     }
 
                     if (option.Value == "--")
@@ -71,14 +172,14 @@ internal static class BashCwdInvocationGrammar
                                 query = true;
                                 break;
                             default:
-                                return BashDispatchKind.None;
+                                return new BashDispatchAnalysis(false, false, true, null);
                         }
                     }
 
                     wordIndex++;
                     if (query)
                     {
-                        return BashDispatchKind.Query;
+                        return new BashDispatchAnalysis(true, true, true, null);
                     }
                 }
 
@@ -87,13 +188,14 @@ internal static class BashCwdInvocationGrammar
 
             if (element.Value == "builtin")
             {
+                hasWrapper = true;
                 wordIndex++;
                 if (wordIndex < words.Count)
                 {
                     var option = clause.Elements[words[wordIndex]];
                     if (!IsStaticWord(option))
                     {
-                        return BashDispatchKind.None;
+                        return new BashDispatchAnalysis(false, false, true, null);
                     }
 
                     if (option.Value == "--")
@@ -102,35 +204,27 @@ internal static class BashCwdInvocationGrammar
                     }
                     else if (option.Value.Length > 1 && option.Value[0] == '-')
                     {
-                        return BashDispatchKind.None;
+                        return new BashDispatchAnalysis(false, false, true, null);
                     }
                 }
 
                 continue;
             }
 
-            if (element.Value is not ("cd" or "chdir"))
-            {
-                return BashDispatchKind.None;
-            }
-
-            var arguments = new int[words.Count - wordIndex - 1];
-            for (var argumentIndex = 0;
-                 argumentIndex < arguments.Length;
-                 argumentIndex++)
-            {
-                arguments[argumentIndex] = words[wordIndex + argumentIndex + 1];
-            }
-
-            cwdArgumentElementIndices = arguments;
-            return BashDispatchKind.CwdTransfer;
+            return new BashDispatchAnalysis(true, false, hasWrapper, wordIndex);
         }
 
-        return BashDispatchKind.None;
+        return new BashDispatchAnalysis(true, false, hasWrapper, null);
     }
 
     private static bool IsStaticWord(ClauseElement element) =>
         element.Kind == ArgKind.Literal;
+
+    private readonly record struct BashDispatchAnalysis(
+        bool IsSupported,
+        bool IsQuery,
+        bool HasWrapper,
+        int? TargetWordIndex);
 }
 
 internal enum BashDispatchKind
@@ -138,4 +232,12 @@ internal enum BashDispatchKind
     None,
     Query,
     CwdTransfer,
+}
+
+internal enum BashExecutionBoundaryKind
+{
+    Allowed,
+    Query,
+    ExecutionBearingBuiltin,
+    UnsupportedDispatch,
 }

--- a/src/ShellSyntaxTree/Internal/Bash/Parsing/BashRedirectAnalysis.cs
+++ b/src/ShellSyntaxTree/Internal/Bash/Parsing/BashRedirectAnalysis.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Text;
+using ShellSyntaxTree.Internal.Bash.Lexing;
 
 namespace ShellSyntaxTree.Internal.Bash.Parsing;
 
@@ -17,6 +18,18 @@ namespace ShellSyntaxTree.Internal.Bash.Parsing;
 internal static class BashRedirectAnalysis
 {
     internal static IReadOnlyList<RedirectAnalysis> Analyze(Clause clause)
+        => AnalyzeCore(clause, source: null, sourceTokens: null);
+
+    internal static IReadOnlyList<RedirectAnalysis> Analyze(
+        Clause clause,
+        string source,
+        IReadOnlyList<BashToken> sourceTokens)
+        => AnalyzeCore(clause, source, sourceTokens);
+
+    private static IReadOnlyList<RedirectAnalysis> AnalyzeCore(
+        Clause clause,
+        string? source,
+        IReadOnlyList<BashToken>? sourceTokens)
     {
         if (clause.Redirects.Count == 0)
         {
@@ -36,7 +49,12 @@ internal static class BashRedirectAnalysis
         for (var index = 0; index < result.Length; index++)
         {
             result[index] = index < elements.Count
-                ? Analyze(index, clause.Redirects[index], elements[index])
+                ? Analyze(
+                    index,
+                    clause.Redirects[index],
+                    elements[index],
+                    source,
+                    sourceTokens)
                 : Incomplete(index);
         }
 
@@ -46,14 +64,32 @@ internal static class BashRedirectAnalysis
     private static RedirectAnalysis Analyze(
         int redirectIndex,
         Redirect compatibility,
-        ClauseElement element)
+        ClauseElement element,
+        string? authoredSource,
+        IReadOnlyList<BashToken>? sourceTokens)
     {
-        if (!TryReadOperator(element.Raw, out var source, out var operation, out var length))
+        if (!TryReadOperator(
+                element.Raw,
+                out var redirectSource,
+                out var operation,
+                out var length))
         {
             return Incomplete(redirectIndex);
         }
 
         var authoredTarget = element.Raw.Substring(length).TrimStart();
+        if (operation == RedirectOperation.HereDocument)
+        {
+            return AnalyzeHereDocument(
+                redirectIndex,
+                authoredSource,
+                sourceTokens,
+                element,
+                redirectSource,
+                stripLeadingTabs: element.Raw.AsSpan(0, length)
+                    .EndsWith("<<-", StringComparison.Ordinal));
+        }
+
         if (operation is RedirectOperation.FileInput or
             RedirectOperation.FileOutput or
             RedirectOperation.FileAppend &&
@@ -61,7 +97,7 @@ internal static class BashRedirectAnalysis
         {
             return AnalyzeDescriptorTarget(
                 redirectIndex,
-                source,
+                redirectSource,
                 authoredTarget,
                 element.Value);
         }
@@ -71,7 +107,7 @@ internal static class BashRedirectAnalysis
             return new RedirectAnalysis
             {
                 RedirectIndex = redirectIndex,
-                Source = source,
+                Source = redirectSource,
             };
         }
 
@@ -79,7 +115,7 @@ internal static class BashRedirectAnalysis
         return new RedirectAnalysis
         {
             RedirectIndex = redirectIndex,
-            Source = source,
+            Source = redirectSource,
             Operation = operation,
             Target = isComplete
                 ? new ShellValueDomain
@@ -91,6 +127,74 @@ internal static class BashRedirectAnalysis
             IsPathRelevant = true,
             IsComplete = isComplete,
         };
+    }
+
+    private static RedirectAnalysis AnalyzeHereDocument(
+        int redirectIndex,
+        string? source,
+        IReadOnlyList<BashToken>? sourceTokens,
+        ClauseElement element,
+        RedirectSource redirectSource,
+        bool stripLeadingTabs)
+    {
+        if (source is null || sourceTokens is null ||
+            element.SourceStart is null || element.SourceLength is null)
+        {
+            return Incomplete(redirectIndex);
+        }
+
+        var elementEnd = element.SourceStart.Value + element.SourceLength.Value;
+        foreach (var token in sourceTokens)
+        {
+            if (token.HeredocBodyValue is null ||
+                token.HeredocBodyStart is null ||
+                token.HeredocBodyLength is null ||
+                token.SourceStart + token.SourceLength != elementEnd)
+            {
+                continue;
+            }
+
+            var bodyStart = token.HeredocBodyStart.Value;
+            var bodyLength = token.HeredocBodyLength.Value;
+            if (token.SourceStart < element.SourceStart.Value ||
+                token.SourceStart + token.SourceLength > source.Length ||
+                bodyStart < 0 || bodyLength < 0 ||
+                bodyStart + bodyLength > source.Length)
+            {
+                return Incomplete(redirectIndex);
+            }
+
+            var hereDocument = new HereDocumentAnalysis
+            {
+                Delimiter = new ShellSourceFragment
+                {
+                    Raw = source.Substring(token.SourceStart, token.SourceLength),
+                    SourceStart = token.SourceStart,
+                    SourceLength = token.SourceLength,
+                },
+                Body = new ShellSourceFragment
+                {
+                    Raw = source.Substring(bodyStart, bodyLength),
+                    SourceStart = bodyStart,
+                    SourceLength = bodyLength,
+                },
+                ExpansionMode = token.IsHeredocDelimiterQuoted
+                    ? HereDocumentExpansionMode.Literal
+                    : HereDocumentExpansionMode.Expand,
+                StripLeadingTabs = stripLeadingTabs,
+                IsComplete = true,
+            };
+            return new RedirectAnalysis
+            {
+                RedirectIndex = redirectIndex,
+                Source = redirectSource,
+                Operation = RedirectOperation.HereDocument,
+                HereDocument = hereDocument,
+                IsComplete = redirectSource.Kind != RedirectSourceKind.Unknown,
+            };
+        }
+
+        return Incomplete(redirectIndex);
     }
 
     private static RedirectAnalysis AnalyzeDescriptorTarget(
@@ -193,22 +297,35 @@ internal static class BashRedirectAnalysis
 
         if (descriptorText.Length > 0)
         {
-            if (!int.TryParse(
+            if (int.TryParse(
                     descriptorText.ToString(),
                     NumberStyles.None,
                     CultureInfo.InvariantCulture,
-                    out var descriptor) ||
-                descriptor < 0)
+                    out var descriptor) &&
+                descriptor >= 0)
+            {
+                source = new RedirectSource
+                {
+                    Kind = RedirectSourceKind.Descriptor,
+                    Descriptor = descriptor,
+                };
+            }
+            else
             {
                 source = new RedirectSource();
+                if (raw.AsSpan(operatorStart).StartsWith("<<-", StringComparison.Ordinal))
+                {
+                    operation = RedirectOperation.HereDocument;
+                    length = operatorStart + 3;
+                }
+                else if (raw.AsSpan(operatorStart).StartsWith("<<", StringComparison.Ordinal))
+                {
+                    operation = RedirectOperation.HereDocument;
+                    length = operatorStart + 2;
+                }
+
                 return true;
             }
-
-            source = new RedirectSource
-            {
-                Kind = RedirectSourceKind.Descriptor,
-                Descriptor = descriptor,
-            };
         }
 
         if (raw.AsSpan(operatorStart).StartsWith(">>", StringComparison.Ordinal))
@@ -227,12 +344,14 @@ internal static class BashRedirectAnalysis
 
         if (raw.AsSpan(operatorStart).StartsWith("<<-", StringComparison.Ordinal))
         {
+            operation = RedirectOperation.HereDocument;
             length = operatorStart + 3;
             return true;
         }
 
         if (raw.AsSpan(operatorStart).StartsWith("<<", StringComparison.Ordinal))
         {
+            operation = RedirectOperation.HereDocument;
             length = operatorStart + 2;
             return true;
         }

--- a/src/ShellSyntaxTree/Internal/Bash/Parsing/BashStructuralCoordinator.cs
+++ b/src/ShellSyntaxTree/Internal/Bash/Parsing/BashStructuralCoordinator.cs
@@ -563,6 +563,28 @@ internal static partial class BashCommandParser
                 IsCommandStringWrapped = _markBashCWrapped,
             };
             var emitted = AttachAttributionArg(clause, _attribution);
+            var executionBoundary =
+                BashCwdInvocationGrammar.ClassifyExecutionBoundary(emitted);
+            if (executionBoundary == BashExecutionBoundaryKind.ExecutionBearingBuiltin)
+            {
+                error = "Bash execution-bearing builtin requires structure-aware state analysis";
+                return false;
+            }
+
+            if (executionBoundary == BashExecutionBoundaryKind.UnsupportedDispatch)
+            {
+                error = "Bash command or builtin dispatch grammar is not statically supported";
+                return false;
+            }
+
+            if (ContainsNamedParameterExpansion(segmentTokens) &&
+                (_options.InitialStateMode != BashInitialStateMode.IsolatedNonInteractive ||
+                 _hasUnmodeledVariableStateMutation))
+            {
+                error = "Bash named parameter expansion requires proved variable-attribute state";
+                return false;
+            }
+
             var dispatchKind = BashCwdInvocationGrammar.Classify(
                 emitted,
                 out _);
@@ -1288,16 +1310,33 @@ internal static partial class BashCommandParser
                     parseOptions.WorkingDirectory ?? Environment.CurrentDirectory));
             }
 
-            var redirectAnalysis = BashRedirectAnalysis.Analyze(simple.Clause);
+            var redirectAnalysis = BashRedirectAnalysis.Analyze(
+                simple.Clause,
+                _source,
+                sourceTokens);
             _facts.Add(simple.Clause, new CommandOccurrenceFacts
             {
                 Redirects = redirectAnalysis,
                 ValueProvenance = valueProvenance.ToArray(),
                 CwdPathDependencies = cwdPathDependencies.ToArray(),
                 IsComplete = simple.Clause.Verb.Tokens.Count > 0 &&
-                    AreRedirectsComplete(simple.Clause) &&
+                    AreRedirectsComplete(redirectAnalysis) &&
                     !HasUnexpandedCommandString(simple.Clause),
             });
+        }
+
+        private static bool AreRedirectsComplete(
+            IReadOnlyList<RedirectAnalysis> redirects)
+        {
+            foreach (var redirect in redirects)
+            {
+                if (!redirect.IsComplete)
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         private static bool TryGetElementValue(
@@ -1389,7 +1428,7 @@ internal static partial class BashCommandParser
 
                 _facts.Add(clonedClause, new CommandOccurrenceFacts
                 {
-                    Redirects = source.Redirects,
+                    Redirects = ClearDecodedHereDocumentSpans(source.Redirects),
                     CwdPathDependencies = cwdPathDependencies,
                     ValueProvenance = valueProvenance,
                     IsComplete = source.IsComplete,
@@ -1409,6 +1448,43 @@ internal static partial class BashCommandParser
 
             error = null;
             return true;
+        }
+
+        private static IReadOnlyList<RedirectAnalysis> ClearDecodedHereDocumentSpans(
+            IReadOnlyList<RedirectAnalysis> redirects)
+        {
+            var rewritten = new RedirectAnalysis[redirects.Count];
+            var changed = false;
+            for (var index = 0; index < rewritten.Length; index++)
+            {
+                var redirect = redirects[index];
+                var hereDocument = redirect.HereDocument;
+                if (hereDocument is null)
+                {
+                    rewritten[index] = redirect;
+                    continue;
+                }
+
+                changed = true;
+                rewritten[index] = redirect with
+                {
+                    HereDocument = hereDocument with
+                    {
+                        Delimiter = hereDocument.Delimiter with
+                        {
+                            SourceStart = null,
+                            SourceLength = null,
+                        },
+                        Body = hereDocument.Body with
+                        {
+                            SourceStart = null,
+                            SourceLength = null,
+                        },
+                    },
+                };
+            }
+
+            return changed ? rewritten : redirects;
         }
 
         private static bool TryFindValueProvenance(
@@ -1488,6 +1564,32 @@ internal static partial class BashCommandParser
                 if (string.Equals(argument.Raw, "-v", StringComparison.Ordinal))
                 {
                     return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool ContainsNamedParameterExpansion(
+            IReadOnlyList<BashToken> tokens)
+        {
+            foreach (var token in tokens)
+            {
+                foreach (var value in new[] { token.ResolverValue, token.HeredocBodyValue })
+                {
+                    if (value is null)
+                    {
+                        continue;
+                    }
+
+                    foreach (var fragment in value.Fragments)
+                    {
+                        if (fragment.Kind == ShellValueFragmentKind.Expansion &&
+                            fragment.Expansion is { Kind: ShellExpansionKind.Variable })
+                        {
+                            return true;
+                        }
+                    }
                 }
             }
 

--- a/tests/ShellSyntaxTree.Tests/Corpus/AstAssert.cs
+++ b/tests/ShellSyntaxTree.Tests/Corpus/AstAssert.cs
@@ -528,6 +528,61 @@ internal static class AstAssert
                 wanted.Target,
                 observed.Target,
                 $"{path}[{index}].target");
+            AssertHereDocumentEqual(
+                wanted.HereDocument,
+                observed.HereDocument,
+                $"{path}[{index}].hereDocument");
+        }
+    }
+
+    private static void AssertHereDocumentEqual(
+        ExpectedHereDocumentAnalysis? expected,
+        HereDocumentAnalysis? actual,
+        string path)
+    {
+        if (expected is null)
+        {
+            if (actual is not null)
+            {
+                throw new XunitException($"{path}: expected null, actual non-null");
+            }
+
+            return;
+        }
+
+        if (actual is null)
+        {
+            throw new XunitException($"{path}: expected non-null, actual null");
+        }
+
+        AssertSourceFragmentEqual(expected.Delimiter, actual.Delimiter, path + ".delimiter");
+        AssertSourceFragmentEqual(expected.Body, actual.Body, path + ".body");
+        if (expected.ExpansionMode != actual.ExpansionMode ||
+            expected.StripLeadingTabs != actual.StripLeadingTabs ||
+            expected.IsComplete != actual.IsComplete)
+        {
+            throw new XunitException(
+                $"{path} differs: expected expansion={expected.ExpansionMode}, "
+                + $"stripTabs={expected.StripLeadingTabs}, complete={expected.IsComplete}; "
+                + $"actual expansion={actual.ExpansionMode}, "
+                + $"stripTabs={actual.StripLeadingTabs}, complete={actual.IsComplete}");
+        }
+    }
+
+    private static void AssertSourceFragmentEqual(
+        ExpectedSourceFragment expected,
+        ShellSourceFragment actual,
+        string path)
+    {
+        if (expected.Raw != actual.Raw ||
+            expected.SourceStart != actual.SourceStart ||
+            expected.SourceLength != actual.SourceLength)
+        {
+            throw new XunitException(
+                $"{path}: expected raw={Quote(expected.Raw)}, "
+                + $"span={expected.SourceStart}:{expected.SourceLength}; "
+                + $"actual raw={Quote(actual.Raw)}, "
+                + $"span={actual.SourceStart}:{actual.SourceLength}");
         }
     }
 

--- a/tests/ShellSyntaxTree.Tests/Corpus/CorpusRunnerTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Corpus/CorpusRunnerTests.cs
@@ -34,12 +34,20 @@ public class CorpusRunnerTests
         Assert.NotNull(entry);
         Assert.False(string.IsNullOrEmpty(entry.Name), $"Corpus entry {fileName} has no name.");
         Assert.NotNull(entry.Expected);
+        if (shell != "bash")
+        {
+            Assert.Null(entry.BashInitialStateMode);
+        }
+
         if (shell != "powershell")
         {
             Assert.Null(entry.PowerShellInitialStateMode);
         }
 
-        var actual = CreateParser(shell, entry.PowerShellInitialStateMode).Parse(entry.Input);
+        var actual = CreateParser(
+            shell,
+            entry.BashInitialStateMode,
+            entry.PowerShellInitialStateMode).Parse(entry.Input);
         AstAssert.Equal(entry.Expected!, actual, $"{shell}/{fileName}");
         AssertClauseElementInvariants(actual, $"{shell}/{fileName}");
         AssertAuthoredTokenCoverage(shell, actual, $"{shell}/{fileName}");
@@ -871,13 +879,15 @@ public class CorpusRunnerTests
     /// </summary>
     internal static IShellParser CreateParser(
         string shell,
+        BashInitialStateMode? bashInitialStateMode = null,
         PwshInitialStateMode? powerShellInitialStateMode = null) => shell switch
         {
             "bash" => new BashParser(new BashParserOptions
             {
                 HomeDirectory = "/home/test",
                 WorkingDirectory = "/work",
-                InitialStateMode = BashInitialStateMode.IsolatedNonInteractive,
+                InitialStateMode = bashInitialStateMode ??
+                    BashInitialStateMode.IsolatedNonInteractive,
             }),
             "powershell" => new PwshParser(new PwshParserOptions
             {
@@ -942,6 +952,8 @@ public sealed record CorpusEntry
     public string Name { get; init; } = "";
 
     public string Input { get; init; } = "";
+
+    public BashInitialStateMode? BashInitialStateMode { get; init; }
 
     public PwshInitialStateMode? PowerShellInitialStateMode { get; init; }
 
@@ -1055,9 +1067,33 @@ public sealed record ExpectedRedirectAnalysis
 
     public ExpectedValueDomain Target { get; init; } = new();
 
+    public ExpectedHereDocumentAnalysis? HereDocument { get; init; }
+
     public bool IsPathRelevant { get; init; }
 
     public bool IsComplete { get; init; }
+}
+
+public sealed record ExpectedHereDocumentAnalysis
+{
+    public ExpectedSourceFragment Delimiter { get; init; } = new();
+
+    public ExpectedSourceFragment Body { get; init; } = new();
+
+    public HereDocumentExpansionMode ExpansionMode { get; init; }
+
+    public bool StripLeadingTabs { get; init; }
+
+    public bool IsComplete { get; init; }
+}
+
+public sealed record ExpectedSourceFragment
+{
+    public string Raw { get; init; } = "";
+
+    public int? SourceStart { get; init; }
+
+    public int? SourceLength { get; init; }
 }
 
 public sealed record ExpectedEffectiveArgument

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/200_v03_expanding_heredoc_substitution.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/200_v03_expanding_heredoc_substitution.json
@@ -116,7 +116,31 @@
       {
         "clauseIndex": 1,
         "immediateRole": "Ordinary",
-        "isComplete": false,
+        "isComplete": true,
+        "redirects": [
+          {
+            "redirectIndex": 0,
+            "sourceKind": "Default",
+            "operation": "HereDocument",
+            "hereDocument": {
+              "delimiter": {
+                "raw": "EOF",
+                "sourceStart": 6,
+                "sourceLength": 3
+              },
+              "body": {
+                "raw": "$(id)\n",
+                "sourceStart": 10,
+                "sourceLength": 6
+              },
+              "expansionMode": "Expand",
+              "stripLeadingTabs": false,
+              "isComplete": true
+            },
+            "isPathRelevant": false,
+            "isComplete": true
+          }
+        ],
         "ancestry": [
           {
             "ancestorKind": "Block",

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/201_v03_literal_heredoc_substitution_spelling.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/201_v03_literal_heredoc_substitution_spelling.json
@@ -47,7 +47,31 @@
       {
         "clauseIndex": 0,
         "immediateRole": "Ordinary",
-        "isComplete": false,
+        "isComplete": true,
+        "redirects": [
+          {
+            "redirectIndex": 0,
+            "sourceKind": "Default",
+            "operation": "HereDocument",
+            "hereDocument": {
+              "delimiter": {
+                "raw": "E\"OF\"",
+                "sourceStart": 6,
+                "sourceLength": 5
+              },
+              "body": {
+                "raw": "$(id)\n",
+                "sourceStart": 12,
+                "sourceLength": 6
+              },
+              "expansionMode": "Literal",
+              "stripLeadingTabs": false,
+              "isComplete": true
+            },
+            "isPathRelevant": false,
+            "isComplete": true
+          }
+        ],
         "ancestry": [
           {
             "ancestorKind": "Block",

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/202_v03_tab_stripping_heredoc_substitution.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/202_v03_tab_stripping_heredoc_substitution.json
@@ -116,7 +116,31 @@
       {
         "clauseIndex": 1,
         "immediateRole": "Ordinary",
-        "isComplete": false,
+        "isComplete": true,
+        "redirects": [
+          {
+            "redirectIndex": 0,
+            "sourceKind": "Default",
+            "operation": "HereDocument",
+            "hereDocument": {
+              "delimiter": {
+                "raw": "EOF",
+                "sourceStart": 7,
+                "sourceLength": 3
+              },
+              "body": {
+                "raw": "\t$(id)\n",
+                "sourceStart": 11,
+                "sourceLength": 7
+              },
+              "expansionMode": "Expand",
+              "stripLeadingTabs": true,
+              "isComplete": true
+            },
+            "isPathRelevant": false,
+            "isComplete": true
+          }
+        ],
         "ancestry": [
           {
             "ancestorKind": "Block",

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/203_v03_heredoc_multiple_substitutions.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/203_v03_heredoc_multiple_substitutions.json
@@ -185,7 +185,31 @@
       {
         "clauseIndex": 2,
         "immediateRole": "Ordinary",
-        "isComplete": false,
+        "isComplete": true,
+        "redirects": [
+          {
+            "redirectIndex": 0,
+            "sourceKind": "Default",
+            "operation": "HereDocument",
+            "hereDocument": {
+              "delimiter": {
+                "raw": "EOF",
+                "sourceStart": 6,
+                "sourceLength": 3
+              },
+              "body": {
+                "raw": "$(first)\n$(second)\n",
+                "sourceStart": 10,
+                "sourceLength": 19
+              },
+              "expansionMode": "Expand",
+              "stripLeadingTabs": false,
+              "isComplete": true
+            },
+            "isPathRelevant": false,
+            "isComplete": true
+          }
+        ],
         "ancestry": [
           {
             "ancestorKind": "Block",

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/238_v03_for_wrapper_export_state_rejected.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/238_v03_for_wrapper_export_state_rejected.json
@@ -3,7 +3,8 @@
   "input": "export f=ambient; bash -c 'for f in a; do printf %s \"$f\"; done'",
   "expected": {
     "isUnparseable": true,
-    "unparseableReasonContains": "isolated non-interactive initial state"
+    "unparseableReasonContains": "execution-bearing builtin"
   },
-  "notes": "A decoded wrapper cannot reuse isolated loop assumptions after the outer source changes inherited variable state."
+  "notes": "Export is globally rejected until its variable-attribute effects are modeled, before a decoded wrapper can reuse isolated loop assumptions.",
+  "oracleExpectation": "OutOfScope"
 }

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/246_v03_for_post_binding_mutation_rejected.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/246_v03_for_post_binding_mutation_rejected.json
@@ -3,8 +3,8 @@
   "input": "for f in a; do :; done; unset f; echo \"$f\"",
   "expected": {
     "isUnparseable": true,
-    "unparseableReasonContains": "invalid parser-owned facts"
+    "unparseableReasonContains": "execution-bearing builtin"
   },
-  "notes": "Loop bindings persist after done; an unsupported later unset cannot leave a stale exact effective value.",
+  "notes": "Loop bindings persist after done; unset is globally rejected until its variable-attribute effects are modeled.",
   "oracleExpectation": "OutOfScope"
 }

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/269_v03_nameref_heredoc_expansion.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/269_v03_nameref_heredoc_expansion.json
@@ -1,0 +1,10 @@
+{
+  "name": "v0.3 Bash nameref heredoc expansion fails closed",
+  "input": "declare -a values; declare -n current='values[$(printf marker >&2)0]'; cat <<EOF\n${current}\nEOF",
+  "expected": {
+    "isUnparseable": true,
+    "unparseableReasonContains": "execution-bearing builtin"
+  },
+  "notes": "A nameref can defer executable array-subscript evaluation until a later simple parameter expansion, so declare remains outside the modeled boundary.",
+  "oracleExpectation": "OutOfScope"
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/270_v03_wrapped_execution_builtin.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/270_v03_wrapped_execution_builtin.json
@@ -1,0 +1,10 @@
+{
+  "name": "v0.3 Bash wrapped execution-bearing builtin fails closed",
+  "input": "command -p -- builtin -- eval 'printf marker >&2'",
+  "expected": {
+    "isUnparseable": true,
+    "unparseableReasonContains": "execution-bearing builtin"
+  },
+  "notes": "Exact command and builtin dispatch wrappers are recursively unwrapped before the global execution-bearing builtin catalog is applied.",
+  "oracleExpectation": "OutOfScope"
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/271_v03_unknown_named_parameter_state.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/271_v03_unknown_named_parameter_state.json
@@ -1,0 +1,11 @@
+{
+  "name": "v0.3 Bash unknown-state named parameter expansion fails closed",
+  "input": "printf '%s' \"$value\"",
+  "bashInitialStateMode": "Unknown",
+  "expected": {
+    "isUnparseable": true,
+    "unparseableReasonContains": "variable-attribute state"
+  },
+  "notes": "Without a caller-proved isolated initial state, even a simple named parameter may carry integer or nameref execution semantics.",
+  "oracleExpectation": "OutOfScope"
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/272_v03_attached_printf_v.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/272_v03_attached_printf_v.json
@@ -1,0 +1,10 @@
+{
+  "name": "v0.3 Bash attached printf variable assignment fails closed",
+  "input": "printf -v'value[$(printf marker >&2)0]' '%s' data",
+  "expected": {
+    "isUnparseable": true,
+    "unparseableReasonContains": "execution-bearing builtin"
+  },
+  "notes": "Bash accepts an attached -vname option, and an array-subscript variable name can execute command substitution during assignment.",
+  "oracleExpectation": "OutOfScope"
+}

--- a/tests/ShellSyntaxTree.Tests/Lexing/BashLexerTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Lexing/BashLexerTests.cs
@@ -220,6 +220,22 @@ public class BashLexerTests
         Assert.Equal("rest", tokens[3].Value);
     }
 
+    [Theory]
+    [InlineData("cmd 2<<EOF\nbody\nEOF", "2<<")]
+    [InlineData("cmd 10<<-EOF\n\tbody\n\tEOF", "10<<-")]
+    [InlineData("cmd 1\\\n0<<EOF\nbody\nEOF", "10<<")]
+    public void Numeric_source_heredoc_prefers_the_longest_redirect_operator(
+        string input,
+        string expectedOperator)
+    {
+        var tokens = LexNonWs(input);
+
+        Assert.Equal(3, tokens.Length);
+        Assert.Equal(expectedOperator, tokens[1].OperatorText);
+        Assert.Equal("EOF", tokens[2].Value);
+        Assert.NotNull(tokens[2].HeredocBodyValue);
+    }
+
     // ------------------------------------------------------------ quoting
 
     [Fact]
@@ -454,6 +470,21 @@ public class BashLexerTests
         Assert.Equal(BashTokenKind.UnparseableSentinel, t.Kind);
         Assert.Equal("$((1 + 2))", t.Value);
         Assert.Contains("arithmetic", t.UnparseableReason);
+    }
+
+    [Theory]
+    [InlineData("$[value]")]
+    [InlineData("\"$[value]\"")]
+    [InlineData("prefix$[value]suffix")]
+    [InlineData("prefix$((1 + 2))suffix")]
+    [InlineData("prefix${value@P}suffix")]
+    public void Unsupported_expansion_anywhere_in_a_word_emits_unparseable_sentinel(
+        string source)
+    {
+        var tokens = LexNonWs(source);
+
+        Assert.Contains(tokens, token =>
+            token.Kind == BashTokenKind.UnparseableSentinel);
     }
 
     [Fact]

--- a/tests/ShellSyntaxTree.Tests/Parsing/BashExecutionBoundaryTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Parsing/BashExecutionBoundaryTests.cs
@@ -1,0 +1,162 @@
+// -----------------------------------------------------------------------
+// <copyright file="BashExecutionBoundaryTests.cs" company="Aaron Stannard">
+//      Copyright (C) 2026 - 2026 Aaron Stannard <https://github.com/Aaronontheweb>
+// </copyright>
+// -----------------------------------------------------------------------
+using Xunit;
+
+namespace ShellSyntaxTree.Tests.Parsing;
+
+public class BashExecutionBoundaryTests
+{
+    [Theory]
+    [InlineData("eval 'printf unsafe'")]
+    [InlineData("source script.sh")]
+    [InlineData(". script.sh")]
+    [InlineData("trap 'printf unsafe' DEBUG")]
+    [InlineData("let 'value=1'")]
+    [InlineData("declare value=1")]
+    [InlineData("typeset value=1")]
+    [InlineData("local value=1")]
+    [InlineData("readonly value=1")]
+    [InlineData("export value=1")]
+    [InlineData("unset value")]
+    [InlineData("read value")]
+    [InlineData("readarray value")]
+    [InlineData("mapfile value")]
+    [InlineData("getopts ab value")]
+    [InlineData("set -u")]
+    [InlineData("printf -v value '%s' data")]
+    [InlineData("printf -vvalue '%s' data")]
+    public void Execution_bearing_builtin_fails_atomically(string source)
+    {
+        var result = Parse(source, BashInitialStateMode.IsolatedNonInteractive);
+
+        AssertAtomicFailure(result, "execution-bearing builtin");
+    }
+
+    [Theory]
+    [InlineData("command -- eval 'printf unsafe'")]
+    [InlineData("builtin -- declare value=1")]
+    [InlineData("command -p -- builtin -- unset value")]
+    [InlineData("builtin command -- printf -v value data")]
+    public void Static_dispatch_wrapper_cannot_hide_execution_bearing_builtin(string source)
+    {
+        var result = Parse(source, BashInitialStateMode.IsolatedNonInteractive);
+
+        AssertAtomicFailure(result, "execution-bearing builtin");
+    }
+
+    [Theory]
+    [InlineData("printf \"$option\" data")]
+    [InlineData("printf -v\"$name\" data")]
+    public void Dynamic_printf_option_position_fails_atomically(string source)
+    {
+        var result = Parse(source, BashInitialStateMode.IsolatedNonInteractive);
+
+        AssertAtomicFailure(result, "execution-bearing builtin");
+    }
+
+    [Theory]
+    [InlineData("command -z echo ok")]
+    [InlineData("builtin -p echo ok")]
+    [InlineData("command \"$dispatch\" ok")]
+    public void Unsupported_dispatch_grammar_fails_atomically(string source)
+    {
+        var result = Parse(source, BashInitialStateMode.IsolatedNonInteractive);
+
+        AssertAtomicFailure(result, "dispatch grammar");
+    }
+
+    [Theory]
+    [InlineData("printf '%s' \"$value\"")]
+    [InlineData("printf '%s' \"${value}\"")]
+    [InlineData("cat >&$descriptor")]
+    [InlineData("cat <<EOF\n${value}\nEOF")]
+    public void Unknown_initial_state_rejects_named_parameter_expansion(string source)
+    {
+        var result = Parse(source, BashInitialStateMode.Unknown);
+
+        AssertAtomicFailure(result, "variable-attribute state");
+    }
+
+    [Theory]
+    [InlineData("(printf '%s' \"$value\")")]
+    [InlineData("printf '%s' \"$(printf '%s' \"$value\")\"")]
+    public void Unknown_parameter_state_propagates_into_isolated_execution_regions(
+        string source)
+    {
+        var result = Parse(source, BashInitialStateMode.Unknown);
+
+        AssertAtomicFailure(result, "variable-attribute state");
+    }
+
+    [Theory]
+    [InlineData("printf '%s' \"$value\"")]
+    [InlineData("cat <<EOF\n${value}\nEOF")]
+    [InlineData("printf -- \"$format\" data")]
+    public void Isolated_initial_state_accepts_fresh_named_parameter_expansion(string source)
+    {
+        var result = Parse(source, BashInitialStateMode.IsolatedNonInteractive);
+
+        Assert.False(result.IsUnparseable, result.UnparseableReason);
+        Assert.NotEmpty(result.Commands);
+    }
+
+    [Theory]
+    [InlineData("(printf '%s' \"$value\")")]
+    [InlineData("printf '%s' \"$(printf '%s' \"$value\")\"")]
+    public void Proved_isolated_parameter_state_is_inherited_by_isolated_execution_regions(
+        string source)
+    {
+        var result = Parse(source, BashInitialStateMode.IsolatedNonInteractive);
+
+        Assert.False(result.IsUnparseable, result.UnparseableReason);
+        Assert.NotEmpty(result.Commands);
+    }
+
+    [Theory]
+    [InlineData("printf '%s' '$value'")]
+    [InlineData("printf '%s' \\$value")]
+    [InlineData("printf '%s' \"$1\"")]
+    [InlineData("printf '%s' \"$?\"")]
+    [InlineData("command -v eval")]
+    [InlineData("command -V unset")]
+    [InlineData("command")]
+    [InlineData("builtin")]
+    [InlineData("printf '%s' data")]
+    [InlineData("printf -- '%s' data")]
+    public void Non_named_or_non_executing_forms_remain_supported_in_unknown_state(string source)
+    {
+        var result = Parse(source, BashInitialStateMode.Unknown);
+
+        Assert.False(result.IsUnparseable, result.UnparseableReason);
+    }
+
+    [Fact]
+    public void Nameref_declaration_before_heredoc_expansion_fails_atomically()
+    {
+        const string source = "declare -a a; declare -n x='a[$(printf NREF >&2)0]'; " +
+            "cat <<EOF\n${x}\nEOF";
+
+        var result = Parse(source, BashInitialStateMode.IsolatedNonInteractive);
+
+        AssertAtomicFailure(result, "execution-bearing builtin");
+    }
+
+    private static ParsedCommand Parse(string source, BashInitialStateMode initialStateMode) =>
+        new BashParser(new BashParserOptions
+        {
+            HomeDirectory = "/home/test",
+            WorkingDirectory = "/work",
+            InitialStateMode = initialStateMode,
+        }).Parse(source);
+
+    private static void AssertAtomicFailure(ParsedCommand result, string reason)
+    {
+        Assert.True(result.IsUnparseable);
+        Assert.Empty(result.Commands);
+        Assert.Empty(result.Clauses);
+        Assert.Contains(reason, result.UnparseableReason!);
+    }
+}

--- a/tests/ShellSyntaxTree.Tests/Parsing/BashForInStructuralTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Parsing/BashForInStructuralTests.cs
@@ -141,14 +141,14 @@ public class BashForInStructuralTests
     [Theory]
     [InlineData("eval \"cd /a\"; for f in x; do rm -- \"$f\" rel.txt; done")]
     [InlineData("trap \"f=x\" DEBUG; for f in a b; do echo \"$f\"; done")]
-    public void Loop_after_prior_shell_state_mutation_fails_atomically(string source)
+    public void Execution_bearing_builtin_before_loop_fails_atomically(string source)
     {
         var result = Parse(source);
 
         Assert.True(result.IsUnparseable);
         Assert.Empty(result.Commands);
         Assert.Empty(result.Clauses);
-        Assert.Contains("shell-state mutation", result.UnparseableReason!);
+        Assert.Contains("execution-bearing builtin", result.UnparseableReason!);
     }
 
     [Theory]
@@ -820,7 +820,10 @@ public class BashForInStructuralTests
         Assert.True(result.IsUnparseable);
         Assert.Empty(result.Commands);
         Assert.Empty(result.Clauses);
-        Assert.Contains("mutation or control transfer", result.UnparseableReason!);
+        Assert.True(
+            result.UnparseableReason!.Contains("mutation or control transfer") ||
+            result.UnparseableReason.Contains("execution-bearing builtin"),
+            result.UnparseableReason);
     }
 
     [Theory]
@@ -972,7 +975,7 @@ public class BashForInStructuralTests
     }
 
     [Fact]
-    public void Decoded_loop_fails_after_outer_variable_state_mutation()
+    public void Export_before_decoded_loop_fails_at_the_global_execution_boundary()
     {
         var result = Parse(
             "export f=ambient; bash -c 'for f in a; do printf %s \"$f\"; done'");
@@ -980,18 +983,18 @@ public class BashForInStructuralTests
         Assert.True(result.IsUnparseable);
         Assert.Empty(result.Commands);
         Assert.Empty(result.Clauses);
-        Assert.Contains("isolated non-interactive initial state", result.UnparseableReason!);
+        Assert.Contains("execution-bearing builtin", result.UnparseableReason!);
     }
 
     [Fact]
-    public void Decoded_nonloop_command_remains_visible_after_outer_export()
+    public void Export_before_decoded_nonloop_command_fails_at_the_global_execution_boundary()
     {
         var result = Parse("export f=ambient; bash -c 'printf ok'");
 
-        Assert.False(result.IsUnparseable, result.UnparseableReason);
-        Assert.Equal(
-            new[] { "export", "printf" },
-            result.Commands.Select(command => command.Clause.Verb.Tokens[0]));
+        Assert.True(result.IsUnparseable);
+        Assert.Empty(result.Commands);
+        Assert.Empty(result.Clauses);
+        Assert.Contains("execution-bearing builtin", result.UnparseableReason!);
     }
 
     private static ClauseElement EffectiveValueElement(

--- a/tests/ShellSyntaxTree.Tests/Parsing/BashStructuralProjectionTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Parsing/BashStructuralProjectionTests.cs
@@ -1069,7 +1069,7 @@ public class BashStructuralProjectionTests
         Assert.False(result.IsUnparseable);
         Assert.Equal(new[] { "printf body", "cat" }, result.Commands.Select(CommandVerb));
         Assert.True(result.Commands[0].IsComplete);
-        Assert.False(result.Commands[1].IsComplete);
+        Assert.True(result.Commands[1].IsComplete);
         var outer = Assert.IsType<SimpleCommandSyntax>(Assert.Single(result.Syntax.Statements));
         Assert.Equal(0, outer.SourceStart);
         Assert.Equal(source.Length, outer.SourceLength);
@@ -1077,6 +1077,216 @@ public class BashStructuralProjectionTests
         Assert.Equal(source.IndexOf("$(", System.StringComparison.Ordinal), substitution.SourceStart);
         Assert.Equal("$(printf body)".Length, substitution.SourceLength);
         Assert.Equal(CommandOccurrenceRole.Substitution, result.Commands[0].ImmediateRole);
+    }
+
+    [Fact]
+    public void Literal_heredoc_publishes_authored_data_and_retains_compatibility_redirect()
+    {
+        const string source = "cat > output.txt <<'EOF'\nhello\nEOF\n";
+
+        var result = Parse(source);
+
+        Assert.False(result.IsUnparseable, result.UnparseableReason);
+        var occurrence = Assert.Single(result.Commands);
+        Assert.True(occurrence.IsComplete);
+        Assert.Equal(2, occurrence.Redirects.Count);
+
+        var redirect = occurrence.Redirects[1];
+        Assert.Equal(1, redirect.RedirectIndex);
+        Assert.Equal(RedirectSourceKind.Default, redirect.Source.Kind);
+        Assert.Null(redirect.Source.Descriptor);
+        Assert.Equal(RedirectOperation.HereDocument, redirect.Operation);
+        Assert.Equal(ShellValueDomainKind.Unknown, redirect.Target.Kind);
+        Assert.False(redirect.IsPathRelevant);
+        Assert.True(redirect.IsComplete);
+
+        var hereDocument = Assert.IsType<HereDocumentAnalysis>(redirect.HereDocument);
+        Assert.Equal("'EOF'", hereDocument.Delimiter.Raw);
+        Assert.Equal(source.IndexOf("'EOF'", System.StringComparison.Ordinal),
+            hereDocument.Delimiter.SourceStart);
+        Assert.Equal("'EOF'".Length, hereDocument.Delimiter.SourceLength);
+        Assert.Equal("hello\n", hereDocument.Body.Raw);
+        Assert.Equal(source.IndexOf("hello", System.StringComparison.Ordinal),
+            hereDocument.Body.SourceStart);
+        Assert.Equal("hello\n".Length, hereDocument.Body.SourceLength);
+        Assert.Equal(HereDocumentExpansionMode.Literal, hereDocument.ExpansionMode);
+        Assert.False(hereDocument.StripLeadingTabs);
+        Assert.True(hereDocument.IsComplete);
+
+        var compatibility = occurrence.Clause.Redirects[1];
+        Assert.Equal(RedirectDirection.In, compatibility.Direction);
+        Assert.Equal("<<EOF>", compatibility.Target);
+        Assert.False(compatibility.IsDynamicSkip);
+        var element = occurrence.Clause.Elements.Last(item =>
+            item.Role == ClauseElementRole.Redirect);
+        Assert.Equal("<<'EOF'", element.Raw);
+        Assert.Equal("EOF", element.Value);
+        Assert.False(element.IsPath);
+    }
+
+    [Fact]
+    public void Expanding_heredoc_publishes_complete_body_and_substitution_facts()
+    {
+        const string source = "cat <<EOF\nbefore $(id) after\nEOF";
+
+        var result = Parse(source);
+
+        Assert.False(result.IsUnparseable, result.UnparseableReason);
+        Assert.Equal(new[] { "id", "cat" }, result.Commands.Select(CommandVerb));
+        var consumer = result.Commands[1];
+        Assert.True(consumer.IsComplete);
+        var redirect = Assert.Single(consumer.Redirects);
+        Assert.Equal(RedirectOperation.HereDocument, redirect.Operation);
+        Assert.True(redirect.IsComplete);
+        var hereDocument = Assert.IsType<HereDocumentAnalysis>(redirect.HereDocument);
+        Assert.Equal("EOF", hereDocument.Delimiter.Raw);
+        Assert.Equal("before $(id) after\n", hereDocument.Body.Raw);
+        Assert.Equal(HereDocumentExpansionMode.Expand, hereDocument.ExpansionMode);
+        Assert.True(hereDocument.IsComplete);
+        Assert.Equal(CommandOccurrenceRole.Substitution, result.Commands[0].ImmediateRole);
+    }
+
+    [Fact]
+    public void Simple_parameter_in_expanding_heredoc_remains_complete_data()
+    {
+        const string source = "cat <<EOF\n${value}\nEOF";
+
+        var result = Parse(source);
+
+        Assert.False(result.IsUnparseable, result.UnparseableReason);
+        var redirect = Assert.Single(Assert.Single(result.Commands).Redirects);
+        Assert.True(redirect.IsComplete);
+        var hereDocument = Assert.IsType<HereDocumentAnalysis>(redirect.HereDocument);
+        Assert.Equal("${value}\n", hereDocument.Body.Raw);
+        Assert.Equal(HereDocumentExpansionMode.Expand, hereDocument.ExpansionMode);
+        Assert.True(hereDocument.IsComplete);
+    }
+
+    [Fact]
+    public void Tab_stripping_heredoc_retains_authored_tabs_in_body_provenance()
+    {
+        const string source = "cat <<-EOF\n\tvalue\n\tEOF";
+
+        var result = Parse(source);
+
+        Assert.False(result.IsUnparseable, result.UnparseableReason);
+        var redirect = Assert.Single(Assert.Single(result.Commands).Redirects);
+        var hereDocument = Assert.IsType<HereDocumentAnalysis>(redirect.HereDocument);
+        Assert.Equal(RedirectOperation.HereDocument, redirect.Operation);
+        Assert.Equal("\tvalue\n", hereDocument.Body.Raw);
+        Assert.Equal(source.IndexOf("\tvalue", System.StringComparison.Ordinal),
+            hereDocument.Body.SourceStart);
+        Assert.True(hereDocument.StripLeadingTabs);
+        Assert.Equal(HereDocumentExpansionMode.Expand, hereDocument.ExpansionMode);
+        Assert.True(hereDocument.IsComplete);
+    }
+
+    [Theory]
+    [InlineData("cat 2<<EOF\nbody\nEOF", 2, false)]
+    [InlineData("cat 10<<-EOF\n\tbody\n\tEOF", 10, true)]
+    [InlineData("cat 1\\\n0<<EOF\nbody\nEOF", 10, false)]
+    public void Numeric_source_heredoc_preserves_descriptor_and_body_semantics(
+        string source,
+        int sourceDescriptor,
+        bool stripLeadingTabs)
+    {
+        var result = Parse(source);
+
+        Assert.False(result.IsUnparseable, result.UnparseableReason);
+        var occurrence = Assert.Single(result.Commands);
+        Assert.True(occurrence.IsComplete);
+        var redirect = Assert.Single(occurrence.Redirects);
+        Assert.Equal(RedirectSourceKind.Descriptor, redirect.Source.Kind);
+        Assert.Equal(sourceDescriptor, redirect.Source.Descriptor);
+        Assert.Equal(RedirectOperation.HereDocument, redirect.Operation);
+        Assert.True(redirect.IsComplete);
+        var hereDocument = Assert.IsType<HereDocumentAnalysis>(redirect.HereDocument);
+        Assert.Equal("EOF", hereDocument.Delimiter.Raw);
+        Assert.Equal(stripLeadingTabs ? "\tbody\n" : "body\n", hereDocument.Body.Raw);
+        Assert.Equal(stripLeadingTabs, hereDocument.StripLeadingTabs);
+        Assert.True(hereDocument.IsComplete);
+
+        var compatibility = Assert.Single(occurrence.Clause.Redirects);
+        Assert.Equal(RedirectDirection.In, compatibility.Direction);
+        Assert.Equal("<<EOF>", compatibility.Target);
+        Assert.False(compatibility.IsDynamicSkip);
+    }
+
+    [Fact]
+    public void Overflow_numeric_source_heredoc_preserves_body_but_remains_incomplete()
+    {
+        var result = Parse("cat 999999999999999999999<<EOF\nbody\nEOF");
+
+        Assert.False(result.IsUnparseable, result.UnparseableReason);
+        var occurrence = Assert.Single(result.Commands);
+        Assert.False(occurrence.IsComplete);
+        var redirect = Assert.Single(occurrence.Redirects);
+        Assert.Equal(RedirectSourceKind.Unknown, redirect.Source.Kind);
+        Assert.Equal(RedirectOperation.HereDocument, redirect.Operation);
+        Assert.False(redirect.IsComplete);
+        var hereDocument = Assert.IsType<HereDocumentAnalysis>(redirect.HereDocument);
+        Assert.Equal("body\n", hereDocument.Body.Raw);
+        Assert.True(hereDocument.IsComplete);
+    }
+
+    [Theory]
+    [InlineData("cat <<EOF\nEOF", "")]
+    [InlineData("cat <<EOF\r\nbody\r\nEOF", "body\r\n")]
+    public void Heredoc_body_fragment_preserves_empty_and_crlf_source(
+        string source,
+        string expectedBody)
+    {
+        var result = Parse(source);
+
+        Assert.False(result.IsUnparseable, result.UnparseableReason);
+        var redirect = Assert.Single(Assert.Single(result.Commands).Redirects);
+        var hereDocument = Assert.IsType<HereDocumentAnalysis>(redirect.HereDocument);
+        Assert.Equal(expectedBody, hereDocument.Body.Raw);
+        Assert.Equal(expectedBody.Length, hereDocument.Body.SourceLength);
+        Assert.Equal(source.IndexOf('\n') + 1, hereDocument.Body.SourceStart);
+        Assert.True(redirect.IsComplete);
+        Assert.True(hereDocument.IsComplete);
+    }
+
+    [Theory]
+    [InlineData("E\\OF", "E\\OF")]
+    [InlineData("E\"OF\"", "E\"OF\"")]
+    public void Escaped_or_mixed_quoted_delimiter_publishes_literal_mode(
+        string delimiter,
+        string expectedRaw)
+    {
+        var source = "cat <<" + delimiter + "\n$value\nEOF";
+
+        var result = Parse(source);
+
+        Assert.False(result.IsUnparseable, result.UnparseableReason);
+        var redirect = Assert.Single(Assert.Single(result.Commands).Redirects);
+        var hereDocument = Assert.IsType<HereDocumentAnalysis>(redirect.HereDocument);
+        Assert.Equal(expectedRaw, hereDocument.Delimiter.Raw);
+        Assert.Equal("$value\n", hereDocument.Body.Raw);
+        Assert.Equal(HereDocumentExpansionMode.Literal, hereDocument.ExpansionMode);
+        Assert.True(hereDocument.IsComplete);
+    }
+
+    [Fact]
+    public void Decoded_wrapper_heredoc_retains_raw_data_without_outer_source_offsets()
+    {
+        const string source = "bash -c \"cat <<'EOF'\nhello\nEOF\"";
+
+        var result = Parse(source);
+
+        Assert.False(result.IsUnparseable, result.UnparseableReason);
+        var occurrence = Assert.Single(result.Commands);
+        Assert.True(occurrence.Clause.IsCommandStringWrapped);
+        var redirect = Assert.Single(occurrence.Redirects);
+        Assert.True(redirect.IsComplete);
+        var hereDocument = Assert.IsType<HereDocumentAnalysis>(redirect.HereDocument);
+        Assert.Equal("'EOF'", hereDocument.Delimiter.Raw);
+        Assert.Equal("hello\n", hereDocument.Body.Raw);
+        Assert.Null(hereDocument.Delimiter.SourceStart);
+        Assert.Null(hereDocument.Delimiter.SourceLength);
+        Assert.Null(hereDocument.Body.SourceStart);
+        Assert.Null(hereDocument.Body.SourceLength);
     }
 
     [Theory]
@@ -1200,6 +1410,9 @@ public class BashStructuralProjectionTests
     [InlineData("cat <<A <<B\na\nA\nb\nB")]
     [InlineData("cat <<EOF\n`id`\nEOF")]
     [InlineData("cat <<EOF\n$((1+1))\nEOF")]
+    [InlineData("cat <<EOF\n$[x]\nEOF")]
+    [InlineData("cat <<EOF\n${x@P}\nEOF")]
+    [InlineData("cat <<EOF\n${x:-$(id)}\nEOF")]
     [InlineData("cat <<EOF\n$\\\n(id)\nEOF")]
     [InlineData("cat <<EOF\n$(id\nEOF")]
     [InlineData("cat <<EOF\n$(id)\n")]

--- a/tests/ShellSyntaxTree.Tests/Parsing/ClauseElementTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Parsing/ClauseElementTests.cs
@@ -21,6 +21,7 @@ public class ClauseElementTests
     {
         HomeDirectory = "/home/test",
         WorkingDirectory = "/work",
+        InitialStateMode = BashInitialStateMode.IsolatedNonInteractive,
     });
 
     private static readonly PwshParser Pwsh = new(new PwshParserOptions

--- a/tests/ShellSyntaxTree.Tests/Parsing/ResolverProvenanceTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Parsing/ResolverProvenanceTests.cs
@@ -13,6 +13,7 @@ public class ResolverProvenanceTests
     {
         HomeDirectory = "/home/test",
         WorkingDirectory = "/work",
+        InitialStateMode = BashInitialStateMode.IsolatedNonInteractive,
     });
 
     private static readonly PwshParser Pwsh = new(new PwshParserOptions
@@ -43,6 +44,7 @@ public class ResolverProvenanceTests
         {
             HomeDirectory = "/home/test user",
             WorkingDirectory = "/work",
+            InitialStateMode = BashInitialStateMode.IsolatedNonInteractive,
         });
 
         var unquoted = Assert.Single(Assert.Single(parser.Parse("cat $HOME").Clauses).Args);

--- a/tests/ShellSyntaxTree.Tests/Parsing/ShellValueOracleTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Parsing/ShellValueOracleTests.cs
@@ -102,6 +102,44 @@ public class ShellValueOracleTests
         Assert.Equal(expected, Run("bash", "-c", source));
     }
 
+    [Fact]
+    public void Bash_prompt_parameter_transform_can_execute_command_text_in_heredoc()
+    {
+        if (!IsNativeBashAvailable())
+        {
+            return;
+        }
+
+        var output = Run(
+            "bash",
+            "--noprofile",
+            "--norc",
+            "-c",
+            "x='$(printf HIDDEN_EXEC)'; cat <<EOF\n${x@P}\nEOF");
+
+        Assert.Equal("HIDDEN_EXEC", output);
+    }
+
+    [Fact]
+    public void Bash_obsolete_arithmetic_expansion_can_execute_command_text_in_heredoc()
+    {
+        if (!IsNativeBashAvailable())
+        {
+            return;
+        }
+
+        var result = RunUnchecked(
+            "bash",
+            "--noprofile",
+            "--norc",
+            "-c",
+            "x='a[$(printf OLD_ARITH >&2)0]'; cat <<EOF\n$[x]\nEOF");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Equal("0\n", result.StandardOutput);
+        Assert.Equal("OLD_ARITH", result.StandardError);
+    }
+
     [Theory]
     [InlineData("cat <<EOF >out\nbody\nEOF")]
     [InlineData("cat <<EOF; evil\nbody\nEOF")]
@@ -813,6 +851,64 @@ public class ShellValueOracleTests
             "for f in a b; do trap 'f=x' DEBUG; printf '<%s>\\n' \"$f\"; done");
 
         Assert.Equal(new[] { "<x>", "<x>" }, Lines(output));
+    }
+
+    [Fact]
+    public void Bash_nameref_parameter_expansion_can_execute_deferred_array_subscript()
+    {
+        if (!IsNativeBashAvailable())
+        {
+            return;
+        }
+
+        var result = RunUnchecked(
+            "bash",
+            "--noprofile",
+            "--norc",
+            "-c",
+            "declare -a a; declare -n x='a[$(printf NREF >&2)0]'; " +
+            "cat <<EOF\n${x}\nEOF");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("NREF", result.StandardError);
+    }
+
+    [Fact]
+    public void Bash_integer_declaration_can_execute_array_subscript_during_assignment()
+    {
+        if (!IsNativeBashAvailable())
+        {
+            return;
+        }
+
+        var result = RunUnchecked(
+            "bash",
+            "--noprofile",
+            "--norc",
+            "-c",
+            "declare -a a; declare -i x='a[$(printf INTEGER >&2)0]'");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("INTEGER", result.StandardError);
+    }
+
+    [Fact]
+    public void Bash_printf_attached_v_option_can_execute_array_subscript_assignment()
+    {
+        if (!IsNativeBashAvailable())
+        {
+            return;
+        }
+
+        var result = RunUnchecked(
+            "bash",
+            "--noprofile",
+            "--norc",
+            "-c",
+            "declare -a a; printf -v'a[$(printf PRINTF_V >&2)0]' '%s' data");
+
+        Assert.Equal(0, result.ExitCode);
+        Assert.Contains("PRINTF_V", result.StandardError);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

- expose typed Bash heredoc delimiter, body, expansion, tab-stripping, and completeness facts, including numeric source descriptors
- recursively discover supported expanding-body substitutions while rejecting hidden execution and incomplete forms atomically
- require proved Bash variable-attribute state and fail closed on the locked execution-bearing builtin catalog and dispatch wrappers
- add native Bash oracles, typed executable-corpus assertions, and synchronize the OpenSpec and implementation plan

## Validation

- `dotnet build -c Release` — 0 warnings/errors
- `dotnet test -c Release --no-build` — 2,455 passed
- strict OpenSpec validation, headers, PII/API checks, `git diff --check`, and Slopwatch — passed
- adversarial review — PASS; 136 generated bypass probes, 0 failures

## Scope

Command-resolution mutations (`exec`, mutating `hash`, alias/shopt, and enable forms) are intentionally handled in the next separate fail-closed slice.