### PR TITLE
Record the alpha.5 publication

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -620,11 +620,15 @@ priorities.
       and [GitHub prerelease](https://github.com/Aaronontheweb/ShellSyntaxTree/releases/tag/0.3.0-alpha.4)
       preserve strict unknown and source-mutated policy facts while default-mode
       static PowerShell commands no longer require ambient resolution proof.
-- [ ] Publish `0.3.0-alpha.5` with the reviewed host-selected PowerShell dialect
-      contract, explicit PowerShell 7.6 and Windows PowerShell 5.1 behavior,
-      same-language child-host selection, cross-language non-delegation, and
-      live dual-dialect Windows oracle proof. Use this package for Netclaw's
-      native-Windows integration gate.
+- [x] Published `0.3.0-alpha.5` with the reviewed host-selected PowerShell
+      dialect contract, explicit PowerShell 7.6 and Windows PowerShell 5.1
+      behavior, same-language child-host selection, cross-language
+      non-delegation, and live dual-dialect Windows oracle proof. The
+      [NuGet package](https://www.nuget.org/packages/ShellSyntaxTree/0.3.0-alpha.5)
+      and [GitHub prerelease](https://github.com/Aaronontheweb/ShellSyntaxTree/releases/tag/0.3.0-alpha.5)
+      were published by successful [tag workflow run 31357832880](https://github.com/Aaronontheweb/ShellSyntaxTree/actions/runs/31357832880)
+      after Linux and native Windows validation passed. Use this package for
+      Netclaw's native-Windows integration gate.
 - [x] Replace the pre-alpha consumer preview with the v0.3 occurrence-based
       authorization loop and separate syntax-display guidance. Document exact,
       finite, pattern, unknown, joined-cwd, redirect, incomplete-result,


### PR DESCRIPTION
## Summary

- mark the `0.3.0-alpha.5` publication task complete
- link the public NuGet package and GitHub prerelease
- record the successful tag workflow that published both artifacts

## Validation

- `dotnet build -c Release`
- `dotnet test -c Release` (2,815 passed)
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`
- `openspec validate --all --strict`
- adversarial review: PASS
- public NuGet package and GitHub prerelease verified independently