### PR TITLE
Record 0.3.0-alpha.1 publication

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -515,10 +515,13 @@ priorities.
 - [x] Publish `0.3.0-alpha` for the Netclaw migration gate. The bare SemVer tag
       published the NuGet package, symbol package, and GitHub prerelease from
       the reviewed merge commit after Linux and Windows CI passed.
-- [x] Prepare `0.3.0-alpha.1` as the next Netclaw validation package. It carries
-      the bounded Bash heredoc, command-resolution mutation, and here-string
-      slices merged after the first alpha without changing the public API.
-      Record publication separately after the tag workflow succeeds.
+- [x] Publish `0.3.0-alpha.1` as the next Netclaw validation package. Bare tag
+      [`0.3.0-alpha.1`](https://github.com/Aaronontheweb/ShellSyntaxTree/releases/tag/0.3.0-alpha.1)
+      points to reviewed merge `a0f95bdb`; the tag workflow published the
+      package and symbols to NuGet and created the GitHub prerelease after
+      Linux and Windows PR validation passed. It carries the bounded Bash
+      heredoc, command-resolution mutation, and here-string slices merged after
+      the first alpha without changing the public API.
 - [x] Replace the pre-alpha consumer preview with the v0.3 occurrence-based
       authorization loop and separate syntax-display guidance. Document exact,
       finite, pattern, unknown, joined-cwd, redirect, incomplete-result,


### PR DESCRIPTION
## Summary

- record the completed `0.3.0-alpha.1` publication in the implementation plan
- link the GitHub prerelease and identify the reviewed merge commit
- retain stable v0.3 and OpenSpec task 11.9 as incomplete

## Live evidence

- adversarial verification: PASS
- tag `0.3.0-alpha.1` resolves to `a0f95bdb`
- PR #126 passed Linux and Windows validation before merge
- publish workflow 31299911481 succeeded
- NuGet lists and serves the signed package with repository commit `a0f95bdb`
- GitHub prerelease contains the nupkg and snupkg assets
- `git diff --check` passed