### PR TITLE
Correct Netclaw v0.3 integration evidence

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -321,17 +321,16 @@ priorities.
       parser tests plus executable corpus cases pin the boundary. Next prove
       the paired Netclaw redirect matrix.
 - [x] Migrate Netclaw's Bash approval path to `0.3.0-alpha`. Netclaw PR
-      [#5](https://github.com/Aaronontheweb/netclaw/pull/5) enumerates every
+      [#1835](https://github.com/netclaw-dev/netclaw/pull/1835) enumerates every
       `CommandOccurrence`, consumes complete ancestry, cwd, compatibility
       argument/path, and explicit redirect facts, and removes the temporary raw
-      descriptor inference. Focused security tests and the 120-case approval
+      descriptor inference. Focused security tests and the 166-case approval
       matrix pin ordinary commands, pipelines, wrappers, static and dynamic
       redirects, cwd joins, symlink boundaries, POSIX shell payloads, and
       hard-deny precedence. Unknown or incomplete occurrence and redirect facts
       and dynamic or unresolved compatibility arguments remain fail closed.
-      Follow-up PR [#6](https://github.com/Aaronontheweb/netclaw/pull/6)
-      keeps stable macOS root aliases usable while scanning authored redirect
-      segments before lexical normalization can erase symlink traversal.
+      Cross-platform test fixtures canonicalize platform temporary roots while
+      production symlink checks remain unchanged.
       Bounded Bash loop approval cases and the separate PowerShell consumer
       migration remain the next downstream gates.
 - [x] Deliver occurrence-level PowerShell explicit redirect facts while

--- a/openspec/changes/v0-3-structured-shell-analysis/tasks.md
+++ b/openspec/changes/v0-3-structured-shell-analysis/tasks.md
@@ -87,13 +87,12 @@
     task 4.5 maps its stream model.
 - [x] 4.7 Verify the explicit model removes the need for raw-prefix inference in a Netclaw integration test.
   - Netclaw PR
-    [#5](https://github.com/Aaronontheweb/netclaw/pull/5) consumes typed
+    [#1835](https://github.com/netclaw-dev/netclaw/pull/1835) consumes typed
     descriptor duplicate, move, close, combined-output, and file-target facts.
     It removes the temporary raw descriptor-prefix workaround and pins static,
-    computed, malformed, and future-enum forms in focused security tests.
-    Follow-up PR [#6](https://github.com/Aaronontheweb/netclaw/pull/6)
-    preserves macOS system path aliases without trusting writable symlinks or
-    allowing lexical normalization to erase authored parent traversal.
+    computed, malformed, and future-enum forms in focused security tests. Its
+    cross-platform fixtures preserve production symlink rejection rather than
+    weakening that fail-closed check for macOS temporary-path aliases.
 
 ## 5. Consumer Migration Baseline
 
@@ -108,14 +107,14 @@
   the downstream migration gate.
 - [x] 5.7 Migrate Netclaw's existing-command analysis to the occurrence and redirect APIs behind focused regression tests.
   - Netclaw PR
-    [#5](https://github.com/Aaronontheweb/netclaw/pull/5) migrates the Bash
+    [#1835](https://github.com/netclaw-dev/netclaw/pull/1835) migrates the Bash
     approval path to `ParsedCommand.Commands`, complete ancestry and cwd facts,
     compatibility argument/path facts, and explicit redirects. Unknown or
     incomplete identity, ancestry, cwd, or redirect facts and dynamic or
-    unresolved compatibility arguments still fail closed. The 120-case
+    unresolved compatibility arguments still fail closed. The 166-case
     approval matrix and focused security tests cover
     ordinary commands, wrappers, pipelines, cwd attribution, redirects,
-    symlinks, authored redirect-path traversal, and hard-deny precedence.
+    symlinks, wrapper-prefix executables, and hard-deny precedence.
 
 ## 6. Bash For-In Vertical Slice
 


### PR DESCRIPTION
## Summary

- replace fork-only proof links with the merged official Netclaw PR #1835
- record the exact 166-case approval matrix and wrapper-prefix coverage
- preserve the fail-closed symlink claim without overstating authored parent-traversal visibility
- keep the remaining downstream-matrix task open

## Evidence

- Netclaw PR netclaw-dev/netclaw#1835 merged as `6f3c72788ab1f2b908b98ca0f29f9818209be07d`
- adversarial review passed after correcting the matrix count and removing an unsupported traversal claim
- `dotnet build -c Release`
- `dotnet test -c Release` (2543 passed)
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`
- `git diff --check`