### PR TITLE
docs: specify ShellSyntaxTree 0.3.1 approval facts

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -10,7 +10,23 @@ priorities.
 
 ---
 
-## NOW (0.3.0 host integration and release acceptance)
+## NOW (0.3.1 bounded approval facts)
+
+- [x] **Create the v0.3.1 approval-fact OpenSpec.** Harvest and sanitize the
+      Netclaw v0.26.0-beta.3 approval window. Classify all 18 distinct prompts
+      and define bounded concatenation, separate effective and authored-source
+      word facts, lexical path shape, consumer, corpus, and adversarial
+      contracts under `openspec/changes/v0-3-1-approval-facts/`.
+- [ ] **Approve the v0.3.1 public contract.** Confirm the additive
+      `IntegerRange`, `Concatenation`, `AuthoredValue`, `ShellPathShape`,
+      `AuthoredPathShape`, and `PublishAuthoredSourceFacts` names. Confirm that
+      Netclaw may use the pre-field-splitting word fact for approval matching
+      while effective facts retain runtime meaning.
+- [ ] **Implement and release v0.3.1.** Follow the OpenSpec task order. Run the
+      API, unit, corpus, PII, native-oracle, package, header, downstream
+      Netclaw, and adversarial gates before publication.
+
+## Completed v0.3.0 host integration and release acceptance
 
 > **Spec:** `SPEC.POWERSHELL.md` (v0.2.0). The PowerShell parser is
 > implemented — phases 1–14 of `SPEC.POWERSHELL.md` §16 are complete (see

--- a/openspec/changes/v0-3-1-approval-facts/.openspec.yaml
+++ b/openspec/changes/v0-3-1-approval-facts/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-11

--- a/openspec/changes/v0-3-1-approval-facts/design.md
+++ b/openspec/changes/v0-3-1-approval-facts/design.md
@@ -1,0 +1,285 @@
+## Context
+
+The sanitized harvest is stored in `evidence/approval-matrix.json`. D02 and D10
+contain an embedded status expansion, not a standalone numeric argument. D14
+contains a static loop whose complete path word is finite from authored source.
+
+ShellSyntaxTree 0.3.0 already produces a finite effective value for D14-like
+input when the caller proves `IsolatedNonInteractive`. Netclaw cannot make that
+runtime assertion because it inherits ambient process state. Default `Unknown`
+therefore withholds the effective value. Relabeling the source result as an
+effective value would be false in the presence of ambient Bash nameref or
+integer attributes.
+
+The contract needs two independent axes:
+
+1. the bounded value language; and
+2. the provenance of the proof.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Represent canonical bounded integers and bounded string concatenation.
+- Keep the existing effective-value contract unchanged.
+- Expose a separate authored word value before field splitting.
+- Expose lexical path shape without claiming executable operand semantics.
+- Preserve conservative effective behavior for identities, redirects,
+  substitutions, unquoted field splitting, ambient variables, and explicit
+  state mutation.
+- Keep the public API additive and closed to consumer construction.
+- Pin exact sanitized evidence and adversarial boundaries.
+
+**Non-Goals:**
+
+- Assert that authored-source values are runtime-effective values.
+- Change default parser behavior for existing consumers.
+- Parse an executable's private options or operands.
+- Reimplement finite loop-fragment composition already shipped in 0.3.0.
+- Execute commands, inspect ambient variables, or enumerate the filesystem.
+- Add Bash `if`, `while`, `case`, implicit loops, or process substitution.
+- Change PowerShell language semantics.
+
+## Decisions
+
+### 1. Extend the bounded value language
+
+The exact additive API is:
+
+```csharp
+public abstract record ShellValueDomain
+{
+    private protected ShellValueDomain() { }
+    private protected abstract object LibraryOwnership { get; }
+
+    public sealed record IntegerRange : ShellValueDomain
+    {
+        internal IntegerRange(long minimumInclusive, long maximumInclusive)
+        {
+            if (minimumInclusive > maximumInclusive)
+                throw new ArgumentOutOfRangeException(nameof(minimumInclusive));
+            MinimumInclusive = minimumInclusive;
+            MaximumInclusive = maximumInclusive;
+        }
+        private protected override object LibraryOwnership => this;
+        internal override ShellValueDomainKind InternalKind =>
+            ShellValueDomainKind.IntegerRange;
+        public long MinimumInclusive { get; }
+        public long MaximumInclusive { get; }
+    }
+
+    public sealed record Concatenation : ShellValueDomain
+    {
+        internal Concatenation(IReadOnlyList<ShellValueDomain> parts) =>
+            Parts = PublicCollection.Copy(parts);
+        private protected override object LibraryOwnership => this;
+        internal override ShellValueDomainKind InternalKind =>
+            ShellValueDomainKind.Concatenation;
+        public IReadOnlyList<ShellValueDomain> Parts { get; }
+    }
+}
+```
+
+The internal `ShellValueDomainKind` appends `IntegerRange` and `Concatenation`.
+The internal factories enforce all part-shape and normalization rules before
+they call these constructors. The public surface has no consumer constructor or
+setter.
+
+`IntegerRange` is inclusive. Every represented value uses canonical signed
+ASCII decimal: `0`; a nonzero digit followed by zero or more digits; or `-`
+followed by a nonzero digit and zero or more digits. A plus sign and leading
+zeros are not represented. Bash status is the nonnegative `0..255` subset.
+
+`Concatenation` is a bounded string-language upper bound. It contains two
+through 16 normalized parts. Parts may be `Exact`, `FiniteSet`, or
+`IntegerRange`. `Unknown`, `PathPattern`, and nested `Concatenation` are
+rejected. Construction removes empty exact parts, merges adjacent exact parts,
+and collapses an all-exact result to `Exact`. If normalization leaves one
+non-exact part, the factory returns that part instead of `Concatenation`. More
+than 16 normalized parts produces `Unknown`; it never truncates. Repeated
+dynamic parts are conservatively independent. The language can include values
+that Bash cannot produce, but it never omits an actual value.
+
+The existing 32-member finite-set cap still applies to `FiniteSet`. A
+concatenation is bounded by its typed representation rather than by enumerating
+its Cartesian product.
+
+### 2. Publish only quoted Bash status values
+
+Double-quoted `$?` is one shell field and has `IntegerRange(0, 255)`. Literal
+prefixes and suffixes create `Concatenation`.
+
+For example, `echo "---EXIT $?---"` produces:
+
+```text
+Concatenation([
+  Exact("---EXIT "),
+  IntegerRange(0, 255),
+  Exact("---")
+])
+```
+
+Unquoted `$?` remains unknown because ambient `IFS` can split its decimal
+characters into multiple fields. Status in command identity or redirect target
+position remains strict. Single-quoted `$?` is the exact literal `$?`.
+
+### 3. Separate effective values from authored word values
+
+`AnalyzedArgument.Value` retains its released meaning: effective shell-value
+proof under the selected initial-state contract.
+
+Two additive members are appended:
+
+```csharp
+public sealed record AnalyzedArgument
+{
+    internal AnalyzedArgument() { }
+    public Arg Argument { get; internal init; } = null!;
+    public ClauseElement Element { get; internal init; } = null!;
+    public ShellValueDomain Value { get; internal init; } = null!;
+    public ShellValueDomain AuthoredValue { get; internal init; } = null!;
+    public ShellPathShape AuthoredPathShape { get; internal init; }
+}
+
+public enum ShellPathShape
+{
+    Unknown = 0,
+    Posix = 1,
+    Windows = 2,
+}
+```
+
+`AuthoredValue` is the bounded shell word that source proves before field
+splitting and pathname expansion. It applies quote removal and bounded source
+bindings. It does not apply unobserved ambient variable attributes or ambient
+`IFS`. It is not an argv claim or a runtime-value prediction. For arguments
+where this distinction does not matter, `AuthoredValue` equals `Value`.
+
+`AuthoredPathShape` describes lexical form only. Classification precedence for
+each represented word is deterministic:
+
+1. a URI-shaped word matching `^[A-Za-z][A-Za-z0-9+.-]*://` is `Unknown`;
+2. a drive, UNC, or backslash-bearing form is `Windows`;
+3. an absolute, `./`, `../`, eligible tilde, or slash-bearing form is `Posix`;
+4. every other form is `Unknown`.
+
+Thus `C:/work/a` is `Windows`, not `Posix`. A domain publishes a known shape
+only when every word it represents proves the same known shape. Mixed shapes,
+any partially unknown member, or a symbolic concatenation for which one shape
+cannot be proved produces `Unknown`. For example, `Exact("/tmp/")` followed by
+an integer range is provably `Posix`; a finite set containing `/tmp/a` and
+`C:\\work\\b` is `Unknown`.
+
+ShellSyntaxTree does not claim that an executable treats the word as a
+filesystem operand. A repository slug, container image, API route, or
+slash-bearing data can have a path shape. `Unknown` means no uniform lexical
+path-shape proof. Netclaw can use shape to require more path review, but never
+as filesystem authority.
+
+### 4. Make authored-source publication an explicit opt-in
+
+Append this option with a default of `false`:
+
+```csharp
+public sealed record BashParserOptions : ShellParserOptions
+{
+    public BashInitialStateMode InitialStateMode { get; init; }
+    public bool PublishAuthoredSourceFacts { get; init; }
+}
+```
+
+With the default `false`, static loops under `BashInitialStateMode.Unknown`
+retain the released `IsUnparseable=true`, empty `Commands`, and empty `Clauses`
+result. Existing consumers see no behavior change.
+
+When `PublishAuthoredSourceFacts=true`, a supported static loop that fails only
+the ambient attribute or field-splitting proof can publish:
+
+```text
+Value         = Unknown
+AuthoredValue = FiniteSet(...)
+```
+
+The occurrence is structurally complete only for authored source. The option
+does not assert runtime isolation. `IsolatedNonInteractive` continues to
+publish the finite effective set and does not require the option.
+
+Explicit source-level nameref/integer declarations, `eval`, `source`, dynamic
+identity, command substitution, and unsupported control flow keep the affected
+region strict. An unassigned ambient name has `Unknown` for both properties.
+
+This removes the proposed `AuthoredCommand` mode. The option requests an
+additional conservative source projection. It does not select a policy or
+relabel the result as effective. Netclaw decides whether it can consume that
+projection.
+
+### 5. Reuse shipped finite composition
+
+The implementation reuses the existing per-visit correlation and fragment
+composition. It evaluates the authored word before field splitting when the
+new option is enabled. It does not add a second composition engine.
+
+The valid tilde example is `cat ~/"repo/$f"`. `cat "~/repo/$f"` keeps a literal
+tilde, matching native Bash.
+
+### 6. Preserve the consumer boundary
+
+ShellSyntaxTree reports structure, value domains, proof provenance, lexical
+path shape, redirects, and completeness. It never labels an argument safe
+or grants authority. Netclaw decides whether its approval model accepts an
+authored-source proof, then applies hard deny, protected paths, stored grants,
+safe policy, and execution containment.
+
+An old consumer's default switch arm fails closed on the new domain records.
+An existing consumer sees no loop-admission relaxation unless it sets the new
+option.
+
+PowerShell has exact compatibility behavior in 0.3.1. Literal, dynamic, path,
+and provider arguments set `AuthoredValue` equal to their existing `Value`.
+`AuthoredPathShape` is `Unknown` for all PowerShell arguments in this release.
+
+### 7. Use the exact sanitized catalog
+
+`evidence/approval-matrix.json` is byte-identical to the paired Netclaw
+artifact. It contains all 18 deduplicated prompts, exact sanitized source,
+observed response class, owner, and expected result. D02, D10, and D14 become
+ShellSyntaxTree regression inputs. The other rows remain cross-repository
+classification evidence.
+
+## Risks / Trade-offs
+
+- **A consumer mistakes authored source for runtime truth.** The API uses a
+  separate property; `Value` remains unchanged; the guide requires an explicit
+  policy decision before consuming `AuthoredValue`.
+- **Concatenation can denote many strings.** The representation is capped,
+  immutable, nonrecursive, and never silently enumerated as a finite set.
+- **Path shape is not operand semantics.** Netclaw uses it only to add strict
+  path review. It never creates filesystem authority.
+- **Opt-in loop admission changes three released signals.** The guide lists
+  `IsUnparseable`, `Commands`, and `IsComplete`. Default options retain all
+  released results.
+- **Additive records affect reflection and serialization.** Results are not a
+  stable wire format; API snapshots and release notes make the change explicit.
+
+## Migration Plan
+
+1. Approve the public names, opt-in behavior, and Netclaw's use of authored
+   pre-field-splitting word facts.
+2. Update `SPEC.md` and API snapshots before production implementation.
+3. Add value-domain projection and quoted-status tests.
+4. Reuse loop analysis to publish `AuthoredValue` and lexical path shape.
+5. Add exact sanitized corpus and native Bash oracle cases.
+6. Update the consumer guide and release notes.
+7. Build, test, pack, PII-audit, and publish 0.3.1 by tag.
+8. Upgrade Netclaw only after its paired policy change is ready.
+
+Rollback restores 0.3.0. No persisted format contains these parser records.
+
+## Open Questions
+
+- Maintainer approval is required for `AuthoredValue`, `ShellPathShape`,
+  `AuthoredPathShape`, `PublishAuthoredSourceFacts`, `IntegerRange`, and
+  `Concatenation` before implementation.
+- Maintainer approval is required for Netclaw to use a pre-field-splitting word
+  fact. That approval boundary excludes ambient attributes, ambient `IFS`, and
+  field splitting while effective facts remain strict for execution and deny.

--- a/openspec/changes/v0-3-1-approval-facts/evidence/approval-matrix.json
+++ b/openspec/changes/v0-3-1-approval-facts/evidence/approval-matrix.json
@@ -1,0 +1,175 @@
+{
+  "cutoffUtc": "2026-08-11T15:13:55Z",
+  "sourceRelease": "Netclaw 0.26.0-beta.3",
+  "sanitization": {
+    "user": "user",
+    "workingRepository": "/work",
+    "remoteRepository": "example/project",
+    "numericIdentifier": "123456",
+    "commit": "deadbeef"
+  },
+  "cases": [
+    {
+      "id": "D01",
+      "command": "which netclaw netclawd 2>/dev/null; netclaw --version 2>/dev/null || netclawd --version 2>/dev/null || echo \"no CLI version flag found\"",
+      "observed": "Session",
+      "classification": "CorrectPrompt",
+      "owner": "Netclaw",
+      "sstExpectation": "Complete static command identities and redirects; no relaxation required.",
+      "netclawExpectation": "Prompt because at least one fallback executable has no grant coverage."
+    },
+    {
+      "id": "D02",
+      "command": "gh run view 123456 --repo example/project --log-failed --verbose 2>&1 | head -200; echo \"---EXIT $?---\"",
+      "observed": "Once",
+      "classification": "ShellSyntaxTreeFactGap",
+      "owner": "ShellSyntaxTree",
+      "sstExpectation": "The echo argument is Concatenation(Exact, IntegerRange(0,255), Exact); the status is not a path or identity.",
+      "netclawExpectation": "Allow when gh run view has global grant coverage and head plus echo have reviewed safe coverage."
+    },
+    {
+      "id": "D03",
+      "command": "cd /tmp && gh api repos/example/project/actions/jobs/123456/logs > slopwatch.log 2>&1; wc -c slopwatch.log; head -100 slopwatch.log",
+      "observed": "Once",
+      "classification": "NetclawPolicyDefect",
+      "owner": "Netclaw",
+      "sstExpectation": "Publish the leading success-gated directory transition, file redirect, relative paths, and four command occurrences.",
+      "netclawExpectation": "Allow after cd and gh api grants plus wc and head safe coverage compose per candidate; hard-deny and real path checks still pass."
+    },
+    {
+      "id": "D04",
+      "command": "cd /work && /home/user/.dotnet/dotnet build src/App/App.csproj -v minimal --nologo 2>&1 | tail -25",
+      "observed": "Once",
+      "classification": "CorrectPrompt",
+      "owner": "Netclaw",
+      "sstExpectation": "Publish the explicit executable path, build arguments, redirect duplication, pipeline, and cwd transition.",
+      "netclawExpectation": "Prompt because the explicit /home/user/.dotnet/dotnet executable has no matching grant."
+    },
+    {
+      "id": "D05",
+      "command": "cd /work && /home/user/.dotnet/dotnet list src/App/App.csproj package --include-transitive 2>/dev/null | grep -i \"ProtocolPackage\" | head -5",
+      "observed": "Once",
+      "classification": "CorrectPrompt",
+      "owner": "Netclaw",
+      "sstExpectation": "Publish all static identities, paths, redirects, and pipeline stages.",
+      "netclawExpectation": "Prompt because the explicit dotnet executable has no matching grant; agent alignment may remove the mismatch later."
+    },
+    {
+      "id": "D06",
+      "command": "cd /work && /home/user/.dotnet/dotnet list src/Service/Service.csproj package 2>&1 | grep -i \"ProtocolPackage\"; echo \"===TESTS===\"; /home/user/.dotnet/dotnet list tests/Service.Tests/Service.Tests.csproj package 2>&1 | grep -i \"ProtocolPackage\"; echo \"===ASSETS===\"; grep -o '\"ProtocolPackage[^\"]*\"' src/App/obj/project.assets.json | sort -u | head",
+      "observed": "Once",
+      "classification": "CorrectPrompt",
+      "owner": "Netclaw",
+      "sstExpectation": "Publish the static command list, redirects, pipelines, and authored paths.",
+      "netclawExpectation": "Prompt because both explicit dotnet invocations lack grant coverage."
+    },
+    {
+      "id": "D07",
+      "command": "cd /work && git push upstream feature/update:automation/update 2>&1 | tail -5",
+      "observed": "Session",
+      "classification": "NetclawPolicyDefect",
+      "owner": "Netclaw",
+      "sstExpectation": "Publish git push as a static token sequence with later argument tokens.",
+      "netclawExpectation": "Allow when a migrated git push grant covers the candidate at shell-token boundaries and tail is safely covered."
+    },
+    {
+      "id": "D08",
+      "command": "cd /work && git ls-remote upstream feature/update; echo \"---LOCAL---\"; git rev-parse HEAD; git log --oneline -3",
+      "observed": "Once",
+      "classification": "NetclawPolicyDefect",
+      "owner": "Netclaw",
+      "sstExpectation": "Publish the cwd transition and static git plus echo occurrences.",
+      "netclawExpectation": "Allow when existing global grants and safe coverage compose under the intended cwd."
+    },
+    {
+      "id": "D09",
+      "command": "cd /work && gh api repos/example/project/commits/deadbeef --jq '{sha: .sha, message: .commit.message}' 2>&1; echo \"===RUN 123456===\"; gh run view 123456 --repo example/project --json status,conclusion 2>&1 | head -40",
+      "observed": "Once",
+      "classification": "NetclawPolicyDefect",
+      "owner": "Netclaw",
+      "sstExpectation": "Publish static gh, echo, and head occurrences with the cwd transition.",
+      "netclawExpectation": "Allow when global gh grants and reviewed safe coverage compose."
+    },
+    {
+      "id": "D10",
+      "command": "cd /work && git fetch upstream feature/update 2>&1 | tail -2 && echo \"===REMOTE TIP===\" && git rev-parse FETCH_HEAD && git log --oneline -3 FETCH_HEAD && echo \"===HAS FIX?===\" && git show FETCH_HEAD:src/App/App.csproj | grep -n \"ProtocolPackage\"; echo \"exit: $?\"",
+      "observed": "Once",
+      "classification": "ShellSyntaxTreeFactGap",
+      "owner": "ShellSyntaxTreeAndNetclaw",
+      "sstExpectation": "The final echo argument is Concatenation(Exact, IntegerRange(0,255)); all command identities and control operators remain explicit.",
+      "netclawExpectation": "Allow after bounded status plus global grants and safe coverage compose under causal intent."
+    },
+    {
+      "id": "D11",
+      "command": "cd /work && echo \"===PARENT===\" && gh api repos/example/project/commits/deadbeef --jq '.parents[] | {sha: .sha}' 2>&1; echo \"===CURRENT PR HEAD===\" && gh pr view 123 --repo example/project --json headRefOid,updatedAt",
+      "observed": "Once",
+      "classification": "NetclawPolicyDefect",
+      "owner": "Netclaw",
+      "sstExpectation": "Publish the cwd transition and static echo plus gh occurrences.",
+      "netclawExpectation": "Allow when global gh grants and echo safe coverage compose."
+    },
+    {
+      "id": "D12",
+      "command": "mv /home/user/repos/source-project /home/user/repos/group/target-project && git -C /home/user/repos/group/target-project status --short --branch && ls -d /home/user/repos/group/target-project",
+      "observed": "Denied",
+      "classification": "CorrectPrompt",
+      "owner": "Netclaw",
+      "sstExpectation": "Publish the move source and target paths and later inspection commands.",
+      "netclawExpectation": "Prompt or deny because a cross-scope filesystem mutation is not covered by read-only policy."
+    },
+    {
+      "id": "D13",
+      "command": "for f in $(find /work/src /work/tests -name \"*.csproj\" | sort); do echo \"=== $f ===\"; grep -E \"TargetFramework|PackageReference|ProjectReference\" \"$f\"; done",
+      "observed": "Once",
+      "classification": "IrreduciblyDynamic",
+      "owner": "ShellSyntaxTree",
+      "sstExpectation": "Discover find and sort but keep the runtime-generated iterator and dependent values unknown.",
+      "netclawExpectation": "Prompt once; do not execute find during policy analysis."
+    },
+    {
+      "id": "D14",
+      "command": "for f in src/App/App.csproj src/Hosting/Hosting.csproj src/Discovery/Discovery.csproj tests/Hosting.Tests/Hosting.Tests.csproj; do echo \"=== $f ===\"; cat /work/$f; done",
+      "observed": "Once",
+      "classification": "ShellSyntaxTreeFactGap",
+      "owner": "ShellSyntaxTree",
+      "sstExpectation": "With PublishAuthoredSourceFacts enabled, effective cat value is Unknown; AuthoredValue is the four pre-field-splitting /work words and AuthoredPathShape is Posix.",
+      "netclawExpectation": "Allow only if product policy accepts pre-field-splitting authored words, applies path checks conservatively, and covers cat plus echo."
+    },
+    {
+      "id": "D15",
+      "command": "for pkg in Package.One Package.Two Package.Three; do code=$(curl -s -o /dev/null -w \"%{http_code}\" \"https://packages.example.invalid/v3/$pkg/index.json\"); echo \"$pkg -> HTTP $code\"; if [ \"$code\" = \"200\" ]; then curl -s \"https://packages.example.invalid/v3/$pkg/index.json\" | jq -r '.versions[-3:][]'; fi; done",
+      "observed": "Pending",
+      "classification": "IrreduciblyDynamic",
+      "owner": "ShellSyntaxTree",
+      "sstExpectation": "Keep command substitution and unsupported Bash if control flow strict.",
+      "netclawExpectation": "Prompt once; do not infer network results."
+    },
+    {
+      "id": "D16",
+      "command": "gh search repos example topic --limit 10 2>/dev/null; echo \"---REPO CHECK---\"; for r in project-one project-two project-three; do echo \"example/$r:\"; gh repo view example/$r --json name,visibility 2>&1 | head -2; done",
+      "observed": "Pending",
+      "classification": "CorrectPrompt",
+      "owner": "Netclaw",
+      "sstExpectation": "Publish the static search and finite loop structure.",
+      "netclawExpectation": "Prompt because the ungranted network search remains visible even if later reads have coverage."
+    },
+    {
+      "id": "D17",
+      "command": "cd /work && echo \"===API BRANCH===\" && gh api repos/example/project/branches/feature%2Fupdate --jq '.commit.sha' 2>&1; echo \"===GIT REMOTE===\" && git ls-remote upstream 'refs/heads/feature/update'; echo \"===COMMIT===\" && gh api repos/example/project/commits/deadbeef --jq '{sha: .sha, message: .commit.message}' 2>&1",
+      "observed": "Once",
+      "classification": "NetclawPolicyDefect",
+      "owner": "Netclaw",
+      "sstExpectation": "Publish the cwd transition and static gh, git, and echo occurrences.",
+      "netclawExpectation": "Allow when existing global grants and safe coverage compose."
+    },
+    {
+      "id": "D18",
+      "command": "gh pr close 123 --repo example/project --comment \"Closing this automated update because it is being replaced by a coordinated change.\" 2>&1",
+      "observed": "Pending",
+      "classification": "CorrectPrompt",
+      "owner": "Netclaw",
+      "sstExpectation": "Publish the static remote-mutation command and redirect duplication.",
+      "netclawExpectation": "Prompt because closing a pull request is a remote mutation without an explicit matching grant."
+    }
+  ]
+}

--- a/openspec/changes/v0-3-1-approval-facts/proposal.md
+++ b/openspec/changes/v0-3-1-approval-facts/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+Netclaw v0.26.0-beta.3 produced 18 distinct shell approval prompts after its
+2026-08-11 15:13:55 UTC daemon start. Two prompt classes expose facts that
+ShellSyntaxTree 0.3.0 cannot communicate without a consumer reparsing shell
+source:
+
+- a quoted argument can concatenate literals with a bounded special parameter,
+  for example `echo "---EXIT $?---"`; and
+- a static loop can have a finite authored path expression even when ambient
+  Bash attributes prevent an effective runtime-value proof.
+
+The second case is not a missing loop-composition algorithm. Version 0.3.0
+already composes finite fragments in `IsolatedNonInteractive` mode. The missing
+contract is a truthful separation between effective runtime values and values
+proved from authored source alone, plus parser-owned lexical path shape.
+
+## What Changes
+
+- Add bounded integer and concatenation alternatives to `ShellValueDomain`.
+- Add `AnalyzedArgument.AuthoredValue` as a pre-field-splitting word fact
+  without changing the existing effective `Value` property.
+- Add shell-general `AuthoredPathShape` that reports lexical shape, not operand
+  semantics or authority.
+- Add opt-in `BashParserOptions.PublishAuthoredSourceFacts`. The default keeps
+  the released unparseable-loop behavior.
+- Preserve the existing isolated-mode finite composition implementation and
+  crop duplicate work from the plan.
+- Add an exact, sanitized D01-D18 evidence catalog and executable corpus cases
+  for the three ShellSyntaxTree-owned facts.
+- Update the contract and consumer guide with input/output examples and strict
+  counterexamples.
+
+The paired Netclaw change is `structure-shell-approval-policy`. It decides
+whether its approval threat model may consume `AuthoredValue`; ShellSyntaxTree
+does not make that policy decision.
+
+## Capabilities
+
+### New Capabilities
+
+- `bounded-shell-values`: typed bounded scalar and concatenated string facts,
+  authored-source word values, and lexical path shape.
+
+### Modified Capabilities
+
+- None.
+
+## Impact
+
+- Public API: additive nested `ShellValueDomain` records, one additive enum,
+  one Bash option, and two additive `AnalyzedArgument` properties.
+- Bash analysis: quoted `$?` becomes bounded. An opt-in projection exposes a
+  static loop word before ambient attributes, `IFS`, and field splitting.
+- PowerShell: no language behavior change. `AuthoredValue` equals `Value`, and
+  `AuthoredPathShape` remains `Unknown` in 0.3.1.
+- Consumers: existing use of `Value` is unchanged and remains conservative.
+  Use of `AuthoredValue` is an explicit product-policy choice.
+- Release: additive v0.x release `0.3.1`, with package and consumer-guide work
+  required before publication.

--- a/openspec/changes/v0-3-1-approval-facts/specs/bounded-shell-values/spec.md
+++ b/openspec/changes/v0-3-1-approval-facts/specs/bounded-shell-values/spec.md
@@ -1,0 +1,304 @@
+## ADDED Requirements
+
+### Requirement: Bounded integer and concatenation domains
+
+ShellSyntaxTree SHALL append library-owned `ShellValueDomain.IntegerRange` and
+`ShellValueDomain.Concatenation` alternatives.
+
+`IntegerRange` SHALL contain inclusive signed 64-bit bounds. It SHALL reject a
+minimum greater than its maximum. Values SHALL use canonical signed ASCII
+decimal. A plus sign and leading zeros SHALL NOT be represented. Bash status
+SHALL use the nonnegative `0..255` subset.
+
+`Concatenation` SHALL contain two through 16 normalized immutable parts. Parts
+SHALL be `Exact`, `FiniteSet`, or `IntegerRange`. The library SHALL reject
+unknown, pattern, and nested-concatenation parts. It SHALL remove empty exact
+parts and merge adjacent exact parts. It SHALL return `Exact` when all parts
+become exact. It SHALL return the sole non-exact domain when one part remains.
+More than 16 normalized parts SHALL produce `Unknown`, not truncation.
+
+#### Scenario: Quoted Bash exit status is bounded
+
+- **WHEN** the Bash parser analyzes `status-report "$?"`
+- **THEN** the argument value is `IntegerRange(0, 255)`
+- **AND** the parser does not enumerate 256 strings
+
+#### Scenario: Embedded status preserves literals
+
+- **WHEN** the Bash parser analyzes `echo "---EXIT $?---"`
+- **THEN** the argument value is `Concatenation`
+- **AND** its parts are `Exact("---EXIT ")`, `IntegerRange(0, 255)`, and
+  `Exact("---")` in that order
+
+#### Scenario: Multiple quoted expansions remain bounded
+
+- **WHEN** the Bash parser analyzes `status-report "left=$?;right=$?"`
+- **THEN** both status positions are bounded integer parts
+- **AND** no correlation claim between those parts is required
+
+#### Scenario: Unquoted status remains strict
+
+- **WHEN** the default Bash parser analyzes `status-report $?`
+- **THEN** the argument value is `Unknown`
+- **AND** the parser does not assume an ambient `IFS`
+
+#### Scenario: Status cannot select an executable
+
+- **WHEN** the Bash parser analyzes `"$?" --version`
+- **THEN** the command identity remains dynamic
+- **AND** the parse is unparseable under the existing identity rule
+
+#### Scenario: Status cannot name a redirect target
+
+- **WHEN** the Bash parser analyzes `status-report ok > "$?"`
+- **THEN** the redirect target does not gain bounded authority
+- **AND** the affected command remains strict
+
+#### Scenario: Positional parameter is not bounded status
+
+- **WHEN** the Bash parser analyzes `status-report "$1"`
+- **THEN** the argument value is not `IntegerRange`
+- **AND** it retains the existing positional-parameter result
+
+#### Scenario: Option-shaped finite data is not inert
+
+- **WHEN** an authored finite value contains `-o` or `--execute`
+- **THEN** ShellSyntaxTree reports bounded shell data only
+- **AND** it does not claim how an external executable treats that data
+
+### Requirement: Effective and authored values stay distinct
+
+`AnalyzedArgument.Value` SHALL retain its effective shell-value meaning.
+`AnalyzedArgument.AuthoredValue` SHALL describe the authored shell word before
+field splitting, pathname expansion, ambient attributes, and ambient `IFS` can
+transform it.
+
+ShellSyntaxTree SHALL append `BashParserOptions.PublishAuthoredSourceFacts`.
+Its default SHALL be `false`. The default SHALL retain the released
+unparseable static-loop result under `BashInitialStateMode.Unknown`.
+
+#### Scenario: Opt-in exposes a static authored word
+
+- **WHEN** default `Unknown` mode with `PublishAuthoredSourceFacts=true` analyzes
+  `for f in a b; do show "$f"; done`
+- **THEN** the body occurrence is structurally complete for authored source
+- **AND** effective `Value` is `Unknown`
+- **AND** `AuthoredValue` is `FiniteSet(["a", "b"])`
+
+#### Scenario: Default options preserve released loop admission
+
+- **WHEN** default `Unknown` mode with `PublishAuthoredSourceFacts=false`
+  analyzes the same loop
+- **THEN** `IsUnparseable` is true
+- **AND** `Commands` and `Clauses` are empty
+- **AND** no existing consumer sees a new complete occurrence
+
+#### Scenario: Isolated mode keeps its existing effective proof
+
+- **WHEN** `IsolatedNonInteractive` analyzes the same loop
+- **THEN** `Value` is `FiniteSet(["a", "b"])`
+- **AND** `AuthoredValue` is the same finite set
+
+#### Scenario: Ambient state is not relabeled as effective fact
+
+- **GIVEN** ambient Bash can change attributes or `IFS`
+- **WHEN** opt-in authored-source mode analyzes the static loop
+- **THEN** effective `Value` remains `Unknown`
+- **AND** only `AuthoredValue` contains authored word candidates
+
+#### Scenario: Unquoted word is pre-field-splitting evidence
+
+- **WHEN** opt-in authored-source mode analyzes
+  `for f in src/A.cs src/B.cs; do show /work/$f; done`
+- **THEN** `AuthoredValue` contains the two complete `/work/` words
+- **AND** effective `Value` remains `Unknown`
+- **AND** the parser does not claim an argv count or ambient `IFS`
+
+#### Scenario: Explicit source attribute mutation remains strict
+
+- **WHEN** source declares a relevant nameref or integer binding before use
+- **THEN** the affected authored value is `Unknown`
+- **AND** hidden execution keeps the region incomplete or unparseable
+
+#### Scenario: Unassigned ambient variable remains unknown
+
+- **WHEN** the parser analyzes `show "$external_value"`
+- **THEN** it does not inspect the process environment
+- **AND** both value projections are `Unknown` if a result can be published
+
+### Requirement: Authored lexical path shape
+
+ShellSyntaxTree SHALL append `ShellPathShape` with `Unknown = 0`, `Posix = 1`,
+and `Windows = 2`. `AnalyzedArgument.AuthoredPathShape` SHALL expose this fact.
+
+The fact SHALL describe lexical form only. It SHALL NOT claim that an external
+executable treats the word as a filesystem operand. It SHALL NOT create
+filesystem authority. Classification SHALL apply this precedence to each
+represented word: URI shape matching `^[A-Za-z][A-Za-z0-9+.-]*://` produces
+`Unknown`; otherwise drive, UNC, or backslash-bearing form produces `Windows`;
+otherwise absolute, `./`, `../`, eligible tilde, or slash-bearing form produces
+`Posix`; otherwise the result is `Unknown`.
+
+A bounded domain SHALL publish a known shape only when every represented word
+proves the same known shape. Mixed known shapes, any member with unknown shape,
+or a symbolic concatenation without one provable shape SHALL produce `Unknown`.
+
+#### Scenario: Static loop composes a source path shape
+
+- **WHEN** default mode with `PublishAuthoredSourceFacts=true` analyzes
+  `for f in src/A.cs src/B.cs; do cat "/work/$f"; done`
+- **THEN** effective `Value` is `Unknown`
+- **AND** `AuthoredValue` is
+  `FiniteSet(["/work/src/A.cs", "/work/src/B.cs"])`
+- **AND** `AuthoredPathShape` is `Posix`
+
+#### Scenario: Eligible tilde prefix uses configured home
+
+- **GIVEN** configured home `/home/user`
+- **WHEN** `Unknown` mode with `PublishAuthoredSourceFacts=true` analyzes
+  `for f in A.cs B.cs; do cat ~/"repo/$f"; done`
+- **THEN** effective `Value` is `Unknown`
+- **AND** `AuthoredValue` contains the two `/home/user/repo/` words
+- **AND** `AuthoredPathShape` is `Posix`
+
+#### Scenario: Quoted tilde remains literal
+
+- **GIVEN** configured home `/home/user`
+- **WHEN** `Unknown` mode with `PublishAuthoredSourceFacts=true` analyzes
+  `for f in A.cs B.cs; do cat "~/repo/$f"; done`
+- **THEN** effective `Value` is `Unknown`
+- **AND** `AuthoredValue` contains the two literal `~/repo/` words
+- **AND** `AuthoredPathShape` is `Posix`
+- **AND** the parser does not claim home expansion
+
+#### Scenario: Windows drive takes precedence over slash shape
+
+- **WHEN** an authored word is `C:/work/file.txt`
+- **THEN** `AuthoredPathShape` is `Windows`
+
+#### Scenario: Mixed domains have unknown shape
+
+- **WHEN** `AuthoredValue` is `FiniteSet(["/tmp/a", "C:\\work\\b"])`
+- **THEN** `AuthoredPathShape` is `Unknown`
+
+#### Scenario: Partially unknown domains have unknown shape
+
+- **WHEN** `AuthoredValue` is `FiniteSet(["/tmp/a", "bare-name"])`
+- **THEN** `AuthoredPathShape` is `Unknown`
+
+#### Scenario: Concatenation can prove one shape
+
+- **WHEN** `AuthoredValue` concatenates `Exact("/tmp/status-")` with
+  `IntegerRange(0, 255)`
+- **THEN** `AuthoredPathShape` is `Posix`
+
+#### Scenario: URI schemes take precedence
+
+- **WHEN** authored words are `https://example.invalid/a`,
+  `ssh://example.invalid/a`, and `custom+v1://example.invalid/a`
+- **THEN** each `AuthoredPathShape` is `Unknown`
+
+#### Scenario: Repository slug is shape, not authority
+
+- **WHEN** the parser analyzes `gh repo view example/project`
+- **THEN** the slash-bearing argument MAY have `Posix` shape
+- **AND** ShellSyntaxTree does not claim filesystem operand semantics
+
+#### Scenario: Container image is shape, not authority
+
+- **WHEN** the parser analyzes `docker pull example/project`
+- **THEN** the slash-bearing argument MAY have `Posix` shape
+- **AND** the shape does not create filesystem authority
+
+#### Scenario: URI stays separate from path shape
+
+- **WHEN** the parser analyzes `fetch https://example.invalid/api/v1`
+- **THEN** URI recognition takes precedence and `AuthoredPathShape` is `Unknown`
+- **AND** the parser does not claim a filesystem operand
+
+#### Scenario: Slash-bearing data stays semantically unknown
+
+- **WHEN** the parser analyzes `printf '%s' /api/v1`
+- **THEN** `/api/v1` MAY have `Posix` shape
+- **AND** ShellSyntaxTree does not claim how `printf` interprets it
+
+#### Scenario: Bare dynamic filename has unknown shape
+
+- **WHEN** the parser analyzes `show "$external_value"`
+- **THEN** `AuthoredPathShape` is `Unknown`
+- **AND** a consumer does not infer path safety
+
+#### Scenario: Runtime iterator remains unknown
+
+- **WHEN** `IsolatedNonInteractive` analyzes
+  `for f in $(find /work -name '*.cs'); do cat "$f"; done`
+- **THEN** the parser discovers the substitution command
+- **AND** it does not execute `find` or enumerate its output
+- **AND** the loop-dependent authored value and path shape are `Unknown`
+
+### Requirement: Consumer boundary stays shell-general
+
+ShellSyntaxTree SHALL report shell structure, value domains, proof provenance,
+lexical path shape, redirects, and completeness. It SHALL NOT label a fact safe
+or grant authority.
+
+A consumer SHALL fail closed on unknown policy facts. Use of `AuthoredValue`
+SHALL be an explicit threat-model choice. Path shape SHALL only add conservative
+path review and SHALL NOT grant authority.
+
+#### Scenario: Existing consumer remains compatible
+
+- **WHEN** a consumer upgrades and keeps default parser options
+- **THEN** `IsUnparseable`, `Commands`, `Clauses`, and `IsComplete` retain
+  v0.3.0 loop behavior
+- **AND** effective `Value` retains v0.3.0 semantics
+
+#### Scenario: Authored-source consumer declares its boundary
+
+- **WHEN** a consumer enables and uses `AuthoredValue` for approval matching
+- **THEN** it documents that ambient attributes, ambient `IFS`, and field
+  splitting are outside the approval claim
+- **AND** it retains effective facts for execution and deny checks
+
+#### Scenario: Path shape cannot authorize slash-bearing value
+
+- **WHEN** a consumer receives `AuthoredPathShape=Posix`
+- **THEN** it MAY apply conservative path checks
+- **AND** it does not infer filesystem operand semantics or authority
+
+#### Scenario: Unknown future domain fails closed
+
+- **WHEN** a consumer receives an unrecognized `ShellValueDomain` subtype
+- **THEN** it prompts or denies when the value affects policy
+
+### Requirement: Sanitized v0.3.1 evidence and corpus
+
+The exact D01-D18 evidence SHALL live at `evidence/approval-matrix.json` and
+SHALL match the paired Netclaw artifact byte-for-byte. D02, D10, and D14 SHALL
+be executable Bash corpus or focused regression cases with complete facts.
+
+The corpus SHALL include dynamic identity, unquoted field splitting, redirect
+target, command substitution, explicit attribute mutation, multiple expansion,
+option-shaped finite data, slash-bearing non-path data, and resource-cap cases.
+Sanitization SHALL follow `SPEC.md` section 14. The automated PII gate SHALL
+scan the OpenSpec evidence file and corpus JSON.
+
+#### Scenario: PII audit passes
+
+- **WHEN** the PII audit scans the change and executable corpus
+- **THEN** it finds no local username, private repository, channel, thread,
+  host, email, token, or secret
+
+#### Scenario: Exact harvested cases stay linked
+
+- **WHEN** either repository changes a D01-D18 classification or command
+- **THEN** both evidence files change together
+- **AND** byte equality is checked during review
+
+#### Scenario: PowerShell projection is exact and compatible
+
+- **WHEN** shared argument projection gains the additive properties
+- **THEN** each PowerShell literal, dynamic, path, and provider argument sets
+  `AuthoredValue` equal to its existing effective `Value`
+- **AND** `AuthoredPathShape` is `Unknown`
+- **AND** every v0.3.0 PowerShell result otherwise remains unchanged

--- a/openspec/changes/v0-3-1-approval-facts/tasks.md
+++ b/openspec/changes/v0-3-1-approval-facts/tasks.md
@@ -1,0 +1,80 @@
+## 1. Contract and maintainer decisions
+
+- [ ] 1.1 Approve `AuthoredValue`, `ShellPathShape`, `AuthoredPathShape`,
+  `PublishAuthoredSourceFacts`, `IntegerRange`, and `Concatenation`.
+- [ ] 1.2 Approve Netclaw's use of a pre-field-splitting authored word. Record
+  the ambient attribute, ambient `IFS`, and field-splitting boundary.
+- [ ] 1.3 Update `SPEC.md` public API and bounded-analysis contracts before code.
+- [ ] 1.4 Approve the public API snapshot diff explicitly.
+
+## 2. Bounded value domains
+
+- [ ] 2.1 Add library-owned `IntegerRange` with inclusive-bound validation and
+  exact canonical-decimal documentation.
+- [ ] 2.2 Add immutable, flattened `Concatenation` with empty-part removal,
+  collapse rules, the 16-part cap, and allowed-part validation.
+- [ ] 2.3 Extend internal discriminants, projector validation, equality, and
+  public API snapshots without changing existing alternatives.
+- [ ] 2.4 Add construction and malformed-projector tests for every invariant.
+
+## 3. Quoted Bash status
+
+- [ ] 3.1 Recognize `$?` only in proved single-field double-quoted value
+  positions.
+- [ ] 3.2 Publish standalone `IntegerRange(0, 255)` and embedded
+  `Concatenation` without enumeration.
+- [ ] 3.3 Keep unquoted status, command identity, redirects, positional
+  parameters, substitutions, and unsupported mixed contexts strict.
+- [ ] 3.4 Add native Bash oracle tests for quoted, unquoted, single-quoted,
+  embedded, and multiple-expansion forms.
+
+## 4. Authored-source projection
+
+- [ ] 4.1 Add `AuthoredValue` while preserving the exact released meaning of
+  `Value`.
+- [ ] 4.2 Add the default-false `PublishAuthoredSourceFacts` option and preserve
+  default `IsUnparseable`, `Commands`, `Clauses`, and completeness results.
+- [ ] 4.3 Reuse the existing loop evaluator to project opt-in pre-field-splitting
+  authored words; do not duplicate fragment composition.
+- [ ] 4.4 Keep explicit source attribute mutation, hidden execution, dynamic
+  identity, runtime iteration, and unsupported regions strict.
+- [ ] 4.5 Add default, opt-in, and isolated tests. Cover nameref, integer, `IFS`,
+  field splitting, and option-shaped values.
+
+## 5. Authored lexical path shape
+
+- [ ] 5.1 Add lexical `ShellPathShape` and `AuthoredPathShape`; do not claim
+  filesystem operand semantics.
+- [ ] 5.2 Cover absolute, separator-bearing relative, `./`, `../`, eligible
+  tilde, quoted-literal tilde, and unknown bare-value cases.
+- [ ] 5.3 Prove D14's pre-field-splitting words while effective values remain
+  unknown under opt-in default-state mode.
+- [ ] 5.4 Add URI, repository slug, container image, and slash-bearing data
+  counterexamples.
+- [ ] 5.5 Prove exact PowerShell compatibility: `AuthoredValue=Value` and
+  `AuthoredPathShape=Unknown` for literal, dynamic, path, and provider cases.
+
+## 6. Evidence, corpus, and documentation
+
+- [ ] 6.1 Keep `evidence/approval-matrix.json` byte-identical to the Netclaw
+  artifact and add a parity check to the delivery checklist.
+- [ ] 6.2 Add exact sanitized D02, D10, and D14 executable cases plus adversarial
+  boundaries to the Bash corpus or focused tests.
+- [ ] 6.3 Extend the automated PII audit to the OpenSpec evidence JSON and run it
+  with zero hits.
+- [ ] 6.4 Update `docs/CONSUMER_GUIDE.md` with input/output examples and a
+  fail-closed recursive domain switch.
+- [ ] 6.5 Update `IMPLEMENTATION_PLAN.md`, `RELEASE_NOTES.md`, and version
+  metadata for 0.3.1.
+
+## 7. Validation and release
+
+- [ ] 7.1 Run `openspec validate v0-3-1-approval-facts --type change --strict
+  --no-interactive` before implementation and before delivery.
+- [ ] 7.2 Run tool restore, Release build, full tests, header verification, and
+  public API approval.
+- [ ] 7.3 Run Release pack and inspect the 0.3.1 package metadata.
+- [ ] 7.4 Obtain adversarial review of API truthfulness, Bash semantics,
+  sanitization, and consumer misuse boundaries.
+- [ ] 7.5 Push the SemVer tag, verify publish workflow success, and verify the
+  package appears on nuget.org before marking release complete.


### PR DESCRIPTION
## Summary

- records the sanitized D01-D18 Netclaw approval corpus and ownership classification
- proposes additive bounded `IntegerRange` and `Concatenation` value facts
- separates effective values from opt-in, pre-field-splitting `AuthoredValue`
- adds lexical-only `AuthoredPathShape` without granting filesystem authority
- preserves ShellSyntaxTree 0.3.0 behavior by default and pins exact PowerShell compatibility

## Decisions required before implementation

- approve the additive public API names
- approve whether Netclaw may consume pre-field-splitting authored facts while excluding ambient attributes, ambient `IFS`, and field splitting from its approval claim

## Validation

- `openspec validate v0-3-1-approval-facts --type change --strict --no-interactive`
- `dotnet build -c Release`
- `dotnet test -c Release --no-build` — 2,870 passed
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`
- PII audit and manual review passed
- paired evidence is byte-identical with the Netclaw proposal
- adversarial review: PASS
