### PR TITLE
Document v0.3 downstream acceptance

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -14,8 +14,8 @@ priorities.
 
 > **Spec:** `SPEC.POWERSHELL.md` (v0.2.0). The PowerShell parser is
 > implemented — phases 1–14 of `SPEC.POWERSHELL.md` §16 are complete (see
-> below). What remains is the downstream Netclaw integration, which needs
-> actions outside this repository.
+> below). The downstream Netclaw integration and cross-platform acceptance
+> gates are complete. The stable package publication remains.
 
 - [x] **v0.3 prerelease consumer-API correction.** Preserve the stable v0.2
       API and the `Syntax` / `Commands` / `Clauses` ingestion lanes, but replace
@@ -28,7 +28,7 @@ priorities.
       README, and Netclaw together. No compatibility shim for 0.3 alphas. The
       library, specifications, snapshots, corpus DTOs, generated expectations,
       README, consumer guide, and prerelease migration notes are synchronized;
-      Netclaw migration remains the next downstream item.
+      Netclaw PRs #1855 and #1857 complete migration and downstream acceptance.
 
 - [x] **v0.3 host-selected grammar and PowerShell dialect — library slice.** The executor
       selects one top-level parser; Bash never cross-parses `pwsh` payloads and
@@ -45,16 +45,16 @@ priorities.
       prefer a compatible `pwsh.exe`, fall back to `powershell.exe`, and
       reparse and reauthorize if executable selection changes.
 
-- [ ] **v0.3 authored-command approval correction.** Treat PowerShell and Bash
+- [x] **v0.3 authored-command approval correction.** Treat PowerShell and Bash
       approval completeness consistently: prove every authored executable
       region, but do not require proof of ambient aliases, functions, modules,
       profiles, executable lookup, or inherited environment state. Preserve the
       existing `PwshInitialStateMode` API. Default-mode PowerShell occurrence
       completeness now follows that authored boundary while loop-dependent
       effective values remain Unknown unless fresh-process state is proved.
-      Next expand the executable corpus and prove the Netclaw approval matrix.
-      Explicit
-      source mutation, computed identity, hidden execution, unknown receiver
+      The 2,870-case ShellSyntaxTree suite and Netclaw's 240-row catalog prove
+      the executable corpus and approval matrix. Explicit source mutation,
+      computed identity, hidden execution, unknown receiver
       semantics, unsupported constructs, and policy-sensitive unknown values,
       paths, cwd, or redirects remain strict.
 
@@ -137,9 +137,13 @@ priorities.
       worked public use cases, and immutable permalinks to Netclaw's production
       integration. Added compact input-to-result-to-policy examples for command
       occurrences, attached arguments, bounded and zero-or-more loops, cwd
-      propagation, file and descriptor redirects, substitutions, and safe-fail
-      results. Linked it from the README and aligned stale PowerShell
-      prerelease/status wording in the public project docs.
+      propagation, file and descriptor redirects, substitutions, PowerShell
+      command-owned execution regions, and safe-fail results. The execution-
+      region example pins exact `HostArgument` identity, known metadata,
+      nonempty complete body evidence, independent host/body authorization, and
+      strict unknown or incomplete fallbacks. Linked it from the README and
+      aligned stale PowerShell prerelease/status wording in the public project
+      docs.
 - [x] **Issue #52 — hyphenated PowerShell parameters/native options.**
       Preserve internal hyphens, apply bash-compatible native
       `--flag=value` splitting and path classification, keep colon binding
@@ -392,8 +396,9 @@ priorities.
       values, indirect and parameter-operator rejection, and every candidate
       and transition cap. All unmodeled mutations, dynamic dispatch, control
       transfers, and occurrence-specific redirect values remain fail closed.
