### PR TITLE
Record 0.3.0 stable publication evidence

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -682,11 +682,18 @@ priorities.
       joined-argument, value-domain, redirect-source, and redirect-analysis
       alternatives. Netclaw PR #1857 closes the downstream acceptance gate with
       240 catalog rows and green cross-platform CI.
-- [ ] Publish `0.3.0` stable from the reviewed release metadata after the
-      release PR passes Linux and Windows CI. Derive the bare SemVer tag from
-      the merged MSBuild `Version`, observe the tag-driven NuGet workflow, and
-      verify the package, symbols package, and non-prerelease GitHub release
-      before completing OpenSpec task 11.9.
+- [x] Published `0.3.0` stable from the reviewed release metadata in
+      [PR #149](https://github.com/Aaronontheweb/ShellSyntaxTree/pull/149),
+      merge `217c007a`, after Linux and native Windows CI passed. The bare
+      `0.3.0` tag was derived from the merged MSBuild `Version`; successful
+      [tag workflow run 31444933607](https://github.com/Aaronontheweb/ShellSyntaxTree/actions/runs/31444933607)
+      published the package and symbols package. The
+      [NuGet package](https://www.nuget.org/packages/ShellSyntaxTree/0.3.0)
+      resolves as version `0.3.0` for both target frameworks, and the
+      [GitHub release](https://github.com/Aaronontheweb/ShellSyntaxTree/releases/tag/0.3.0)
+      is a non-draft, non-prerelease release with both `.nupkg` and `.snupkg`
+      assets. Netclaw PRs #1855 and #1857 had already completed the downstream
+      migration and cross-platform acceptance gates.
 - [x] Replace the pre-alpha consumer preview with the v0.3 occurrence-based
       authorization loop and separate syntax-display guidance. Document exact,
       finite, pattern, unknown, joined-cwd, redirect, incomplete-result,

--- a/openspec/changes/v0-3-structured-shell-analysis/tasks.md
+++ b/openspec/changes/v0-3-structured-shell-analysis/tasks.md
@@ -408,7 +408,15 @@
   - The `0.3.0-alpha` release notes document the explicit redirect model. The
     workaround was removed only in the reviewed Netclaw migration after the
     prerelease package was published.
-- [ ] 11.9 Promote stable 0.3.0 only after Linux and Windows CI, package publication, and downstream acceptance succeed.
+- [x] 11.9 Promote stable 0.3.0 only after Linux and Windows CI, package publication, and downstream acceptance succeed.
+  - ShellSyntaxTree PR #149 merged as `217c007a` after its Linux and native
+    Windows checks passed. The bare `0.3.0` tag, derived from the merged MSBuild
+    `Version`, completed tag workflow run 31444933607. The public NuGet package
+    resolves as stable version `0.3.0` with `net8.0` and `netstandard2.0`
+    targets, and the non-draft, non-prerelease GitHub release contains both the
+    package and symbols package. Netclaw PRs #1855 and #1857 had already passed
+    the migration, 240-row approval catalog, and cross-platform downstream
+    acceptance gates.
 
 ## Post-v0.3 Backlog (Non-Gating)
 


### PR DESCRIPTION
Closes the final v0.3 OpenSpec task after verifying the stable NuGet package, symbols package, GitHub release, Linux and Windows release CI, and the completed Netclaw downstream acceptance gates.\n\nLocal validation: Release build with zero warnings; 2,870 tests passed with no skips; headers verified; strict OpenSpec validation passed; task ledger reports 85/85. A fresh adversarial reviewer independently verified every publication claim and returned PASS with no warnings.