### PR TITLE
Prepare 0.3.0-alpha.2 release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <VersionPrefix>0.3.0</VersionPrefix>
-    <VersionSuffix>alpha.1</VersionSuffix>
+    <VersionSuffix>alpha.2</VersionSuffix>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Target framework matrix -->

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -528,6 +528,10 @@ priorities.
       Linux and Windows PR validation passed. It carries the bounded Bash
       heredoc, command-resolution mutation, and here-string slices merged after
       the first alpha without changing the public API.
+- [ ] Publish `0.3.0-alpha.2` for the Netclaw PowerShell policy matrix after
+      Linux and Windows validate the reviewed proved-data receiver slice. The
+      package must include exact module-qualified-looking alias and canonical
+      alias-target shadowing defenses without changing the public API.
 - [x] Replace the pre-alpha consumer preview with the v0.3 occurrence-based
       authorization loop and separate syntax-display guidance. Document exact,
       finite, pattern, unknown, joined-cwd, redirect, incomplete-result,

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,34 @@
   results require a consumer-owned, versioned DTO or explicit serializer
   mapping that fails closed on unknown node and enum values.
 
+#### 0.3.0-alpha.2 2026-08-09 ####
+
+This prerelease completes the stable-v0.3 boundary between PowerShell script
+blocks proved to be data and blocks that may execute. It does not change the
+public v0.3 API surface, and the conservative v0.2 projection remains
+available.
+
+## Added
+
+- Keep script blocks passed to a proved `Write-Output` receiver opaque under a
+  constrained PowerShell baseline instead of inventing nested command
+  occurrences.
+- Preserve unknown script-block receivers as visible, incomplete execution
+  regions, and expose proved local `Invoke-Command` bodies as synchronous
+  command occurrences.
+
+## Security and compatibility
+
+- Require bounded command-resolution proof before classifying a script block as
+  data. Default runspace state remains conservative.
+- Track exact command mutations through authored and canonical alias identities.
+  This prevents exact module-qualified-looking aliases and `echo` alias chains
+  from hiding an executable script block.
+- Preserve unrelated-name precision and reset runspace-local mutations at fresh
+  parallel child-runspace boundaries without clearing process-wide uncertainty.
+- Expand the generated PowerShell corpus to 422 entries, all validated against
+  the live PowerShell parser and the PII audit.
+
 #### 0.3.0-alpha.1 2026-08-09 ####
 
 This prerelease refreshes the Netclaw validation package with the Bash


### PR DESCRIPTION
## Summary

- bump the prerelease suffix to `alpha.2`
- document the reviewed PowerShell proved-data receiver and alias-shadowing defenses from PR #128
- record alpha.2 as pending until tag publication completes

## Verification

- adversarial release review: PASS
- public API diff against published alpha.1: no changes for net8.0 or netstandard2.0
- `dotnet build -c Release --no-restore`
- `dotnet test -c Release --no-restore` (2575 passed)
- `dotnet pack -c Release --no-restore -o ./bin/nuget`
- package + symbols: `ShellSyntaxTree.0.3.0-alpha.2`
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`
- `openspec validate v0-3-structured-shell-analysis --strict`
- publish workflow verified to accept the bare `0.3.0-alpha.2` tag and matching release-note section