### PR TITLE
Prepare 0.3.0-alpha.3 release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <VersionPrefix>0.3.0</VersionPrefix>
-    <VersionSuffix>alpha.2</VersionSuffix>
+    <VersionSuffix>alpha.3</VersionSuffix>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Target framework matrix -->

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -579,6 +579,10 @@ priorities.
       and [GitHub prerelease](https://github.com/Aaronontheweb/ShellSyntaxTree/releases/tag/0.3.0-alpha.2)
       include exact module-qualified-looking alias and canonical alias-target
       shadowing defenses without changing the public API.
+- [ ] Publish `0.3.0-alpha.3` for the Netclaw PowerShell approval integration
+      after Linux and Windows validate the reviewed initial-state, value,
+      command-binding, and state-invalidation slice. The package must preserve
+      the v0.2 projection and the existing public v0.3 API.
 - [x] Replace the pre-alpha consumer preview with the v0.3 occurrence-based
       authorization loop and separate syntax-display guidance. Document exact,
       finite, pattern, unknown, joined-cwd, redirect, incomplete-result,

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,35 @@
   results require a consumer-owned, versioned DTO or explicit serializer
   mapping that fails closed on unknown node and enum values.
 
+#### 0.3.0-alpha.3 2026-08-09 ####
+
+This prerelease adds the PowerShell state and value proofs needed for the
+Netclaw approval-policy integration. It does not change the public v0.3 API
+surface, and the conservative v0.2 projection remains available.
+
+## Added
+
+- Apply the explicit PowerShell initial-state contract to command identity,
+  native-versus-cmdlet argument binding, working-directory attribution,
+  redirects, automatic `HOME`, and `USERPROFILE` values.
+- Preserve argument-binding provenance through static current-scope
+  `Invoke-Expression` payloads while keeping decoded child-host state isolated.
+- Expand the generated PowerShell corpus from 422 to 491 entries with direct,
+  wrapper, alias, script, redirect, child-host, and unknown-state cases.
+
+## Security and compatibility
+
+- Treat aliases as capable of shadowing built-ins and path-shaped command
+  names; exact argument binding requires constrained, unmutated command
+  resolution.
+- Invalidate following authorization state after uninspected scripts and
+  unproved in-process invocations instead of retaining stale exact values.
+- Keep supported non-pipeline bodies of unknown receivers visible and
+  incomplete, while failing an unproved interior pipeline atomically with
+  empty authorization projections.
+- Preserve ordinary v0.2 compatibility leaves under ambient uncertainty and
+  keep the public v0.3 API snapshot unchanged.
+
 #### 0.3.0-alpha.2 2026-08-09 ####
 
 This prerelease completes the stable-v0.3 boundary between PowerShell script


### PR DESCRIPTION
## Summary

- bump the package suffix from alpha.2 to alpha.3
- add release notes for the PowerShell value/state analysis delivered in #133
- record the publication step as pending until the tag workflow succeeds

## Validation

- adversarial release review: PASS
- dotnet build -c Release: clean, 0 warnings
- dotnet test -c Release --no-build: 2,765/2,765
- public API snapshots: 40/40
- dotnet pack: emitted ShellSyntaxTree.0.3.0-alpha.3.nupkg and .snupkg
- nuspec and both target-framework assemblies report 0.3.0-alpha.3
- public API diff against published alpha.2: empty for net8.0 and netstandard2.0
- release-note extraction for 0.3.0-alpha.3: verified
- strict OpenSpec validation, headers, and git diff checks: clean
- Slopwatch: no new findings
