### PR TITLE
Prepare 0.3.0-alpha.5 release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <VersionPrefix>0.3.0</VersionPrefix>
-    <VersionSuffix>alpha.4</VersionSuffix>
+    <VersionSuffix>alpha.5</VersionSuffix>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Target framework matrix -->

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -620,6 +620,11 @@ priorities.
       and [GitHub prerelease](https://github.com/Aaronontheweb/ShellSyntaxTree/releases/tag/0.3.0-alpha.4)
       preserve strict unknown and source-mutated policy facts while default-mode
       static PowerShell commands no longer require ambient resolution proof.
+- [ ] Publish `0.3.0-alpha.5` with the reviewed host-selected PowerShell dialect
+      contract, explicit PowerShell 7.6 and Windows PowerShell 5.1 behavior,
+      same-language child-host selection, cross-language non-delegation, and
+      live dual-dialect Windows oracle proof. Use this package for Netclaw's
+      native-Windows integration gate.
 - [x] Replace the pre-alpha consumer preview with the v0.3 occurrence-based
       authorization loop and separate syntax-display guidance. Document exact,
       finite, pattern, unknown, joined-cwd, redirect, incomplete-result,

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -19,6 +19,38 @@
   property also participates in options-record equality, hashing, `ToString()`,
   reflection, and default serialization shape.
 
+#### 0.3.0-alpha.5 2026-08-10 ####
+
+This prerelease adds an explicit host-selected PowerShell dialect contract and
+keeps Bash and PowerShell analysis at the native host boundary. The v0.2
+projection remains supported, and the public API changes are additive.
+
+## Added
+
+- Add `PwshDialect` and `PwshParserOptions.Dialect`, defaulting to the
+  compatible PowerShell 7 behavior and failing closed for unknown enum values.
+- Model Windows PowerShell 5.1 as an explicit native-Windows fallback with its
+  own alias catalog, receiver conservatism, and rejection of unsupported
+  `&&` / `||` pipeline-chain syntax.
+- Carry the selected dialect through nested PowerShell parsing and select the
+  matching dialect for static same-language `pwsh` and `powershell.exe` child
+  hosts.
+
+## Security and compatibility
+
+- Keep shell languages separate: Bash treats `pwsh` as an ordinary external
+  command, and PowerShell treats `bash` as an ordinary external command. The
+  parser never interprets a child command string in the other language.
+- Require consumers to select `PowerShell7` only for a compatible PowerShell
+  7.6 host (`>=7.6.4` and `<7.7`) and use `WindowsPowerShell51` for the native
+  `powershell.exe` fallback. Host selection, parser dialect, approval policy,
+  and executor identity must agree.
+- Preserve the v0.2 compatibility projection and report exactly two additive
+  public API changes: the dialect enum and the parser-options property.
+- Expand the generated PowerShell corpus to 504 entries. Linux and Windows CI
+  validate it with hash-pinned PowerShell 7.6.4; Windows additionally validates
+  the Windows PowerShell 5.1 dialect with the native executable.
+
 #### 0.3.0-alpha.4 2026-08-09 ####
 
 This prerelease corrects PowerShell occurrence completeness to describe the


### PR DESCRIPTION
## Summary

- package the merged host-selected PowerShell dialect and language-boundary slice
- add explicit PowerShell 7.6 and Windows PowerShell 5.1 release guidance
- preserve the v0.2 compatibility projection and document the two additive API changes
- prepare the prerelease used by Netclaw's native-Windows integration gate

## Validation

- `dotnet tool restore`
- `dotnet restore`
- `dotnet build -c Release --no-restore` — clean, zero warnings
- `dotnet test -c Release --no-build` — 2,815 passed
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`
- `dotnet pack -c Release --no-build -o ./bin/nuget-alpha5`
  - `ShellSyntaxTree.0.3.0-alpha.5.nupkg`
  - `ShellSyntaxTree.0.3.0-alpha.5.snupkg`
  - `net8.0` and `netstandard2.0`
- publish-workflow release-note extraction reproduced locally
- `slopwatch analyze -d . --fail-on warning --no-baseline` — 0 findings
- `openspec validate v0-3-structured-shell-analysis --strict`
- `git diff --check`
- adversarial release review: PASS

Publication remains intentionally unchecked in `IMPLEMENTATION_PLAN.md` until the reviewed merge is tagged and the tag workflow proves NuGet plus GitHub release delivery.
