### PR TITLE
Pin Bash coprocess fail-closed corpus case

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -565,9 +565,10 @@ priorities.
       mutating or ambiguous `hash`, `alias`, `unalias`, `shopt`, and `enable`
       forms before later occurrences can inherit a false executable identity; retain only
       exact static query grammar and pin native-shell behavior, recursive
-      wrappers, and executable corpus cases. Fail unmodeled `time`, negation,
-      coprocess, and current-shell brace-group syntax closed rather than
-      flattening nested execution into apparent ordinary verb chains.
+      wrappers, and executable corpus cases. Entries 273-280 pin the mutation
+      and reserved-form boundaries, including unmodeled `time`, negation,
+      coprocess, and current-shell brace-group syntax, which fail closed rather
+      than flattening nested execution into apparent ordinary verb chains.
 - [ ] Promote the Bash command-resolution mutation cases into Netclaw's strict
       allow/prompt/deny matrix before the downstream approval-fatigue gate.
 - [x] Add the separately tested Bash `<<<` here-string redirect slice with

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/280_v03_coproc_rejected.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/280_v03_coproc_rejected.json
@@ -1,0 +1,10 @@
+{
+  "name": "v0.3 Bash coprocess form fails closed before nested command",
+  "input": "coproc git status",
+  "expected": {
+    "isUnparseable": true,
+    "unparseableReasonContains": "reserved execution syntax"
+  },
+  "notes": "A coprocess starts asynchronous execution with pipe state that stable v0.3 does not model, so its command body cannot be treated as an ordinary complete command.",
+  "oracleExpectation": "OutOfScope"
+}


### PR DESCRIPTION
Adds the missing executable-corpus case for the Bash `coproc` reserved form.

The parser must reject this form atomically because stable v0.3 does not model asynchronous coprocess execution or its pipe state. This completes the ShellSyntaxTree corpus half of OpenSpec task 3.13e; the downstream Netclaw matrix remains tracked separately.

Validation:
- `dotnet build -c Release`
- `dotnet test -c Release --no-build` (2,576 passed)
- focused corpus and PII audit (705 passed)
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`
- adversarial review: PASS