### PR TITLE
Prepare 0.3.0-alpha.6 release

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -8,7 +8,7 @@
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <VersionPrefix>0.3.0</VersionPrefix>
-    <VersionSuffix>alpha.5</VersionSuffix>
+    <VersionSuffix>alpha.6</VersionSuffix>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Target framework matrix -->

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -660,6 +660,10 @@ priorities.
       were published by successful [tag workflow run 31357832880](https://github.com/Aaronontheweb/ShellSyntaxTree/actions/runs/31357832880)
       after Linux and native Windows validation passed. Use this package for
       Netclaw's native-Windows integration gate.
+- [ ] Publish `0.3.0-alpha.6` with the corrected stable-v0.3 consumer API.
+      Use the package to remove Netclaw's alpha.5 coordinate and property-bag
+      validation, then rerun its Linux and native-Windows approval matrices
+      before promoting stable v0.3.
 - [x] Replace the pre-alpha consumer preview with the v0.3 occurrence-based
       authorization loop and separate syntax-display guidance. Document exact,
       finite, pattern, unknown, joined-cwd, redirect, incomplete-result,

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,7 @@
 #### Unreleased ####
 
+#### 0.3.0-alpha.6 2026-08-10 ####
+
 ## Changed
 
 - Replace the experimental v0.3 sparse `EffectiveArguments` coordinate overlay


### PR DESCRIPTION
## Summary

- set the package version to `0.3.0-alpha.6`
- publish the corrected stable-v0.3 consumer API migration notes from PR #146
- record alpha.6 as the package Netclaw must validate before stable v0.3

## Validation

- `dotnet build -c Release --no-restore` — 0 warnings, 0 errors
- `dotnet test -c Release --no-restore` — 2,870 passed
- `dotnet pack -c Release --no-restore -o ./bin/nuget`
- package metadata reports `0.3.0-alpha.6` for `netstandard2.0` and `net8.0`
- release-workflow regex extracts the non-empty alpha.6 notes
- `slopwatch analyze --no-baseline --fail-on warning` — 0 issues
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`
- `git diff --check`
- adversarial release review: no content blockers

After this PR merges and Linux/Windows validation passes, push the bare `0.3.0-alpha.6` tag from the merge commit. The tag workflow will publish NuGet and symbol packages and create the GitHub prerelease.
