### PR TITLE
Prepare 0.3.0-alpha.1 release

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,5 +203,6 @@ dotnet test -c Release
 dotnet pack -c Release -o ./bin/nuget
 
 # Cut a release (manual, then push the tag)
-git tag 0.3.0-alpha && git push origin 0.3.0-alpha
+release_version=$(dotnet msbuild src/ShellSyntaxTree/ShellSyntaxTree.csproj -nologo -getProperty:Version)
+git tag "$release_version" && git push origin "$release_version"
 ```

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <VersionPrefix>0.3.0</VersionPrefix>
-    <VersionSuffix>alpha</VersionSuffix>
+    <VersionSuffix>alpha.1</VersionSuffix>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Target framework matrix -->

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -515,6 +515,10 @@ priorities.
 - [x] Publish `0.3.0-alpha` for the Netclaw migration gate. The bare SemVer tag
       published the NuGet package, symbol package, and GitHub prerelease from
       the reviewed merge commit after Linux and Windows CI passed.
+- [x] Prepare `0.3.0-alpha.1` as the next Netclaw validation package. It carries
+      the bounded Bash heredoc, command-resolution mutation, and here-string
+      slices merged after the first alpha without changing the public API.
+      Record publication separately after the tag workflow succeeds.
 - [x] Replace the pre-alpha consumer preview with the v0.3 occurrence-based
       authorization loop and separate syntax-display guidance. Document exact,
       finite, pattern, unknown, joined-cwd, redirect, incomplete-result,

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Hand-rolled, AOT-trim friendly, zero native dependencies. Multi-targets
 
 ```bash
 # Current structured-analysis prerelease
-dotnet add package ShellSyntaxTree --version 0.3.0-alpha
+dotnet add package ShellSyntaxTree --version 0.3.0-alpha.1
 ```
 
-The latest stable package is `0.2.0`. The `0.3.0-alpha` prerelease adds the
+The latest stable package is `0.2.0`. The `0.3.0-alpha.1` prerelease adds the
 typed syntax tree and command-occurrence authorization API documented below.
 
 ## What you get

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,32 @@
   results require a consumer-owned, versioned DTO or explicit serializer
   mapping that fails closed on unknown node and enum values.
 
+#### 0.3.0-alpha.1 2026-08-09 ####
+
+This prerelease refreshes the Netclaw validation package with the Bash
+redirect and command-resolution slices completed after `0.3.0-alpha`. It does
+not change the public v0.3 API surface, and the conservative v0.2 projection
+remains available.
+
+## Added
+
+- Added bounded Bash heredoc analysis with explicit delimiter, body, expansion,
+  tab-stripping, completeness, and substitution facts.
+- Added Bash `<<<` here-string analysis. Exact and finite data include Bash's
+  trailing newline, remain non-path, and preserve independently executable
+  substitutions as command occurrences.
+
+## Security and compatibility
+
+- Reject command-resolution mutation through unsupported `exec`, `hash`,
+  alias, shell-option, builtin-enable, and reserved execution forms before a
+  later occurrence can inherit an unsafe executable identity.
+- Keep unknown here-string values structurally visible without guessing their
+  data, and fail malformed redirect forms atomically.
+- Pin the unchanged public API with reflection, equality, hashing, string, and
+  unknown-enum compatibility tests, and document occurrence-first consumer
+  authorization.
+
 #### 0.3.0-alpha 2026-08-08 ####
 
 This prerelease exposes the v0.3 structured-analysis API for Netclaw

--- a/docs/CONSUMER_GUIDE.md
+++ b/docs/CONSUMER_GUIDE.md
@@ -179,7 +179,7 @@ approval must never bypass a deny.
 
 ## v0.3 authorization and migration contract
 
-The `0.3.0-alpha` package adds `ParsedCommand.Commands` as the authorization
+The `0.3.0-alpha.1` package adds `ParsedCommand.Commands` as the authorization
 projection and `ParsedCommand.Syntax` as the typed display/analysis tree. This
 guide describes the stable v0.3 contract; constructs not yet complete in an
 installed prerelease remain prompt-or-deny cases. The migration rules are:


### PR DESCRIPTION
## Summary

- set the repository package version to `0.3.0-alpha.1`
- add release notes for the post-alpha Bash heredoc, command-resolution hardening, and here-string slices
- update current-package installation and consumer-guide references
- make the release command derive the tag from MSBuild so the constitution does not retain a stale version
- record preparation separately from publication in the implementation plan

## Release evidence

- adversarial release review: PASS after version, workflow, package, claims, and stale-reference audit
- `0.3.0-alpha.1` is absent from NuGet, remote tags, and GitHub releases
- packed `ShellSyntaxTree.0.3.0-alpha.1.nupkg` and symbol package successfully
- package contains the expected README, icon, two target assemblies, repository metadata, and symbols
- release-note extraction selects the exact `0.3.0-alpha.1` section
- no exported production source changed since `0.3.0-alpha`; only `Internal/` implementation files changed
- `dotnet build -c Release`: clean
- `dotnet test -c Release`: 2562 passed
- `dotnet pack -c Release`: passed
- header and diff checks: passed

After auto-merge, tag the actual merge commit as `0.3.0-alpha.1` and verify NuGet plus the GitHub prerelease before recording publication.