-      Next add the Netclaw approval matrix before calling the Bash consumer
-      integration complete.
+      Netclaw PR
+      [#1857](https://github.com/netclaw-dev/netclaw/pull/1857) completes the
+      consumer gate with 199 Bash approval rows on the alpha.6 package.
 - [x] Deliver occurrence-level Bash explicit redirect facts for ordinary file
       input/output/append, static descriptor duplicate/close/move, computed
       descriptor targets, and combined `&>` / `&>>` output. Static descriptor
@@ -407,8 +412,9 @@ priorities.
       they join multi-digit sources. Exact file targets now complete their
       containing occurrence, while cwd or value uncertainty still downgrades
       the redirect and occurrence after abstract-state joins. Direct lexer and
-      parser tests plus executable corpus cases pin the boundary. Next prove
-      the paired Netclaw redirect matrix.
+      parser tests plus executable corpus cases pin the boundary. Netclaw PR
+      #1857 pins the paired allow, prompt, stored-grant, and fail-closed
+      redirect dispositions.
 - [x] Migrate Netclaw's Bash approval path to `0.3.0-alpha`. Netclaw PR
       [#1835](https://github.com/netclaw-dev/netclaw/pull/1835) enumerates every
       `CommandOccurrence`, consumes complete ancestry, cwd, compatibility
@@ -420,8 +426,7 @@ priorities.
       and dynamic or unresolved compatibility arguments remain fail closed.
       Cross-platform test fixtures canonicalize platform temporary roots while
       production symlink checks remain unchanged.
-      Bounded Bash loop approval cases and the separate PowerShell consumer
-      migration remain the next downstream gates.
+      Netclaw PR #1857 adds the bounded Bash loop and PowerShell consumer gates.
 - [x] Deliver occurrence-level PowerShell explicit redirect facts while
       preserving the v0.2 compatibility projection. File output and append
       retain default, numbered, or all-streams sources; the native-only merge
@@ -445,13 +450,19 @@ priorities.
       child command's independent completeness. A fourth review extended that
       ownership through nested quoted and encoded child hosts: the outer
       redirect now uses the outermost authoring invocation rather than the
-      nearest decoded child. Next prove the paired Netclaw redirect matrix.
-- [ ] Complete PowerShell `foreach` integration and add the
+      nearest decoded child. Netclaw PR #1857 pins the paired PowerShell
+      redirect matrix.
+- [x] Complete PowerShell `foreach` integration and add the
       Netclaw approval-matrix cases. The structural slice now preserves literal
       scalar/array and executable iterator forms, recursively parses bodies,
       projects iterator and loop-body ancestry, survives decoded wrappers, and
       fails closed on dynamic iterables, iterator/body state or
       command-resolution mutation, malformed boundaries, and depth overflow.
+      Netclaw PR #1857 adds 36 PowerShell 7 and five Windows PowerShell 5.1
+      approval rows. All 21 refreshed GitHub check runs passed; rebased local
+      acceptance separately passed the Release build, focused security and
+      approval-matrix tests, the full solution suite, headers, and strict
+      OpenSpec validation.
       The authored-command correction makes default-mode loop-body and
       current-scope post-loop static occurrences complete without weakening
       explicit mutation or dynamic execution checks. Isolated child-host loops
@@ -660,10 +671,17 @@ priorities.
       were published by successful [tag workflow run 31357832880](https://github.com/Aaronontheweb/ShellSyntaxTree/actions/runs/31357832880)
       after Linux and native Windows validation passed. Use this package for
       Netclaw's native-Windows integration gate.
-- [ ] Publish `0.3.0-alpha.6` with the corrected stable-v0.3 consumer API.
-      Use the package to remove Netclaw's alpha.5 coordinate and property-bag
-      validation, then rerun its Linux and native-Windows approval matrices
-      before promoting stable v0.3.
+- [x] Published `0.3.0-alpha.6` with the reviewed corrected consumer API from
+      merge `e422aa2a`. The
+      [NuGet package](https://www.nuget.org/packages/ShellSyntaxTree/0.3.0-alpha.6)
+      and [GitHub prerelease](https://github.com/Aaronontheweb/ShellSyntaxTree/releases/tag/0.3.0-alpha.6)
+      were published by successful [tag workflow run 31421653771](https://github.com/Aaronontheweb/ShellSyntaxTree/actions/runs/31421653771)
+      after the Release build, 2,870 tests, package creation, header check,
+      strict OpenSpec validation, public-API comparison, and two adversarial
+      reviews passed. Netclaw PR #1855 consumes this package through the closed
+      joined-argument, value-domain, redirect-source, and redirect-analysis
+      alternatives. Netclaw PR #1857 closes the downstream acceptance gate with
+      240 catalog rows and green cross-platform CI.
 - [x] Replace the pre-alpha consumer preview with the v0.3 occurrence-based
       authorization loop and separate syntax-display guidance. Document exact,
       finite, pattern, unknown, joined-cwd, redirect, incomplete-result,

--- a/docs/CONSUMER_GUIDE.md
+++ b/docs/CONSUMER_GUIDE.md
@@ -861,6 +861,114 @@ make the bytes it prints a statically known `rm` operand. A path-sensitive
 policy therefore evaluates `find` and still prompts or denies `rm`. It does not
 walk `Syntax` afterward and authorize `find` a second time.
 
+### PowerShell command-owned execution regions
+
+PowerShell passes script blocks as values, and only some receiving commands are
+known to execute them. ShellSyntaxTree therefore preserves two related facts:
+
+- the host command keeps the authored script-block argument as `DynamicSkip`;
+- every authored simple command inside a completely delimited executable body
+  is projected into `Commands`, and its ancestry references an
+  `ExecutionRegionSyntax` whose `HostArgument` is the exact `ClauseElement`
+  that produced that host argument.
+
+For example:
+
+```powershell
+Get-ChildItem | ForEach-Object { Remove-Item .\victim.txt }
+```
+
+has this policy-relevant projection:
+
+| Occurrence | Relevant output | Consumer consequence |
+|---|---|---|
+| `Get-ChildItem` | complete pipeline stage | Authorize independently. |
+| `ForEach-Object` | complete host; the script-block argument remains `DynamicSkip` | Authorize the host command independently. Do not approve the body through this grant. |
+| `Remove-Item` | complete `ExecutionRegion` occurrence; ancestry contains a command-argument region with `Process`, `Synchronous`, and `OncePerInputObject`; `HostArgument` references the host's exact script-block element | Authorize the body command independently. The proved region accounts for that exact opaque host argument only. |
+
+A security consumer may stop treating the host's `DynamicSkip` as unexplained
+only when a complete body occurrence proves all of the following about the
+same object:
+
+- its ancestry frame is `CommandAncestryRegion.ExecutionRegion`;
+- the frame's `Ancestor` is an `ExecutionRegionSyntax` with
+  `Origin = CommandArgument`;
+- `HostArgument` is non-null and reference-equal to the host
+  `AnalyzedArgument.Element`; and
+- `Phase`, `Timing`, and `Cardinality` are defined, non-`Unknown` values.
+
+This is an accounting exception for one parser-owned argument, not an allow
+decision. The consumer still evaluates every projected occurrence and combines
+their decisions with `Deny > Prompt > Allow`. Consequently a stored grant for
+`ForEach-Object` does not cover `Remove-Item`, and a grant for `Remove-Item`
+does not cover `ForEach-Object`.
+
+The following application-owned helper illustrates the correlation. Building
+the set by walking complete body occurrences also means an empty region cannot
+account for its opaque host argument:
+
+```csharp
+static IReadOnlyList<ClauseElement> FindAccountedRegionArguments(
+    ParsedCommand parsed)
+{
+    var accounted = new List<ClauseElement>();
+
+    foreach (var occurrence in parsed.Commands)
+    {
+        if (!occurrence.IsComplete)
+        {
+            continue;
+        }
+
+        foreach (var frame in occurrence.Ancestry)
+        {
+            if (frame.Region == CommandAncestryRegion.ExecutionRegion
+                && frame.Ancestor is ExecutionRegionSyntax region
+                && IsKnownCommandArgumentRegion(region))
+            {
+                if (!accounted.Any(element =>
+                        ReferenceEquals(element, region.HostArgument)))
+                {
+                    accounted.Add(region.HostArgument!);
+                }
+            }
+        }
+    }
+
+    return accounted;
+}
+
+static bool IsKnownCommandArgumentRegion(ExecutionRegionSyntax region) =>
+    region.Origin == ExecutionRegionOrigin.CommandArgument
+    && region.HostArgument is not null
+    && Enum.IsDefined(typeof(ExecutionRegionPhase), region.Phase)
+    && region.Phase != ExecutionRegionPhase.Unknown
+    && Enum.IsDefined(typeof(ExecutionRegionTiming), region.Timing)
+    && region.Timing != ExecutionRegionTiming.Unknown
+    && Enum.IsDefined(
+        typeof(ExecutionRegionCardinality),
+        region.Cardinality)
+    && region.Cardinality != ExecutionRegionCardinality.Unknown;
+
+static bool IsAccountedRegionArgument(
+    AnalyzedArgument argument,
+    IReadOnlyList<ClauseElement> accounted) =>
+    argument.Argument.Kind == ArgKind.DynamicSkip
+    && accounted.Any(element => ReferenceEquals(element, argument.Element));
+```
+
+Use reference identity deliberately. Matching the raw script-block text or a
+list position could associate the wrong region when the same text occurs more
+than once. Direct `& { ... }` and `. { ... }` regions have `HostArgument =
+null`; they expose their body occurrences without inventing a host command or
+an argument to suppress.
+
+Unknown and incomplete shapes remain strict. `Invoke-Custom { Remove-Item
+.\victim.txt }` exposes the possible body so it cannot be hidden, but its
+region metadata is `Unknown` and its occurrences are incomplete. An empty
+`ForEach-Object { }` projects no body occurrence. Neither case accounts for the
+host `DynamicSkip`; both prompt or deny rather than reusing a durable approval.
+
 Quoting also determines the scope of host-wrapper substitutions. In
 `pwsh -Command "Write-Output $(Get-Date)"`, the parent evaluates `Get-Date`, so
 the result contains that parent-scope occurrence plus an incomplete outer

--- a/openspec/changes/v0-3-structured-shell-analysis/tasks.md
+++ b/openspec/changes/v0-3-structured-shell-analysis/tasks.md
@@ -43,9 +43,16 @@
   or obsolete compatibility layer. Defensively copy or immutably back every
   `IReadOnlyList<T>` introduced by v0.3 and pin many-to-one inline-option
   argument joins without changing stable v0.2 list semantics.
-- [ ] 1.16 Migrate Netclaw from alpha.5 to the corrected prerelease, delete its
+- [x] 1.16 Migrate Netclaw from alpha.5 to the corrected prerelease, delete its
   coordinate/property-bag validation, and rerun the full Linux plus native-
   Windows approval matrices before stable v0.3.
+  - Netclaw PR [#1855](https://github.com/netclaw-dev/netclaw/pull/1855)
+    migrated to `0.3.0-alpha.6`, removed the superseded coordinate and
+    property-bag checks, and passed 21 Linux, Windows, macOS, native-smoke,
+    package, and security checks before merge `12193d78`.
+  - Netclaw PR [#1857](https://github.com/netclaw-dev/netclaw/pull/1857)
+    then ran the corrected package through the complete 240-row downstream
+    catalog and merged as `b5de8d42` after all 21 GitHub check runs passed.
 
 ## 2. Resolver Provenance Correction and Shared Preparation
 
@@ -80,7 +87,11 @@
   - [x] 3.12c Pin expanding-heredoc sibling/nested ordering, exact spans, isolated state, delimiter modes, escape parity, depth limits, and atomic failure.
   - [x] 3.12d Pin default-versus-isolated parameter dereferences, nameref and integer hidden execution, reachable mutation invalidation, substitution/subshell scope boundaries, and direct/wrapped execution-bearing builtins with native Bash oracles.
   - [x] 3.12e Pin Bash command-resolution mutation, reserved-prefix/group rejection, and exact-query boundaries with direct tests, recursive wrapper cases, and native Bash oracles.
-- [ ] 3.13 Promote ordinary, multiple, nested, iterator, redirect, quoted, escaped, stateful, malformed, and hidden-execution substitution cases into both executable corpora and the Netclaw approval matrix.
+- [x] 3.13 Promote ordinary, multiple, nested, iterator, redirect, quoted, escaped, stateful, malformed, and hidden-execution substitution cases into both executable corpora and the Netclaw approval matrix.
+  - Netclaw PR [#1857](https://github.com/netclaw-dev/netclaw/pull/1857)
+    promoted the downstream Bash and PowerShell substitution dispositions into
+    the executable 240-row approval catalog and merged as `b5de8d42` after the
+    refreshed cross-platform acceptance matrix passed.
   - [x] 3.13a Promote the Bash ordinary, multiple, nested, redirect, quoted, escaped, stateful, malformed, and hidden-execution cases into its executable corpus.
   - [x] 3.13b Promote the PowerShell ordinary, multiple, nested, redirect, quoted, escaped, stateful, malformed, expression-boundary, and hidden-execution cases into its executable corpus.
   - [x] 3.13c Promote expanding, literal, tab-stripped, multiple, and malformed Bash heredoc cases with full structural expectations into the executable corpus.
@@ -125,6 +136,11 @@
   - [x] 5.1a Document the PowerShell `$()` occurrence ordering, standalone/call-operator distinction, parent-versus-child host payload provenance, and completeness-versus-value-safety contract.
 - [x] 5.2 Document syntax-tree display traversal separately from authorization traversal.
 - [x] 5.3 Document exact, finite, pattern, unknown, joined-state, redirect, and incomplete-result handling.
+  - The consumer guide also demonstrates command-owned execution-region
+    accounting: correlate the exact `HostArgument` by reference only from a
+    complete nonempty body occurrence with known origin, phase, timing, and
+    cardinality; authorize every host and body occurrence independently; and
+    keep unknown, empty, or incomplete regions strict.
 - [x] 5.4 Document record equality, hashing, `ToString()`, serialization, and `Clauses` compatibility effects.
 - [x] 5.5 Update the README getting-started and migration examples to direct v0.3 consumers to the command-occurrence API and full consumer guide.
 - [x] 5.6 Publish a 0.3.0 prerelease containing the contracted structural,
@@ -188,11 +204,13 @@
   - The executable corpus includes indirect and parameter-operator rejection,
     loop-body substitution, and atomic transition-budget overflow; native
     oracles pin the shell semantics behind the conservative boundaries.
-- [ ] 6.8 Add sanitized Bash corpus entries and Netclaw disposition cases.
+- [x] 6.8 Add sanitized Bash corpus entries and Netclaw disposition cases.
   Under Netclaw's enforced `BashInitialStateMode.Unknown` contract, bounded
   loop cases must remain prompt or deny; require an allow case only if the
   executor later proves the full isolated non-interactive startup/environment
   contract rather than selecting that parser mode solely to reduce prompts.
+  Netclaw PR #1857 pins 199 Bash catalog rows on POSIX, including bounded-loop,
+  redirect, substitution, unknown-state, stored-grant, and hard-deny outcomes.
 
 ## 7. PowerShell Foreach Vertical Slice
 
@@ -298,13 +316,17 @@
   - Direct and generated corpus cases pin unknown pipeline-object values,
     provider and variable mutation, incomplete dynamic identities, opaque
     splats, the 32-candidate boundary, and overflow-to-Unknown behavior.
-- [ ] 7.7 Add PowerShell corpus entries, live `pwsh` oracle coverage, and Netclaw integration cases.
-  - `PwshCorpusTool` now supports case-specific `PwshInitialStateMode`; keep
-    the generated 540-case manifest and live-oracle matrix aligned, then
-    complete the Netclaw PowerShell policy matrix. Exact generated cases now
-    cover the final stable dynamic-loop and invalid local `Invoke-Command
+- [x] 7.7 Add PowerShell corpus entries, live `pwsh` oracle coverage, and Netclaw integration cases.
+  - `PwshCorpusTool` supports case-specific `PwshInitialStateMode`; the
+    generated 540-case manifest and live-oracle matrix are aligned. Exact
+    generated cases cover the final stable dynamic-loop and invalid local `Invoke-Command
     -AsJob` cases, plus `Measure-Command`, `Trace-Command`, and
     `ForEach-Object -RemainingScripts` directly.
+  - Netclaw PR #1857 adds 36 PowerShell 7 and five Windows PowerShell 5.1
+    approval rows covering safe commands, redirects, subexpressions, loops,
+    execution regions, dialect differences, stored grants, and fail-closed
+    unknown or destructive cases. Its Ubuntu, Windows, and macOS managed-test
+    jobs and Linux/macOS native-smoke jobs passed.
 - [x] 7.8 Implement the additive `PwshDialect` API, PowerShell 7 compatibility
   default, unknown-value safe-fail, Windows PowerShell 5.1 pipeline-chain
   rejection, dialect-specific alias and execution-region metadata, and static
@@ -373,7 +395,15 @@
     v0.2 members, corrected v0.3 type families, property accessors, parser
     entry points, enum ordering, and nullability synchronized into `SPEC.md`
     and `SPEC.POWERSHELL.md`.
-- [ ] 11.6 Validate Netclaw's ordinary-command, redirect, bounded-loop, and unknown-value approval matrices against the prerelease package.
+- [x] 11.6 Validate Netclaw's ordinary-command, redirect, bounded-loop, and unknown-value approval matrices against the prerelease package.
+  - Netclaw PR #1857 validates 240 catalog rows: 199 Bash, 36 PowerShell 7,
+    and five Windows PowerShell 5.1. The POSIX test class passes 244 cases after
+    its three retry regressions and review-table snapshot are included. All 21
+    refreshed GitHub check runs passed, including Ubuntu, Windows, macOS,
+    Linux/macOS native smoke, screenshot, package, header, Slopwatch, and
+    CodeQL. Rebased local acceptance separately passed the Release build, 61
+    focused security tests, the 244-case POSIX matrix, the full solution suite,
+    header verification, and strict OpenSpec validation.
 - [x] 11.7 Update release notes and remove Netclaw's temporary descriptor workaround only after explicit redirect integration is live.
   - The `0.3.0-alpha` release notes document the explicit redirect model. The
     workaround was removed only in the reviewed Netclaw migration after the


### PR DESCRIPTION
## Summary

- record the completed ShellSyntaxTree alpha.6 migration and 240-row Netclaw acceptance matrix
- document safe correlation of PowerShell command-owned execution regions without weakening DynamicSkip handling
- leave only stable 0.3.0 publication open in the accepted OpenSpec

## Validation

- dotnet build -c Release --no-restore
- dotnet test -c Release --no-build --no-restore (2,870 passed)
- pwsh ./scripts/Add-FileHeaders.ps1 -Verify
- openspec validate --all --strict (4 passed)
- git diff --check
- adversarial review: PASS, including a second pass after evidence wording was tightened