### PR TITLE
Prepare 0.3.0-alpha.4 release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <VersionPrefix>0.3.0</VersionPrefix>
-    <VersionSuffix>alpha.3</VersionSuffix>
+    <VersionSuffix>alpha.4</VersionSuffix>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Target framework matrix -->

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -599,6 +599,11 @@ priorities.
       [NuGet package](https://www.nuget.org/packages/ShellSyntaxTree/0.3.0-alpha.3)
       and [GitHub prerelease](https://github.com/Aaronontheweb/ShellSyntaxTree/releases/tag/0.3.0-alpha.3)
       preserve the v0.2 projection and the existing public v0.3 API.
+- [ ] Publish `0.3.0-alpha.4` with the reviewed authored-command completeness
+      correction. Netclaw must validate default-mode static PowerShell commands
+      without requiring ambient profile, module, alias, function, `PATH`,
+      inherited-variable, or prior-runspace proofs. Unknown and source-mutated
+      policy facts must remain strict.
 - [x] Replace the pre-alpha consumer preview with the v0.3 occurrence-based
       authorization loop and separate syntax-display guidance. Document exact,
       finite, pattern, unknown, joined-cwd, redirect, incomplete-result,

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,6 +12,35 @@
   results require a consumer-owned, versioned DTO or explicit serializer
   mapping that fails closed on unknown node and enum values.
 
+#### 0.3.0-alpha.4 2026-08-09 ####
+
+This prerelease corrects PowerShell occurrence completeness to describe the
+authored command text instead of ambient command resolution. It does not
+change the public v0.3 API surface, and the conservative v0.2 projection
+remains available.
+
+## Changed
+
+- Keep static authored PowerShell commands, pipeline stages, decoded child
+  commands, and proved script-block receivers complete under the default
+  initial-state mode.
+- Use an explicit native or `.ps1` path spelling to select authored argument
+  binding without inspecting the executable, `PATH`, profiles, modules,
+  aliases, functions, inherited variables, or prior runspace state.
+- Keep unqualified `.ps1` binding, dynamic command identities, computed
+  execution, unknown receivers, and unsupported executable syntax strict.
+
+## Security and compatibility
+
+- Preserve `Unknown` effective loop values when the submitted source does not
+  prove the runtime binding value.
+- Invalidate later command proofs after a matching mutation that is visible in
+  the submitted source.
+- Keep provider-sensitive repeated loops incomplete when an unknown path could
+  mutate command resolution before a later visit.
+- Preserve all public signatures, the v0.2 compatibility projection, and the
+  491-case generated PowerShell corpus.
+
 #### 0.3.0-alpha.3 2026-08-09 ####
 
 This prerelease adds the PowerShell state and value proofs needed for the

--- a/openspec/changes/v0-3-structured-shell-analysis/tasks.md
+++ b/openspec/changes/v0-3-structured-shell-analysis/tasks.md
@@ -191,7 +191,7 @@
   completeness, while explicit source mutations, computed identities, hidden
   execution, and unsupported syntax remain strict. Preserve the existing
   `PwshInitialStateMode` API shape.
-- [ ] 7.2c Implement authored-command completeness for default-mode static
+- [x] 7.2c Implement authored-command completeness for default-mode static
   PowerShell commands, pipelines, decoded children, and known script-block
   receivers without weakening explicit mutation or dynamic-execution checks.
 - [x] 7.3 Derive exact and finite string domains without treating pipeline objects as literal strings.


### PR DESCRIPTION
## Summary

- package the merged PowerShell authored-command completeness correction
- keep PowerShell analysis limited to submitted syntax and explicit parser inputs
- preserve strict handling for source-visible mutations, unknown values, dynamic execution, and unsupported syntax
- preserve the public v0.3 API and v0.2 compatibility projection

## Validation

- `dotnet build -c Release --no-restore`
- `dotnet test -c Release --no-build --no-restore` — 2,768 passed
- `dotnet pack -c Release --no-build --no-restore -o ./bin/nuget`
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`
- `openspec validate v0-3-structured-shell-analysis --strict`
- `git diff --check`
- adversarial release review: PASS

The repository does not install Slopwatch in its local tool manifest. This PR changes release metadata and documentation only.