### PR TITLE
Record alpha.3 publication

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -579,10 +579,12 @@ priorities.
       and [GitHub prerelease](https://github.com/Aaronontheweb/ShellSyntaxTree/releases/tag/0.3.0-alpha.2)
       include exact module-qualified-looking alias and canonical alias-target
       shadowing defenses without changing the public API.
-- [ ] Publish `0.3.0-alpha.3` for the Netclaw PowerShell approval integration
-      after Linux and Windows validate the reviewed initial-state, value,
-      command-binding, and state-invalidation slice. The package must preserve
-      the v0.2 projection and the existing public v0.3 API.
+- [x] Published `0.3.0-alpha.3` for the Netclaw PowerShell approval integration
+      after Linux and Windows validated the reviewed initial-state, value,
+      command-binding, and state-invalidation slice. The
+      [NuGet package](https://www.nuget.org/packages/ShellSyntaxTree/0.3.0-alpha.3)
+      and [GitHub prerelease](https://github.com/Aaronontheweb/ShellSyntaxTree/releases/tag/0.3.0-alpha.3)
+      preserve the v0.2 projection and the existing public v0.3 API.
 - [x] Replace the pre-alpha consumer preview with the v0.3 occurrence-based
       authorization loop and separate syntax-display guidance. Document exact,
       finite, pattern, unknown, joined-cwd, redirect, incomplete-result,


### PR DESCRIPTION
Summary

- Mark ShellSyntaxTree 0.3.0-alpha.3 as published.
- Link the live NuGet package and GitHub prerelease.
- Record that the package preserves the v0.2 projection and public v0.3 API.

Validation

- dotnet build -c Release: passed with zero warnings
- dotnet test -c Release --no-build: 2,765 passed
- openspec validate --all --strict: passed
- header verification: passed
- Slopwatch with no baseline: zero findings
- git diff --check: passed
- adversarial review: PASS with no material findings