### PR TITLE
Add bounded authored shell facts for 0.3.1

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.3.0</VersionPrefix>
+    <VersionPrefix>0.3.1</VersionPrefix>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Target framework matrix -->

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -17,7 +17,7 @@ priorities.
       and define bounded concatenation, separate effective and authored-source
       word facts, lexical path shape, consumer, corpus, and adversarial
       contracts under `openspec/changes/v0-3-1-approval-facts/`.
-- [ ] **Approve the v0.3.1 public contract.** Confirm the additive
+- [x] **Approve the v0.3.1 public contract.** Confirm the additive
       `IntegerRange`, `Concatenation`, `AuthoredValue`, `ShellPathShape`,
       `AuthoredPathShape`, and `PublishAuthoredSourceFacts` names. Confirm that
       Netclaw may use the pre-field-splitting word fact for approval matching

--- a/README.md
+++ b/README.md
@@ -109,6 +109,9 @@ static string Describe(ShellValueDomain value) => value switch
     ShellValueDomain.Exact exact => exact.Value,
     ShellValueDomain.FiniteSet finite => string.Join(" | ", finite.Values),
     ShellValueDomain.PathPattern pattern => pattern.Pattern,
+    ShellValueDomain.IntegerRange range =>
+        $"{range.MinimumInclusive}..{range.MaximumInclusive}",
+    ShellValueDomain.Concatenation => "bounded concatenation",
     ShellValueDomain.Unknown => "unknown",
     _ => "unknown",
 };

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ Hand-rolled, AOT-trim friendly, zero native dependencies. Multi-targets
 `netstandard2.0` and `net8.0`.
 
 ```bash
-# Current structured-analysis prerelease
-dotnet add package ShellSyntaxTree --version 0.3.0-alpha.1
+# Current package
+dotnet add package ShellSyntaxTree --version 0.3.1
 ```
 
-The latest stable package is `0.2.0`. The `0.3.0-alpha.1` prerelease adds the
-typed syntax tree and command-occurrence authorization API documented below.
+Version `0.3.1` includes the typed syntax tree, command-occurrence API, and
+bounded authored-value analysis documented below.
 
 ## What you get
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,45 @@
 #### Unreleased ####
 
+#### 0.3.1 2026-08-11 ####
+
+This additive release supplies bounded shell facts needed to reduce approval
+fatigue without moving product policy into ShellSyntaxTree. Existing parser
+options preserve every 0.3.0 default.
+
+## Added
+
+- Add library-owned `ShellValueDomain.IntegerRange` and `Concatenation`
+  alternatives. Double-quoted Bash `$?` is `IntegerRange(0, 255)` and quoted
+  literal-plus-status words remain symbolic without enumerating their product.
+- Add `AnalyzedArgument.AuthoredValue` for the bounded pre-field-splitting
+  authored word and `AuthoredPathShape` for lexical POSIX or Windows shape.
+  Path shape is not filesystem operand semantics and never grants authority.
+- Add default-false `BashParserOptions.PublishAuthoredSourceFacts`. Opted-in
+  consumers can inspect finite authored words in supported static loops while
+  effective values, redirects, cwd, dynamic identities, hidden execution, and
+  unsupported regions remain conservative.
+
+## Security and compatibility
+
+- Preserve 0.3.0 behavior when the new option is not selected. Static Bash
+  loops under unknown initial state remain unparseable with empty command and
+  clause projections.
+- Keep unquoted status, positional parameters, redirect targets, computed
+  identities, runtime iterators, explicit attribute mutation, ambient values,
+  and unknown future value alternatives fail closed.
+- Preserve PowerShell behavior exactly: `AuthoredValue` equals the existing
+  effective `Value`, and `AuthoredPathShape` is `Unknown` in 0.3.1.
+
+## Consumer validation
+
+- Add exact sanitized D02, D10, and D14 approval-harvest regressions, native
+  Bash status and tilde oracles, public API and malformed-projector snapshots,
+  PowerShell compatibility coverage, and PII audit coverage for OpenSpec
+  evidence.
+- Expand the consumer guide with input/output examples, an explicit authored-
+  source threat-model boundary, lexical-shape counterexamples, and a recursive
+  fail-closed value-domain switch.
+
 #### 0.3.0 2026-08-11 ####
 
 This stable release promotes the complete v0.3 structured shell-analysis

--- a/SPEC.md
+++ b/SPEC.md
@@ -136,6 +136,7 @@ public enum BashInitialStateMode
 public sealed record BashParserOptions : ShellParserOptions
 {
     public BashInitialStateMode InitialStateMode { get; init; }
+    public bool PublishAuthoredSourceFacts { get; init; }
 }
 
 /// <summary>Compatibility option for PowerShell initial host-state analysis.</summary>
@@ -219,6 +220,7 @@ public sealed record CommandOccurrence { ... }
 public sealed record CommandAncestryFrame { ... }
 public sealed record AnalyzedArgument { ... }
 public abstract record ShellValueDomain { ... }
+public enum ShellPathShape { ... }
 public abstract record RedirectAnalysis { ... }
 public sealed record HereDocumentAnalysis { ... }
 public abstract record RedirectSource { ... }
@@ -631,6 +633,15 @@ public sealed record AnalyzedArgument
     public Arg Argument { get; internal init; } = null!;
     public ClauseElement Element { get; internal init; } = null!;
     public ShellValueDomain Value { get; internal init; } = null!;
+    public ShellValueDomain AuthoredValue { get; internal init; } = null!;
+    public ShellPathShape AuthoredPathShape { get; internal init; }
+}
+
+public enum ShellPathShape
+{
+    Unknown,
+    Posix,
+    Windows,
 }
 
 public abstract record ShellValueDomain
@@ -643,6 +654,15 @@ public abstract record ShellValueDomain
     public sealed record FiniteSet : ShellValueDomain
     {
         public IReadOnlyList<string> Values { get; }
+    }
+    public sealed record IntegerRange : ShellValueDomain
+    {
+        public long MinimumInclusive { get; }
+        public long MaximumInclusive { get; }
+    }
+    public sealed record Concatenation : ShellValueDomain
+    {
+        public IReadOnlyList<ShellValueDomain> Parts { get; }
     }
     public sealed record PathPattern : ShellValueDomain
     {
@@ -741,7 +761,15 @@ The parser emits only these value-domain combinations:
 - `Unknown`: no payload;
 - `Exact`: exactly one non-null value;
 - `FiniteSet`: 2–32 distinct non-null values;
-- `PathPattern`: a non-empty pattern and non-empty covering directory.
+- `PathPattern`: a non-empty pattern and non-empty covering directory;
+- `IntegerRange`: inclusive signed 64-bit bounds with minimum no greater than
+  maximum, representing canonical signed ASCII decimal without a plus sign or
+  leading zeros; and
+- `Concatenation`: two through 16 normalized `Exact`, `FiniteSet`, or
+  `IntegerRange` parts. Empty exact parts are removed, adjacent exact parts are
+  merged, an all-exact result collapses to `Exact`, and one remaining
+  non-exact part is returned directly. Unknown, pattern, nested concatenation,
+  and over-cap inputs produce `Unknown`; the parser never truncates.
 
 The parser does not execute commands, inspect runtime variables, enumerate the
 filesystem, or truncate an over-limit set and call it complete. A result with
@@ -753,6 +781,44 @@ regions; blocks, lists, pipelines, and
 simple-command leaves do not independently increment it. Exceeding 16
 structural containers or 5 decoded-command wrapper recursions makes the entire
 result unparseable.
+
+`AnalyzedArgument.Value` retains the effective shell-value proof under the
+selected initial-state contract. `AuthoredValue` separately describes the
+bounded authored shell word before field splitting, pathname expansion,
+ambient variable attributes, and ambient `IFS` can transform it. It applies
+quote removal and bounded source bindings but is not an argv-count or runtime-
+value claim. Where the distinction does not matter, `AuthoredValue` equals
+`Value`.
+
+Double-quoted Bash `$?` is one field and publishes `IntegerRange(0, 255)`.
+Literal prefixes or suffixes produce a normalized `Concatenation`; repeated
+status positions are independent upper bounds. Unquoted status remains
+`Unknown` because ambient `IFS` can split it. Status in command identity or
+redirect-target position remains strict, and single-quoted `$?` is exact
+literal text.
+
+`BashParserOptions.PublishAuthoredSourceFacts` defaults to `false`. The default
+retains v0.3.0 static-loop admission exactly: under `Unknown` initial state the
+parse is unparseable and publishes empty `Commands` and `Clauses`. When true,
+a supported static loop that fails only the ambient attribute or field-
+splitting proof may publish a structurally complete authored occurrence with
+effective `Value=Unknown` and a finite `AuthoredValue`. Explicit attribute
+mutation, hidden execution, dynamic identity, command substitution, runtime
+iteration, redirects, and unsupported control flow remain strict. The
+`IsolatedNonInteractive` mode retains its existing effective proof and does not
+require the option.
+
+`AuthoredPathShape` is lexical evidence only. URI-shaped words matching
+`^[A-Za-z][A-Za-z0-9+.-]*://` are `Unknown`; otherwise drive, UNC, or
+backslash-bearing forms are `Windows`; otherwise absolute, `./`, `../`,
+eligible or literal tilde-prefix, or slash-bearing forms are `Posix`; all other
+forms are `Unknown`. Windows classification takes precedence for `C:/...`.
+A bounded domain publishes a known shape only when every represented word has
+the same known shape. Mixed, partially unknown, or unprovable symbolic domains
+are `Unknown`. This fact does not claim filesystem operand semantics or grant
+authority: repository slugs, container images, API routes, and other data can
+be path-shaped. PowerShell 0.3.1 sets `AuthoredValue=Value` and
+`AuthoredPathShape=Unknown` for exact compatibility.
 
 #### Bash bounded loop state
 

--- a/docs/CONSUMER_GUIDE.md
+++ b/docs/CONSUMER_GUIDE.md
@@ -448,6 +448,13 @@ foreach (var analyzed in occurrence.Arguments)
                 finite.Values),
         ShellValueDomain.PathPattern pattern =>
             EvaluatePattern(pattern.Pattern, pattern.CoveringDirectory),
+        ShellValueDomain.IntegerRange range =>
+            EvaluateIntegerRange(
+                analyzed.Argument,
+                range.MinimumInclusive,
+                range.MaximumInclusive),
+        ShellValueDomain.Concatenation concatenation =>
+            EvaluateConcatenation(analyzed.Argument, concatenation.Parts),
         ShellValueDomain.Unknown =>
             GateDecision.Prompt("policy-sensitive argument is unknown"),
         _ => GateDecision.Prompt("unrecognized value-domain alternative"),
@@ -463,6 +470,12 @@ foreach (var analyzed in occurrence.Arguments)
 - `PathPattern` is a Bash path-shaped glob plus a conservative
   `CoveringDirectory`. Accept it only when policy understands both the pattern
   and the full covering scope without enumerating the filesystem.
+- `IntegerRange` is an inclusive canonical-decimal range. It is bounded data,
+  not permission to treat every integer as an option, path, or executable.
+- `Concatenation` is a two-through-16-part symbolic string language whose
+  parts are `Exact`, `FiniteSet`, or `IntegerRange`. Evaluate the complete
+  receiver-owned argument role; do not enumerate an unbounded Cartesian
+  product or discard literal prefixes and suffixes.
 - `Unknown` is not an empty string or wildcard grant. Prompt or deny whenever
   the value can affect identity, option binding, a path, or another
   policy-sensitive position.
@@ -470,6 +483,26 @@ foreach (var analyzed in occurrence.Arguments)
 Use runtime type patterns rather than a parallel kind enum. Keep a default
 prompt-or-deny branch so a future library-owned alternative cannot be treated
 as safe accidentally.
+
+For example:
+
+```bash
+echo "---EXIT $?---"
+```
+
+produces one argument with this value:
+
+```text
+Concatenation([
+  Exact("---EXIT "),
+  IntegerRange(0, 255),
+  Exact("---")
+])
+```
+
+This proves bounded shell data. It does not prove that an arbitrary receiver
+interprets the value safely. A consumer that only understands exact and finite
+values must take its default prompt-or-deny branch for both new alternatives.
 
 `WorkingDirectory` uses the same domain type, but stable v0.3 publishes only
 `Exact` or `Unknown`. `Exact` means all modeled reachable states agree. A
@@ -528,6 +561,70 @@ The isolated modes are executor assertions, not parser optimizations. With
 the safe default initial-state modes, these ambient-variable-dependent proofs
 remain unknown or make the construct unparseable as specified earlier. A
 consumer must not select an isolated mode merely to obtain a finite set.
+
+### Opt-in authored-source loop facts
+
+Some approval products intentionally authorize the command text the agent
+authored without claiming to reconstruct every ambient Bash attribute or
+`IFS` value. Those consumers can request a separate pre-field-splitting word
+projection:
+
+```csharp
+var parser = new BashParser(new BashParserOptions
+{
+    WorkingDirectory = workingDirectory,
+    PublishAuthoredSourceFacts = true,
+});
+```
+
+Given:
+
+```bash
+for f in src/A.cs src/B.cs; do cat /work/$f; done
+```
+
+the loop-body argument is:
+
+```text
+Value:             Unknown
+AuthoredValue:     FiniteSet("/work/src/A.cs", "/work/src/B.cs")
+AuthoredPathShape: Posix
+```
+
+`AuthoredValue` is the word proved from submitted source before ambient
+attributes, ambient `IFS`, field splitting, and pathname expansion. It is not
+an argv prediction. Enabling the option admits only supported static loops
+that fail on that ambient boundary; computed identities, substitutions,
+explicit source attribute mutation, redirects, and unsupported control flow
+stay strict. With the default `false`, the same loop retains the 0.3.0 result:
+`IsUnparseable=true` with empty `Commands` and `Clauses`.
+
+Choose the projection explicitly per policy-sensitive argument:
+
+```csharp
+var domain = productPolicyAcceptsPreFieldSplittingWords
+    ? analyzed.AuthoredValue
+    : analyzed.Value;
+
+var decision = EvaluateDomain(domain); // recursive and fail closed
+```
+
+`AuthoredPathShape` is lexical evidence only:
+
+| Authored word | Shape |
+|---|---|
+| `/work/src/A.cs` | `Posix` |
+| `C:/work/src/A.cs` | `Windows` |
+| `example/project` | `Posix` |
+| `https://example.invalid/api/v1` | `Unknown` |
+| `bare-name` | `Unknown` |
+
+A repository slug, container image, API route, or other slash-bearing data can
+be path-shaped. Shape may trigger more conservative path review; it never says
+the executable treats the argument as a filesystem operand and never grants
+filesystem authority. PowerShell 0.3.1 sets `AuthoredValue=Value` and
+`AuthoredPathShape=Unknown`, so the shared ingestion surface remains uniform
+without inventing new PowerShell semantics.
 
 Loops also affect later state even when their body facts are static. With an
 incoming cwd of `/work`:

--- a/openspec/changes/v0-3-1-approval-facts/tasks.md
+++ b/openspec/changes/v0-3-1-approval-facts/tasks.md
@@ -74,7 +74,7 @@
 - [x] 7.2 Run tool restore, Release build, full tests, header verification, and
   public API approval.
 - [x] 7.3 Run Release pack and inspect the 0.3.1 package metadata.
-- [ ] 7.4 Obtain adversarial review of API truthfulness, Bash semantics,
+- [x] 7.4 Obtain adversarial review of API truthfulness, Bash semantics,
   sanitization, and consumer misuse boundaries.
 - [ ] 7.5 Push the SemVer tag, verify publish workflow success, and verify the
   package appears on nuget.org before marking release complete.

--- a/openspec/changes/v0-3-1-approval-facts/tasks.md
+++ b/openspec/changes/v0-3-1-approval-facts/tasks.md
@@ -1,79 +1,79 @@
 ## 1. Contract and maintainer decisions
 
-- [ ] 1.1 Approve `AuthoredValue`, `ShellPathShape`, `AuthoredPathShape`,
+- [x] 1.1 Approve `AuthoredValue`, `ShellPathShape`, `AuthoredPathShape`,
   `PublishAuthoredSourceFacts`, `IntegerRange`, and `Concatenation`.
-- [ ] 1.2 Approve Netclaw's use of a pre-field-splitting authored word. Record
+- [x] 1.2 Approve Netclaw's use of a pre-field-splitting authored word. Record
   the ambient attribute, ambient `IFS`, and field-splitting boundary.
-- [ ] 1.3 Update `SPEC.md` public API and bounded-analysis contracts before code.
-- [ ] 1.4 Approve the public API snapshot diff explicitly.
+- [x] 1.3 Update `SPEC.md` public API and bounded-analysis contracts before code.
+- [x] 1.4 Approve the public API snapshot diff explicitly.
 
 ## 2. Bounded value domains
 
-- [ ] 2.1 Add library-owned `IntegerRange` with inclusive-bound validation and
+- [x] 2.1 Add library-owned `IntegerRange` with inclusive-bound validation and
   exact canonical-decimal documentation.
-- [ ] 2.2 Add immutable, flattened `Concatenation` with empty-part removal,
+- [x] 2.2 Add immutable, flattened `Concatenation` with empty-part removal,
   collapse rules, the 16-part cap, and allowed-part validation.
-- [ ] 2.3 Extend internal discriminants, projector validation, equality, and
+- [x] 2.3 Extend internal discriminants, projector validation, equality, and
   public API snapshots without changing existing alternatives.
-- [ ] 2.4 Add construction and malformed-projector tests for every invariant.
+- [x] 2.4 Add construction and malformed-projector tests for every invariant.
 
 ## 3. Quoted Bash status
 
-- [ ] 3.1 Recognize `$?` only in proved single-field double-quoted value
+- [x] 3.1 Recognize `$?` only in proved single-field double-quoted value
   positions.
-- [ ] 3.2 Publish standalone `IntegerRange(0, 255)` and embedded
+- [x] 3.2 Publish standalone `IntegerRange(0, 255)` and embedded
   `Concatenation` without enumeration.
-- [ ] 3.3 Keep unquoted status, command identity, redirects, positional
+- [x] 3.3 Keep unquoted status, command identity, redirects, positional
   parameters, substitutions, and unsupported mixed contexts strict.
-- [ ] 3.4 Add native Bash oracle tests for quoted, unquoted, single-quoted,
+- [x] 3.4 Add native Bash oracle tests for quoted, unquoted, single-quoted,
   embedded, and multiple-expansion forms.
 
 ## 4. Authored-source projection
 
-- [ ] 4.1 Add `AuthoredValue` while preserving the exact released meaning of
+- [x] 4.1 Add `AuthoredValue` while preserving the exact released meaning of
   `Value`.
-- [ ] 4.2 Add the default-false `PublishAuthoredSourceFacts` option and preserve
+- [x] 4.2 Add the default-false `PublishAuthoredSourceFacts` option and preserve
   default `IsUnparseable`, `Commands`, `Clauses`, and completeness results.
-- [ ] 4.3 Reuse the existing loop evaluator to project opt-in pre-field-splitting
+- [x] 4.3 Reuse the existing loop evaluator to project opt-in pre-field-splitting
   authored words; do not duplicate fragment composition.
-- [ ] 4.4 Keep explicit source attribute mutation, hidden execution, dynamic
+- [x] 4.4 Keep explicit source attribute mutation, hidden execution, dynamic
   identity, runtime iteration, and unsupported regions strict.
-- [ ] 4.5 Add default, opt-in, and isolated tests. Cover nameref, integer, `IFS`,
+- [x] 4.5 Add default, opt-in, and isolated tests. Cover nameref, integer, `IFS`,
   field splitting, and option-shaped values.
 
 ## 5. Authored lexical path shape
 
-- [ ] 5.1 Add lexical `ShellPathShape` and `AuthoredPathShape`; do not claim
+- [x] 5.1 Add lexical `ShellPathShape` and `AuthoredPathShape`; do not claim
   filesystem operand semantics.
-- [ ] 5.2 Cover absolute, separator-bearing relative, `./`, `../`, eligible
+- [x] 5.2 Cover absolute, separator-bearing relative, `./`, `../`, eligible
   tilde, quoted-literal tilde, and unknown bare-value cases.
-- [ ] 5.3 Prove D14's pre-field-splitting words while effective values remain
+- [x] 5.3 Prove D14's pre-field-splitting words while effective values remain
   unknown under opt-in default-state mode.
-- [ ] 5.4 Add URI, repository slug, container image, and slash-bearing data
+- [x] 5.4 Add URI, repository slug, container image, and slash-bearing data
   counterexamples.
-- [ ] 5.5 Prove exact PowerShell compatibility: `AuthoredValue=Value` and
+- [x] 5.5 Prove exact PowerShell compatibility: `AuthoredValue=Value` and
   `AuthoredPathShape=Unknown` for literal, dynamic, path, and provider cases.
 
 ## 6. Evidence, corpus, and documentation
 
-- [ ] 6.1 Keep `evidence/approval-matrix.json` byte-identical to the Netclaw
+- [x] 6.1 Keep `evidence/approval-matrix.json` byte-identical to the Netclaw
   artifact and add a parity check to the delivery checklist.
-- [ ] 6.2 Add exact sanitized D02, D10, and D14 executable cases plus adversarial
+- [x] 6.2 Add exact sanitized D02, D10, and D14 executable cases plus adversarial
   boundaries to the Bash corpus or focused tests.
-- [ ] 6.3 Extend the automated PII audit to the OpenSpec evidence JSON and run it
+- [x] 6.3 Extend the automated PII audit to the OpenSpec evidence JSON and run it
   with zero hits.
-- [ ] 6.4 Update `docs/CONSUMER_GUIDE.md` with input/output examples and a
+- [x] 6.4 Update `docs/CONSUMER_GUIDE.md` with input/output examples and a
   fail-closed recursive domain switch.
-- [ ] 6.5 Update `IMPLEMENTATION_PLAN.md`, `RELEASE_NOTES.md`, and version
+- [x] 6.5 Update `IMPLEMENTATION_PLAN.md`, `RELEASE_NOTES.md`, and version
   metadata for 0.3.1.
 
 ## 7. Validation and release
 
-- [ ] 7.1 Run `openspec validate v0-3-1-approval-facts --type change --strict
+- [x] 7.1 Run `openspec validate v0-3-1-approval-facts --type change --strict
   --no-interactive` before implementation and before delivery.
-- [ ] 7.2 Run tool restore, Release build, full tests, header verification, and
+- [x] 7.2 Run tool restore, Release build, full tests, header verification, and
   public API approval.
-- [ ] 7.3 Run Release pack and inspect the 0.3.1 package metadata.
+- [x] 7.3 Run Release pack and inspect the 0.3.1 package metadata.
 - [ ] 7.4 Obtain adversarial review of API truthfulness, Bash semantics,
   sanitization, and consumer misuse boundaries.
 - [ ] 7.5 Push the SemVer tag, verify publish workflow success, and verify the

--- a/src/ShellSyntaxTree/BashParserOptions.cs
+++ b/src/ShellSyntaxTree/BashParserOptions.cs
@@ -33,4 +33,10 @@ public sealed record BashParserOptions : ShellParserOptions
     /// fails bounded loop-variable analysis closed.
     /// </summary>
     public BashInitialStateMode InitialStateMode { get; init; }
+
+    /// <summary>
+    /// Gets whether bounded facts proved from authored source may be published
+    /// separately from effective runtime-value facts. The default is false.
+    /// </summary>
+    public bool PublishAuthoredSourceFacts { get; init; }
 }

--- a/src/ShellSyntaxTree/CommandOccurrence.cs
+++ b/src/ShellSyntaxTree/CommandOccurrence.cs
@@ -157,7 +157,29 @@ public sealed record AnalyzedArgument
     /// <summary>Gets the effective shell-value proof.</summary>
     public ShellValueDomain Value { get; internal init; } = null!;
 
+    /// <summary>
+    /// Gets the bounded authored word before field splitting and pathname
+    /// expansion. This is not an effective argv-value claim.
+    /// </summary>
+    public ShellValueDomain AuthoredValue { get; internal init; } = null!;
+
+    /// <summary>Gets the authored word's uniform lexical path shape.</summary>
+    public ShellPathShape AuthoredPathShape { get; internal init; }
+
     internal bool HasEffectiveValue { get; init; }
+}
+
+/// <summary>Describes a shell word's lexical path shape.</summary>
+public enum ShellPathShape
+{
+    /// <summary>No uniform lexical path shape is proved.</summary>
+    Unknown,
+
+    /// <summary>A POSIX path-shaped word is proved.</summary>
+    Posix,
+
+    /// <summary>A Windows path-shaped word is proved.</summary>
+    Windows,
 }
 
 internal sealed record EffectiveArgument
@@ -236,6 +258,47 @@ public abstract record ShellValueDomain
         public new IReadOnlyList<string> Values { get; }
     }
 
+    /// <summary>An inclusive range of canonical signed decimal integers.</summary>
+    public sealed record IntegerRange : ShellValueDomain
+    {
+        internal IntegerRange(long minimumInclusive, long maximumInclusive)
+        {
+            if (minimumInclusive > maximumInclusive)
+            {
+                throw new ArgumentOutOfRangeException(nameof(minimumInclusive));
+            }
+
+            MinimumInclusive = minimumInclusive;
+            MaximumInclusive = maximumInclusive;
+        }
+
+        private protected override object LibraryOwnership => this;
+
+        internal override ShellValueDomainKind InternalKind =>
+            ShellValueDomainKind.IntegerRange;
+
+        /// <summary>Gets the inclusive lower bound.</summary>
+        public long MinimumInclusive { get; }
+
+        /// <summary>Gets the inclusive upper bound.</summary>
+        public long MaximumInclusive { get; }
+    }
+
+    /// <summary>A bounded concatenation of independently proved parts.</summary>
+    public sealed record Concatenation : ShellValueDomain
+    {
+        internal Concatenation(IReadOnlyList<ShellValueDomain> parts) =>
+            Parts = PublicCollection.Copy(parts);
+
+        private protected override object LibraryOwnership => this;
+
+        internal override ShellValueDomainKind InternalKind =>
+            ShellValueDomainKind.Concatenation;
+
+        /// <summary>Gets the two through 16 normalized parts.</summary>
+        public IReadOnlyList<ShellValueDomain> Parts { get; }
+    }
+
     /// <summary>A bounded path pattern and its conservative covering directory.</summary>
     public sealed record PathPattern : ShellValueDomain
     {
@@ -267,6 +330,8 @@ internal enum ShellValueDomainKind
     Exact,
     FiniteSet,
     Pattern,
+    IntegerRange,
+    Concatenation,
 }
 
 internal static class ShellValueDomains
@@ -280,4 +345,10 @@ internal static class ShellValueDomains
 
     internal static ShellValueDomain Pattern(string pattern, string coveringDirectory) =>
         new ShellValueDomain.PathPattern(pattern, coveringDirectory);
+
+    internal static ShellValueDomain IntegerRange(long minimumInclusive, long maximumInclusive) =>
+        new ShellValueDomain.IntegerRange(minimumInclusive, maximumInclusive);
+
+    internal static ShellValueDomain Concatenation(IReadOnlyList<ShellValueDomain> parts) =>
+        new ShellValueDomain.Concatenation(parts);
 }

--- a/src/ShellSyntaxTree/Internal/Bash/Parsing/BashAbstractStateAnalyzer.cs
+++ b/src/ShellSyntaxTree/Internal/Bash/Parsing/BashAbstractStateAnalyzer.cs
@@ -27,6 +27,8 @@ internal sealed class BashAbstractStateAnalyzer
         new(ClauseReferenceComparer.Instance);
     private readonly Dictionary<Clause, Dictionary<int, ShellValueDomainFacts>>
         _effectiveArguments = new(ClauseReferenceComparer.Instance);
+    private readonly Dictionary<Clause, Dictionary<int, ShellValueDomainFacts>>
+        _authoredArguments = new(ClauseReferenceComparer.Instance);
     private readonly Dictionary<Clause, HashSet<int>> _cwdResolutionSanitization =
         new(ClauseReferenceComparer.Instance);
     private readonly List<BashForInAnalysisPlanReference> _rewrittenForInPlans = new();
@@ -468,6 +470,20 @@ internal sealed class BashAbstractStateAnalyzer
         var evaluator = input.Bindings;
         foreach (var provenance in sourceFacts.ValueProvenance)
         {
+            var dependsOnTrackedBinding =
+                input.Bindings.ReferencesTrackedBinding(provenance.Value);
+            if (PublishesAuthoredFactsOnly && dependsOnTrackedBinding)
+            {
+                var authoredValue = NormalizeAuthoredParserKnownFragments(provenance.Value);
+                evaluator.TryAnalyzeAuthoredValue(authoredValue, out var authoredDomain);
+                AccumulateArgumentDomain(
+                    _authoredArguments,
+                    simple.Clause,
+                    provenance.ClauseElementIndex,
+                    authoredDomain);
+                continue;
+            }
+
             var hasStateDependentValue = evaluator.TryAnalyzeEffectiveValue(
                 provenance.Value,
                 out var domain);
@@ -490,15 +506,70 @@ internal sealed class BashAbstractStateAnalyzer
             }
 
             accumulated ??= GetEffectiveArguments(simple.Clause);
-            if (accumulated.TryGetValue(provenance.ClauseElementIndex, out var prior))
+            AccumulateArgumentDomain(
+                accumulated,
+                provenance.ClauseElementIndex,
+                domain);
+        }
+    }
+
+    private ShellValue NormalizeAuthoredParserKnownFragments(ShellValue value)
+    {
+        var homeDirectory = BashResolver.GetHomeDirectory(_options);
+        var builder = new ShellValueBuilder();
+        for (var index = 0; index < value.Fragments.Count; index++)
+        {
+            var fragment = value.Fragments[index];
+            if (fragment.Kind == ShellValueFragmentKind.Expansion &&
+                fragment.Expansion is { Kind: ShellExpansionKind.Tilde })
             {
-                accumulated[provenance.ClauseElementIndex] =
-                    BashLoopBindingContext.JoinDomains(prior, domain);
+                var kind = BashResolver.ClassifyTildeExpansion(value, index);
+                if (kind == BashTildeExpansionKind.Home && homeDirectory.Length > 0)
+                {
+                    builder.AppendLiteral(homeDirectory, null, null);
+                    continue;
+                }
+
+                if (kind == BashTildeExpansionKind.Literal)
+                {
+                    builder.AppendLiteral(fragment.Value, null, null);
+                    continue;
+                }
             }
-            else
-            {
-                accumulated.Add(provenance.ClauseElementIndex, domain);
-            }
+
+            builder.Append(fragment);
+        }
+
+        return builder.Build();
+    }
+
+    private static void AccumulateArgumentDomain(
+        Dictionary<Clause, Dictionary<int, ShellValueDomainFacts>> arguments,
+        Clause clause,
+        int elementIndex,
+        ShellValueDomainFacts domain)
+    {
+        if (!arguments.TryGetValue(clause, out var accumulated))
+        {
+            accumulated = new Dictionary<int, ShellValueDomainFacts>();
+            arguments.Add(clause, accumulated);
+        }
+
+        AccumulateArgumentDomain(accumulated, elementIndex, domain);
+    }
+
+    private static void AccumulateArgumentDomain(
+        IDictionary<int, ShellValueDomainFacts> accumulated,
+        int elementIndex,
+        ShellValueDomainFacts domain)
+    {
+        if (accumulated.TryGetValue(elementIndex, out var prior))
+        {
+            accumulated[elementIndex] = BashLoopBindingContext.JoinDomains(prior, domain);
+        }
+        else
+        {
+            accumulated.Add(elementIndex, domain);
         }
     }
 
@@ -551,7 +622,8 @@ internal sealed class BashAbstractStateAnalyzer
         out ShellValueDomainFacts domain)
     {
         var homeDirectory = BashResolver.GetHomeDirectory(_options);
-        var composed = new StringBuilder(value.Decoded.Length);
+        var literal = new StringBuilder(value.Decoded.Length);
+        var parts = new List<ShellValueDomainFacts>();
         for (var fragmentIndex = 0;
              fragmentIndex < value.Fragments.Count;
              fragmentIndex++)
@@ -559,7 +631,7 @@ internal sealed class BashAbstractStateAnalyzer
             var fragment = value.Fragments[fragmentIndex];
             if (fragment.Kind == ShellValueFragmentKind.Literal)
             {
-                composed.Append(fragment.Value);
+                literal.Append(fragment.Value);
                 continue;
             }
 
@@ -573,7 +645,7 @@ internal sealed class BashAbstractStateAnalyzer
             if (expansion.Kind == ShellExpansionKind.Glob &&
                 (fragment.AllowedTransforms & ShellLexicalTransform.Glob) == 0)
             {
-                composed.Append(fragment.Value);
+                literal.Append(fragment.Value);
                 continue;
             }
 
@@ -582,7 +654,7 @@ internal sealed class BashAbstractStateAnalyzer
                 var tildeKind = BashResolver.ClassifyTildeExpansion(value, fragmentIndex);
                 if (tildeKind == BashTildeExpansionKind.Literal)
                 {
-                    composed.Append(fragment.Value);
+                    literal.Append(fragment.Value);
                     continue;
                 }
 
@@ -593,7 +665,14 @@ internal sealed class BashAbstractStateAnalyzer
                     return false;
                 }
 
-                composed.Append(homeDirectory);
+                literal.Append(homeDirectory);
+                continue;
+            }
+
+            if (IsQuotedExitStatus(fragment, expansion))
+            {
+                FlushLiteralPart(literal, parts);
+                parts.Add(ShellValueDomainFacts.IntegerRange(0, 255));
                 continue;
             }
 
@@ -609,15 +688,38 @@ internal sealed class BashAbstractStateAnalyzer
                 return false;
             }
 
-            composed.Append(homeDirectory);
+            literal.Append(homeDirectory);
         }
 
-        domain = new ShellValueDomainFacts
+        FlushLiteralPart(literal, parts);
+        domain = ShellValueDomainFacts.Concatenate(parts);
+        return true;
+    }
+
+    private static bool IsQuotedExitStatus(
+        ShellValueFragment fragment,
+        ShellExpansionReference expansion) =>
+        expansion.Kind == ShellExpansionKind.SpecialParameter &&
+        string.Equals(expansion.Name, "?", StringComparison.Ordinal) &&
+        fragment.Cardinality == ShellValueCardinality.ExactlyOne &&
+        (fragment.AllowedTransforms & ShellLexicalTransform.Variable) != 0 &&
+        (fragment.AllowedTransforms & ShellLexicalTransform.FieldSplit) == 0;
+
+    private static void FlushLiteralPart(
+        StringBuilder literal,
+        ICollection<ShellValueDomainFacts> parts)
+    {
+        if (literal.Length == 0)
+        {
+            return;
+        }
+
+        parts.Add(new ShellValueDomainFacts
         {
             Kind = ShellValueDomainKind.Exact,
-            Values = new[] { composed.ToString() },
-        };
-        return true;
+            Values = new[] { literal.ToString() },
+        });
+        literal.Clear();
     }
 
     private static bool ContainsFieldSplitOrGlobCharacter(string value)
@@ -789,6 +891,20 @@ internal sealed class BashAbstractStateAnalyzer
         {
             _isComplete = false;
             return new BashFlowResult(null, null);
+        }
+
+        if (PublishesAuthoredFactsOnly)
+        {
+            foreach (var argumentValue in argumentValues)
+            {
+                if (!input.Bindings.ReferencesTrackedBinding(argumentValue))
+                {
+                    continue;
+                }
+
+                RecordCwdResolutionSanitization(simple.Clause, argumentElementIndices);
+                return BashFlowResult.Both(input.WithUnknownCwd());
+            }
         }
 
         foreach (var argumentValue in argumentValues)
@@ -1378,10 +1494,13 @@ internal sealed class BashAbstractStateAnalyzer
             sourceFacts.Redirects,
             sourceFacts.RedirectTargetProvenance,
             input.Bindings,
-            clause);
+            clause,
+            allowBindingValues: !PublishesAuthoredFactsOnly);
         facts.Add(clause, new CommandOccurrenceFacts
         {
             EffectiveArguments = CreateEffectiveArguments(simple.Clause),
+            AuthoredArguments = CreateAuthoredArguments(simple.Clause),
+            PublishAuthoredPathShape = true,
             WorkingDirectory = input.ToDomain(),
             Redirects = redirects,
             RedirectTargetProvenance = sourceFacts.RedirectTargetProvenance,
@@ -1397,8 +1516,16 @@ internal sealed class BashAbstractStateAnalyzer
     }
 
     private IReadOnlyList<EffectiveArgumentFacts> CreateEffectiveArguments(Clause clause)
+        => CreateArguments(_effectiveArguments, clause);
+
+    private IReadOnlyList<EffectiveArgumentFacts> CreateAuthoredArguments(Clause clause)
+        => CreateArguments(_authoredArguments, clause);
+
+    private static IReadOnlyList<EffectiveArgumentFacts> CreateArguments(
+        IReadOnlyDictionary<Clause, Dictionary<int, ShellValueDomainFacts>> source,
+        Clause clause)
     {
-        if (!_effectiveArguments.TryGetValue(clause, out var accumulated) ||
+        if (!source.TryGetValue(clause, out var accumulated) ||
             accumulated.Count == 0)
         {
             return Array.Empty<EffectiveArgumentFacts>();
@@ -1609,7 +1736,8 @@ internal sealed class BashAbstractStateAnalyzer
         IReadOnlyList<RedirectAnalysisFacts> source,
         IReadOnlyList<RedirectTargetProvenance> provenance,
         BashLoopBindingContext bindings,
-        Clause clause)
+        Clause clause,
+        bool allowBindingValues)
     {
         if (source.Count == 0)
         {
@@ -1627,7 +1755,8 @@ internal sealed class BashAbstractStateAnalyzer
                     Target = RewriteHereStringTarget(
                         fact,
                         provenance,
-                        bindings),
+                        bindings,
+                        allowBindingValues),
                 };
                 continue;
             }
@@ -1660,13 +1789,18 @@ internal sealed class BashAbstractStateAnalyzer
     private static ShellValueDomainFacts RewriteHereStringTarget(
         RedirectAnalysisFacts fact,
         IReadOnlyList<RedirectTargetProvenance> provenance,
-        BashLoopBindingContext bindings)
+        BashLoopBindingContext bindings,
+        bool allowBindingValues)
     {
         foreach (var candidate in provenance)
         {
             if (candidate.RedirectIndex != fact.RedirectIndex)
             {
                 continue;
+            }
+            if (!allowBindingValues && bindings.ReferencesTrackedBinding(candidate.Value))
+            {
+                return ShellValueDomainFacts.Unknown;
             }
 
             if (!bindings.TryAnalyzeEffectiveValue(candidate.Value, out var domain))
@@ -1900,7 +2034,13 @@ internal sealed class BashAbstractStateAnalyzer
     {
         HomeDirectory = _options.HomeDirectory,
         WorkingDirectory = state.WorkingDirectory ?? _options.WorkingDirectory,
+        InitialStateMode = _options.InitialStateMode,
+        PublishAuthoredSourceFacts = _options.PublishAuthoredSourceFacts,
     };
+
+    private bool PublishesAuthoredFactsOnly =>
+        _options.PublishAuthoredSourceFacts &&
+        _options.InitialStateMode != BashInitialStateMode.IsolatedNonInteractive;
 
     private static Arg CreateAttribution(BashAbstractState state) =>
         state.WorkingDirectory is null

--- a/src/ShellSyntaxTree/Internal/Bash/Parsing/BashAbstractStateAnalyzer.cs
+++ b/src/ShellSyntaxTree/Internal/Bash/Parsing/BashAbstractStateAnalyzer.cs
@@ -472,7 +472,7 @@ internal sealed class BashAbstractStateAnalyzer
         {
             var dependsOnTrackedBinding =
                 input.Bindings.ReferencesTrackedBinding(provenance.Value);
-            if (PublishesAuthoredFactsOnly && dependsOnTrackedBinding)
+            if (_options.PublishAuthoredSourceFacts && dependsOnTrackedBinding)
             {
                 var authoredValue = NormalizeAuthoredParserKnownFragments(provenance.Value);
                 evaluator.TryAnalyzeAuthoredValue(authoredValue, out var authoredDomain);
@@ -481,7 +481,10 @@ internal sealed class BashAbstractStateAnalyzer
                     simple.Clause,
                     provenance.ClauseElementIndex,
                     authoredDomain);
-                continue;
+                if (PublishesAuthoredFactsOnly)
+                {
+                    continue;
+                }
             }
 
             var hasStateDependentValue = evaluator.TryAnalyzeEffectiveValue(

--- a/src/ShellSyntaxTree/Internal/Bash/Parsing/BashLoopAnalysis.cs
+++ b/src/ShellSyntaxTree/Internal/Bash/Parsing/BashLoopAnalysis.cs
@@ -415,32 +415,21 @@ internal sealed class BashLoopBindingContext
 
     private static bool DomainEquals(
         ShellValueDomainFacts left,
-        ShellValueDomainFacts right)
-    {
-        if (left.Kind != right.Kind ||
-            !string.Equals(left.Pattern, right.Pattern, StringComparison.Ordinal) ||
-            !string.Equals(
-                left.CoveringDirectory,
-                right.CoveringDirectory,
-                StringComparison.Ordinal) ||
-            left.Values.Count != right.Values.Count)
-        {
-            return false;
-        }
-
-        for (var index = 0; index < left.Values.Count; index++)
-        {
-            if (!string.Equals(left.Values[index], right.Values[index], StringComparison.Ordinal))
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
+        ShellValueDomainFacts right) => ShellValueDomainFacts.AreEqual(left, right);
 
     internal bool TryAnalyzeEffectiveValue(
         ShellValue value,
+        out ShellValueDomainFacts domain) =>
+        TryAnalyzeValue(value, ignoreFieldSplitting: false, out domain);
+
+    internal bool TryAnalyzeAuthoredValue(
+        ShellValue value,
+        out ShellValueDomainFacts domain) =>
+        TryAnalyzeValue(value, ignoreFieldSplitting: true, out domain);
+
+    private bool TryAnalyzeValue(
+        ShellValue value,
+        bool ignoreFieldSplitting,
         out ShellValueDomainFacts domain)
     {
         var referenced = new List<BindingFrame>();
@@ -462,6 +451,7 @@ internal sealed class BashLoopBindingContext
                 }
 
                 if (fragment.Cardinality != ShellValueCardinality.ExactlyOne ||
+                    !ignoreFieldSplitting &&
                     (fragment.AllowedTransforms & ShellLexicalTransform.FieldSplit) != 0)
                 {
                     dependentButUnsupported = true;

--- a/src/ShellSyntaxTree/Internal/Bash/Parsing/BashStructuralCoordinator.cs
+++ b/src/ShellSyntaxTree/Internal/Bash/Parsing/BashStructuralCoordinator.cs
@@ -570,6 +570,7 @@ internal static partial class BashCommandParser
                     HomeDirectory = _options.HomeDirectory,
                     WorkingDirectory = _attribution.ResolvedCwd,
                     InitialStateMode = _options.InitialStateMode,
+                    PublishAuthoredSourceFacts = _options.PublishAuthoredSourceFacts,
                 };
             }
             else if (_attribution.IsDynamic)
@@ -629,7 +630,8 @@ internal static partial class BashCommandParser
 
             if (ContainsNamedParameterExpansion(segmentTokens) &&
                 (_options.InitialStateMode != BashInitialStateMode.IsolatedNonInteractive ||
-                 _hasUnmodeledVariableStateMutation))
+                 _hasUnmodeledVariableStateMutation) &&
+                !CanPublishActiveLoopBindingFacts(segmentTokens))
             {
                 error = "Bash named parameter expansion requires proved variable-attribute state";
                 return false;
@@ -729,7 +731,8 @@ internal static partial class BashCommandParser
             }
 
             var bindingToken = _tokens[_position++];
-            if (_options.InitialStateMode != BashInitialStateMode.IsolatedNonInteractive)
+            if (_options.InitialStateMode != BashInitialStateMode.IsolatedNonInteractive &&
+                !_options.PublishAuthoredSourceFacts)
             {
                 error = "Bash for-in requires a proved isolated non-interactive initial state";
                 return false;
@@ -1037,6 +1040,7 @@ internal static partial class BashCommandParser
                     HomeDirectory = _options.HomeDirectory,
                     WorkingDirectory = _attribution.ResolvedCwd,
                     InitialStateMode = _options.InitialStateMode,
+                    PublishAuthoredSourceFacts = _options.PublishAuthoredSourceFacts,
                 }
                 : _options;
 
@@ -1716,6 +1720,47 @@ internal static partial class BashCommandParser
             }
 
             return false;
+        }
+
+        private bool CanPublishActiveLoopBindingFacts(IReadOnlyList<BashToken> tokens)
+        {
+            if (!_options.PublishAuthoredSourceFacts ||
+                _hasUnmodeledVariableStateMutation ||
+                _activeLoopBindings.Count == 0)
+            {
+                return false;
+            }
+
+            var sawBinding = false;
+            foreach (var token in tokens)
+            {
+                foreach (var value in new[] { token.ResolverValue, token.HeredocBodyValue })
+                {
+                    if (value is null)
+                    {
+                        continue;
+                    }
+
+                    foreach (var fragment in value.Fragments)
+                    {
+                        if (fragment.Kind != ShellValueFragmentKind.Expansion ||
+                            fragment.Expansion is not
+                            { Kind: ShellExpansionKind.Variable, Name: { } name })
+                        {
+                            continue;
+                        }
+
+                        if (!_activeLoopBindings.Contains(name))
+                        {
+                            return false;
+                        }
+
+                        sawBinding = true;
+                    }
+                }
+            }
+
+            return sawBinding;
         }
 
         private static bool IsPotentialVariableStateMutation(Clause clause)

--- a/src/ShellSyntaxTree/Internal/Pwsh/Parsing/PwshForEachValueAnalysis.cs
+++ b/src/ShellSyntaxTree/Internal/Pwsh/Parsing/PwshForEachValueAnalysis.cs
@@ -6069,26 +6069,7 @@ internal sealed class PwshForEachValueAnalyzer
 
         private static bool DomainEquals(
             ShellValueDomainFacts left,
-            ShellValueDomainFacts right)
-        {
-            if (left.Kind != right.Kind || left.Values.Count != right.Values.Count)
-            {
-                return false;
-            }
-
-            for (var index = 0; index < left.Values.Count; index++)
-            {
-                if (!string.Equals(
-                        left.Values[index],
-                        right.Values[index],
-                        StringComparison.Ordinal))
-                {
-                    return false;
-                }
-            }
-
-            return true;
-        }
+            ShellValueDomainFacts right) => ShellValueDomainFacts.AreEqual(left, right);
 
         private static bool ContainsReference(
             IReadOnlyList<BindingFrame> bindings,

--- a/src/ShellSyntaxTree/ShellSyntaxProjection.cs
+++ b/src/ShellSyntaxTree/ShellSyntaxProjection.cs
@@ -19,6 +19,11 @@ internal sealed class CommandOccurrenceFacts
     internal IReadOnlyList<EffectiveArgumentFacts> EffectiveArguments { get; init; } =
         Array.Empty<EffectiveArgumentFacts>();
 
+    internal IReadOnlyList<EffectiveArgumentFacts> AuthoredArguments { get; init; } =
+        Array.Empty<EffectiveArgumentFacts>();
+
+    internal bool PublishAuthoredPathShape { get; init; }
+
     internal ShellValueDomainFacts WorkingDirectory { get; init; } = ShellValueDomainFacts.Unknown;
 
     internal IReadOnlyList<RedirectAnalysisFacts> Redirects { get; init; } =
@@ -36,6 +41,156 @@ internal sealed class CommandOccurrenceFacts
     internal bool HasCompleteValueProvenance { get; init; }
 
     internal bool IsComplete { get; init; }
+}
+
+internal static class ShellPathShapeClassifier
+{
+    internal static ShellPathShape Classify(ShellValueDomain domain) => domain switch
+    {
+        ShellValueDomain.Exact exact => ClassifyWord(exact.Value),
+        ShellValueDomain.FiniteSet finite => ClassifyWords(finite.Values),
+        ShellValueDomain.Concatenation concatenation => ClassifyConcatenation(
+            concatenation.Parts),
+        _ => ShellPathShape.Unknown,
+    };
+
+    private static ShellPathShape ClassifyWords(IReadOnlyList<string> words)
+    {
+        var shape = ShellPathShape.Unknown;
+        for (var index = 0; index < words.Count; index++)
+        {
+            var candidate = ClassifyWord(words[index]);
+            if (candidate == ShellPathShape.Unknown)
+            {
+                return ShellPathShape.Unknown;
+            }
+
+            if (shape != ShellPathShape.Unknown && shape != candidate)
+            {
+                return ShellPathShape.Unknown;
+            }
+
+            shape = candidate;
+        }
+
+        return shape;
+    }
+
+    private static ShellPathShape ClassifyConcatenation(
+        IReadOnlyList<ShellValueDomain> parts)
+    {
+        var prefix = parts.Count == 0 ? null : parts[0] as ShellValueDomain.Exact;
+        if (prefix is null)
+        {
+            return ShellPathShape.Unknown;
+        }
+
+        var shape = ClassifyWordPrefix(prefix.Value);
+        if (shape != ShellPathShape.Posix)
+        {
+            return shape;
+        }
+
+        for (var index = 1; index < parts.Count; index++)
+        {
+            if (CanContainBackslash(parts[index]))
+            {
+                return ShellPathShape.Unknown;
+            }
+        }
+
+        return ShellPathShape.Posix;
+    }
+
+    private static bool CanContainBackslash(ShellValueDomain domain) => domain switch
+    {
+        ShellValueDomain.Exact exact => exact.Value.IndexOf('\\') >= 0,
+        ShellValueDomain.FiniteSet finite => AnyContainsBackslash(finite.Values),
+        ShellValueDomain.IntegerRange => false,
+        _ => true,
+    };
+
+    private static bool AnyContainsBackslash(IReadOnlyList<string> values)
+    {
+        for (var index = 0; index < values.Count; index++)
+        {
+            if (values[index].IndexOf('\\') >= 0)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static ShellPathShape ClassifyWordPrefix(string value)
+    {
+        var shape = ClassifyWord(value);
+        if (shape != ShellPathShape.Unknown)
+        {
+            return shape;
+        }
+
+        return value.EndsWith("/", StringComparison.Ordinal)
+            ? ShellPathShape.Posix
+            : value.EndsWith("\\", StringComparison.Ordinal)
+                ? ShellPathShape.Windows
+                : ShellPathShape.Unknown;
+    }
+
+    private static ShellPathShape ClassifyWord(string value)
+    {
+        if (LooksLikeUri(value))
+        {
+            return ShellPathShape.Unknown;
+        }
+
+        if (LooksLikeWindowsPath(value))
+        {
+            return ShellPathShape.Windows;
+        }
+
+        return value.StartsWith("/", StringComparison.Ordinal) ||
+               value.StartsWith("./", StringComparison.Ordinal) ||
+               value.StartsWith("../", StringComparison.Ordinal) ||
+               value.StartsWith("~/", StringComparison.Ordinal) ||
+               value.IndexOf('/') >= 0
+            ? ShellPathShape.Posix
+            : ShellPathShape.Unknown;
+    }
+
+    private static bool LooksLikeUri(string value)
+    {
+        var separator = value.IndexOf("://", StringComparison.Ordinal);
+        if (separator <= 0 || !IsAsciiLetter(value[0]))
+        {
+            return false;
+        }
+
+        for (var index = 1; index < separator; index++)
+        {
+            var character = value[index];
+            if (!IsAsciiLetter(character) &&
+                !char.IsDigit(character) &&
+                character is not '+' and not '-' and not '.')
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool LooksLikeWindowsPath(string value) =>
+        value.IndexOf('\\') >= 0 ||
+        value.StartsWith("//", StringComparison.Ordinal) ||
+        value.Length >= 3 &&
+        IsAsciiLetter(value[0]) &&
+        value[1] == ':' &&
+        (value[2] == '/' || value[2] == '\\');
+
+    private static bool IsAsciiLetter(char value) =>
+        value is >= 'A' and <= 'Z' or >= 'a' and <= 'z';
 }
 
 internal sealed record EffectiveArgumentFacts
@@ -56,6 +211,172 @@ internal sealed record ShellValueDomainFacts
     internal string? Pattern { get; init; }
 
     internal string? CoveringDirectory { get; init; }
+
+    internal long MinimumInclusive { get; init; }
+
+    internal long MaximumInclusive { get; init; }
+
+    internal IReadOnlyList<ShellValueDomainFacts> Parts { get; init; } =
+        Array.Empty<ShellValueDomainFacts>();
+
+    internal static ShellValueDomainFacts IntegerRange(
+        long minimumInclusive,
+        long maximumInclusive) => minimumInclusive <= maximumInclusive
+        ? new ShellValueDomainFacts
+        {
+            Kind = ShellValueDomainKind.IntegerRange,
+            MinimumInclusive = minimumInclusive,
+            MaximumInclusive = maximumInclusive,
+        }
+        : Unknown;
+
+    internal static ShellValueDomainFacts Concatenate(
+        IReadOnlyList<ShellValueDomainFacts> source)
+    {
+        var normalized = new List<ShellValueDomainFacts>(source.Count);
+        for (var index = 0; index < source.Count; index++)
+        {
+            var part = source[index];
+            if (!IsAllowedConcatenationPart(part))
+            {
+                return Unknown;
+            }
+
+            if (part.Kind == ShellValueDomainKind.Exact)
+            {
+                var value = part.Values[0];
+                if (value.Length == 0)
+                {
+                    continue;
+                }
+
+                if (normalized.Count > 0 &&
+                    normalized[normalized.Count - 1].Kind == ShellValueDomainKind.Exact)
+                {
+                    var previous = normalized[normalized.Count - 1].Values[0];
+                    normalized[normalized.Count - 1] = new ShellValueDomainFacts
+                    {
+                        Kind = ShellValueDomainKind.Exact,
+                        Values = new[] { previous + value },
+                    };
+                    continue;
+                }
+            }
+
+            normalized.Add(part);
+            if (normalized.Count > 16)
+            {
+                return Unknown;
+            }
+        }
+
+        if (normalized.Count == 0)
+        {
+            return new ShellValueDomainFacts
+            {
+                Kind = ShellValueDomainKind.Exact,
+                Values = new[] { string.Empty },
+            };
+        }
+
+        if (normalized.Count == 1)
+        {
+            return normalized[0];
+        }
+
+        return new ShellValueDomainFacts
+        {
+            Kind = ShellValueDomainKind.Concatenation,
+            Parts = normalized.ToArray(),
+        };
+    }
+
+    private static bool IsAllowedConcatenationPart(ShellValueDomainFacts part)
+    {
+        if (part.Values is null || part.Parts is null)
+        {
+            return false;
+        }
+
+        return part.Kind switch
+        {
+            ShellValueDomainKind.Exact =>
+                part.Values.Count == 1 &&
+                part.Values[0] is not null &&
+                part.Pattern is null &&
+                part.CoveringDirectory is null &&
+                part.Parts.Count == 0 &&
+                part.MinimumInclusive == 0 &&
+                part.MaximumInclusive == 0,
+            ShellValueDomainKind.FiniteSet =>
+                part.Values.Count >= 2 &&
+                part.Values.Count <= ShellAnalysisLimits.MaxValueCandidates &&
+                HasDistinctNonNullValues(part.Values) &&
+                part.Pattern is null &&
+                part.CoveringDirectory is null &&
+                part.Parts.Count == 0 &&
+                part.MinimumInclusive == 0 &&
+                part.MaximumInclusive == 0,
+            ShellValueDomainKind.IntegerRange =>
+                part.Values.Count == 0 &&
+                part.Pattern is null &&
+                part.CoveringDirectory is null &&
+                part.Parts.Count == 0 &&
+                part.MinimumInclusive <= part.MaximumInclusive,
+            _ => false,
+        };
+    }
+
+    private static bool HasDistinctNonNullValues(IReadOnlyList<string> values)
+    {
+        var distinct = new HashSet<string>(StringComparer.Ordinal);
+        for (var index = 0; index < values.Count; index++)
+        {
+            if (values[index] is null || !distinct.Add(values[index]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    internal static bool AreEqual(
+        ShellValueDomainFacts left,
+        ShellValueDomainFacts right)
+    {
+        if (left.Kind != right.Kind ||
+            left.MinimumInclusive != right.MinimumInclusive ||
+            left.MaximumInclusive != right.MaximumInclusive ||
+            !string.Equals(left.Pattern, right.Pattern, StringComparison.Ordinal) ||
+            !string.Equals(
+                left.CoveringDirectory,
+                right.CoveringDirectory,
+                StringComparison.Ordinal) ||
+            left.Values.Count != right.Values.Count ||
+            left.Parts.Count != right.Parts.Count)
+        {
+            return false;
+        }
+
+        for (var index = 0; index < left.Values.Count; index++)
+        {
+            if (!string.Equals(left.Values[index], right.Values[index], StringComparison.Ordinal))
+            {
+                return false;
+            }
+        }
+
+        for (var index = 0; index < left.Parts.Count; index++)
+        {
+            if (!AreEqual(left.Parts[index], right.Parts[index]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }
 
 /// <summary>
@@ -572,14 +893,17 @@ internal static class ShellSyntaxProjection
             redirects = Array.Empty<RedirectAnalysis>();
             if (facts is null ||
                 facts.EffectiveArguments is null ||
+                facts.AuthoredArguments is null ||
                 facts.WorkingDirectory is null ||
                 facts.Redirects is null ||
                 ContainsNull(facts.EffectiveArguments) ||
+                ContainsNull(facts.AuthoredArguments) ||
                 ContainsNull(facts.Redirects) ||
                 !IsValidValueDomain(facts.WorkingDirectory) ||
                 facts.WorkingDirectory.Kind is not (
                     ShellValueDomainKind.Unknown or ShellValueDomainKind.Exact) ||
                 !AreValidEffectiveArguments(clause, facts.EffectiveArguments) ||
+                !AreValidEffectiveArguments(clause, facts.AuthoredArguments) ||
                 !AreValidRedirects(clause, facts.Redirects, facts.IsComplete) ||
                 facts.IsComplete &&
                 (clause.Verb.IsDynamic || clause.Verb.Tokens.Count == 0))
@@ -591,6 +915,8 @@ internal static class ShellSyntaxProjection
             return TryCreateAnalyzedArguments(
                     clause,
                     facts.EffectiveArguments,
+                    facts.AuthoredArguments,
+                    facts.PublishAuthoredPathShape,
                     out arguments) &&
                 TryCreateRedirectAnalyses(clause, facts.Redirects, out redirects);
         }
@@ -610,6 +936,8 @@ internal static class ShellSyntaxProjection
         private static bool TryCreateAnalyzedArguments(
             Clause clause,
             IReadOnlyList<EffectiveArgumentFacts> effective,
+            IReadOnlyList<EffectiveArgumentFacts> authored,
+            bool publishAuthoredPathShape,
             out IReadOnlyList<AnalyzedArgument> arguments)
         {
             arguments = Array.Empty<AnalyzedArgument>();
@@ -640,6 +968,12 @@ internal static class ShellSyntaxProjection
             for (var index = 0; index < effective.Count; index++)
             {
                 domains.Add(effective[index].ClauseElementIndex, effective[index].Value);
+            }
+
+            var authoredDomains = new Dictionary<int, ShellValueDomainFacts>();
+            for (var index = 0; index < authored.Count; index++)
+            {
+                authoredDomains.Add(authored[index].ClauseElementIndex, authored[index].Value);
             }
 
             var projected = new List<AnalyzedArgument>(authoredArguments.Count);
@@ -678,11 +1012,22 @@ internal static class ShellSyntaxProjection
                     var value = hasEffectiveValue
                         ? ToPublicDomain(domain!)
                         : DefaultArgumentDomain(argument, element, count == 1);
+                    var hasAuthoredValue = authoredDomains.TryGetValue(
+                                               elementIndex,
+                                               out var authoredDomain) &&
+                                           offset == effectiveOffset;
+                    var authoredValue = hasAuthoredValue
+                        ? ToPublicDomain(authoredDomain!)
+                        : value;
                     projected.Add(new AnalyzedArgument
                     {
                         Argument = argument,
                         Element = element,
                         Value = value,
+                        AuthoredValue = authoredValue,
+                        AuthoredPathShape = publishAuthoredPathShape
+                            ? ShellPathShapeClassifier.Classify(authoredValue)
+                            : ShellPathShape.Unknown,
                         HasEffectiveValue = hasEffectiveValue,
                     });
                 }
@@ -862,8 +1207,25 @@ internal static class ShellSyntaxProjection
                 ShellValueDomainKind.Pattern => new ShellValueDomain.PathPattern(
                     domain.Pattern!,
                     domain.CoveringDirectory!),
+                ShellValueDomainKind.IntegerRange => new ShellValueDomain.IntegerRange(
+                    domain.MinimumInclusive,
+                    domain.MaximumInclusive),
+                ShellValueDomainKind.Concatenation => new ShellValueDomain.Concatenation(
+                    ToPublicDomains(domain.Parts)),
                 _ => new ShellValueDomain.Unknown(),
             };
+
+        private static IReadOnlyList<ShellValueDomain> ToPublicDomains(
+            IReadOnlyList<ShellValueDomainFacts> domains)
+        {
+            var projected = new ShellValueDomain[domains.Count];
+            for (var index = 0; index < domains.Count; index++)
+            {
+                projected[index] = ToPublicDomain(domains[index]);
+            }
+
+            return projected;
+        }
 
         private static bool AreValidEffectiveArguments(
             Clause clause,
@@ -1006,7 +1368,10 @@ internal static class ShellSyntaxProjection
 
         private static bool IsValidValueDomain(ShellValueDomainFacts domain)
         {
-            if (domain.Values is null || ContainsNull(domain.Values))
+            if (domain.Values is null ||
+                domain.Parts is null ||
+                ContainsNull(domain.Values) ||
+                ContainsNull(domain.Parts))
             {
                 return false;
             }
@@ -1016,23 +1381,81 @@ internal static class ShellSyntaxProjection
                 ShellValueDomainKind.Unknown =>
                     domain.Values.Count == 0 &&
                     domain.Pattern is null &&
-                    domain.CoveringDirectory is null,
+                    domain.CoveringDirectory is null &&
+                    domain.Parts.Count == 0 &&
+                    domain.MinimumInclusive == 0 &&
+                    domain.MaximumInclusive == 0,
                 ShellValueDomainKind.Exact =>
                     domain.Values.Count == 1 &&
                     domain.Pattern is null &&
-                    domain.CoveringDirectory is null,
+                    domain.CoveringDirectory is null &&
+                    domain.Parts.Count == 0 &&
+                    domain.MinimumInclusive == 0 &&
+                    domain.MaximumInclusive == 0,
                 ShellValueDomainKind.FiniteSet =>
                     domain.Values.Count >= 2 &&
                     domain.Values.Count <= ShellAnalysisLimits.MaxValueCandidates &&
                     AreDistinct(domain.Values) &&
                     domain.Pattern is null &&
-                    domain.CoveringDirectory is null,
+                    domain.CoveringDirectory is null &&
+                    domain.Parts.Count == 0 &&
+                    domain.MinimumInclusive == 0 &&
+                    domain.MaximumInclusive == 0,
                 ShellValueDomainKind.Pattern =>
                     domain.Values.Count == 0 &&
                     !string.IsNullOrEmpty(domain.Pattern) &&
-                    !string.IsNullOrEmpty(domain.CoveringDirectory),
+                    !string.IsNullOrEmpty(domain.CoveringDirectory) &&
+                    domain.Parts.Count == 0 &&
+                    domain.MinimumInclusive == 0 &&
+                    domain.MaximumInclusive == 0,
+                ShellValueDomainKind.IntegerRange =>
+                    domain.Values.Count == 0 &&
+                    domain.Pattern is null &&
+                    domain.CoveringDirectory is null &&
+                    domain.Parts.Count == 0 &&
+                    domain.MinimumInclusive <= domain.MaximumInclusive,
+                ShellValueDomainKind.Concatenation =>
+                    domain.Values.Count == 0 &&
+                    domain.Pattern is null &&
+                    domain.CoveringDirectory is null &&
+                    domain.Parts.Count is >= 2 and <= 16 &&
+                    domain.MinimumInclusive == 0 &&
+                    domain.MaximumInclusive == 0 &&
+                    AreValidConcatenationParts(domain.Parts),
                 _ => false,
             };
+        }
+
+        private static bool AreValidConcatenationParts(
+            IReadOnlyList<ShellValueDomainFacts> parts)
+        {
+            var hasNonExactPart = false;
+            for (var index = 0; index < parts.Count; index++)
+            {
+                if (!IsValidValueDomain(parts[index]) ||
+                    parts[index].Kind is not (
+                        ShellValueDomainKind.Exact or
+                        ShellValueDomainKind.FiniteSet or
+                        ShellValueDomainKind.IntegerRange))
+                {
+                    return false;
+                }
+
+                if (parts[index].Kind == ShellValueDomainKind.Exact)
+                {
+                    if (parts[index].Values[0].Length == 0 ||
+                        index > 0 && parts[index - 1].Kind == ShellValueDomainKind.Exact)
+                    {
+                        return false;
+                    }
+                }
+                else
+                {
+                    hasNonExactPart = true;
+                }
+            }
+
+            return hasNonExactPart;
         }
 
         private static bool AreDistinct(IReadOnlyList<string> values)

--- a/src/ShellSyntaxTree/ShellSyntaxProjection.cs
+++ b/src/ShellSyntaxTree/ShellSyntaxProjection.cs
@@ -171,7 +171,7 @@ internal static class ShellPathShapeClassifier
         {
             var character = value[index];
             if (!IsAsciiLetter(character) &&
-                !char.IsDigit(character) &&
+                !IsAsciiDigit(character) &&
                 character is not '+' and not '-' and not '.')
             {
                 return false;
@@ -184,13 +184,14 @@ internal static class ShellPathShapeClassifier
     private static bool LooksLikeWindowsPath(string value) =>
         value.IndexOf('\\') >= 0 ||
         value.StartsWith("//", StringComparison.Ordinal) ||
-        value.Length >= 3 &&
+        value.Length >= 2 &&
         IsAsciiLetter(value[0]) &&
-        value[1] == ':' &&
-        (value[2] == '/' || value[2] == '\\');
+        value[1] == ':';
 
     private static bool IsAsciiLetter(char value) =>
         value is >= 'A' and <= 'Z' or >= 'a' and <= 'z';
+
+    private static bool IsAsciiDigit(char value) => value is >= '0' and <= '9';
 }
 
 internal sealed record EffectiveArgumentFacts

--- a/tests/ShellSyntaxTree.Tests/Corpus/PiiAuditTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Corpus/PiiAuditTests.cs
@@ -101,7 +101,7 @@ public class PiiAuditTests
     public void Corpus_contains_no_pii_per_spec_section_14()
     {
         var hits = new List<string>();
-        var roots = new[] { "Corpus", "DesignCorpus" };
+        var roots = new[] { "Corpus", "DesignCorpus", "Evidence" };
         foreach (var relativeRoot in roots)
         {
             var root = Path.Combine(AppContext.BaseDirectory, relativeRoot);
@@ -199,6 +199,7 @@ public class PiiAuditTests
     {
         if (fieldPath == "input") return true;
         if (fieldPath == "notes") return true;
+        if (fieldPath.EndsWith(".command", StringComparison.Ordinal)) return true;
         if (fieldPath.EndsWith(".raw", StringComparison.Ordinal)) return true;
         return false;
     }

--- a/tests/ShellSyntaxTree.Tests/Parsing/BashAuthoredValueTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Parsing/BashAuthoredValueTests.cs
@@ -1,0 +1,542 @@
+// -----------------------------------------------------------------------
+// <copyright file="BashAuthoredValueTests.cs" company="Aaron Stannard">
+//      Copyright (C) 2026 - 2026 Aaron Stannard <https://github.com/Aaronontheweb>
+// </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+using Xunit;
+
+namespace ShellSyntaxTree.Tests.Parsing;
+
+public class BashAuthoredValueTests
+{
+    [Fact]
+    public void Quoted_exit_status_is_an_inclusive_integer_range()
+    {
+        var result = new BashParser().Parse("status-report \"$?\"");
+
+        var argument = Assert.Single(Assert.Single(result.Commands).Arguments);
+        var range = Assert.IsType<ShellValueDomain.IntegerRange>(argument.Value);
+        Assert.Equal(0, range.MinimumInclusive);
+        Assert.Equal(255, range.MaximumInclusive);
+        Assert.Equal(argument.Value, argument.AuthoredValue);
+    }
+
+    [Fact]
+    public void Embedded_quoted_exit_status_preserves_literal_parts()
+    {
+        var result = new BashParser().Parse("echo \"---EXIT $?---\"");
+
+        var argument = Assert.Single(Assert.Single(result.Commands).Arguments);
+        var concatenation = Assert.IsType<ShellValueDomain.Concatenation>(argument.Value);
+        Assert.Collection(
+            concatenation.Parts,
+            part => Assert.Equal("---EXIT ", Assert.IsType<ShellValueDomain.Exact>(part).Value),
+            part =>
+            {
+                var range = Assert.IsType<ShellValueDomain.IntegerRange>(part);
+                Assert.Equal(0, range.MinimumInclusive);
+                Assert.Equal(255, range.MaximumInclusive);
+            },
+            part => Assert.Equal("---", Assert.IsType<ShellValueDomain.Exact>(part).Value));
+    }
+
+    [Theory]
+    [InlineData(
+        "gh run view 123456 --repo example/project --log-failed --verbose 2>&1 | head -200; echo \"---EXIT $?---\"",
+        "---EXIT ",
+        "---")]
+    [InlineData(
+        "cd /work && git fetch upstream feature/update 2>&1 | tail -2 && echo \"===REMOTE TIP===\" && git rev-parse FETCH_HEAD && git log --oneline -3 FETCH_HEAD && echo \"===HAS FIX?===\" && git show FETCH_HEAD:src/App/App.csproj | grep -n \"ProtocolPackage\"; echo \"exit: $?\"",
+        "exit: ",
+        null)]
+    public void Harvested_status_cases_publish_symbolic_data(
+        string source,
+        string prefix,
+        string? suffix)
+    {
+        var result = new BashParser().Parse(source);
+
+        Assert.False(result.IsUnparseable);
+        var echo = result.Commands[result.Commands.Count - 1];
+        var argument = Assert.Single(echo.Arguments);
+        var concatenation = Assert.IsType<ShellValueDomain.Concatenation>(argument.Value);
+        Assert.Equal(prefix, Assert.IsType<ShellValueDomain.Exact>(concatenation.Parts[0]).Value);
+        Assert.IsType<ShellValueDomain.IntegerRange>(concatenation.Parts[1]);
+        if (suffix is null)
+        {
+            Assert.Equal(2, concatenation.Parts.Count);
+        }
+        else
+        {
+            Assert.Equal(
+                suffix,
+                Assert.IsType<ShellValueDomain.Exact>(concatenation.Parts[2]).Value);
+        }
+    }
+
+    [Fact]
+    public void Multiple_quoted_status_expansions_remain_symbolic()
+    {
+        var result = new BashParser().Parse("status-report \"left=$?;right=$?\"");
+
+        var argument = Assert.Single(Assert.Single(result.Commands).Arguments);
+        var concatenation = Assert.IsType<ShellValueDomain.Concatenation>(argument.Value);
+        Assert.Equal(4, concatenation.Parts.Count);
+        Assert.Equal(2, CountIntegerRanges(concatenation));
+    }
+
+    [Theory]
+    [InlineData("status-report $?", typeof(ShellValueDomain.Unknown))]
+    [InlineData("status-report '$?'", typeof(ShellValueDomain.Exact))]
+    [InlineData("status-report \"$1\"", typeof(ShellValueDomain.Unknown))]
+    public void Non_quoted_status_boundaries_keep_existing_results(
+        string source,
+        Type expectedType)
+    {
+        var result = new BashParser().Parse(source);
+
+        var argument = Assert.Single(Assert.Single(result.Commands).Arguments);
+        Assert.IsType(expectedType, argument.Value);
+    }
+
+    [Fact]
+    public void Exit_status_cannot_select_the_command_identity()
+    {
+        var result = new BashParser().Parse("\"$?\" --version");
+
+        Assert.True(result.IsUnparseable);
+        Assert.Empty(result.Commands);
+    }
+
+    [Fact]
+    public void Exit_status_cannot_name_a_redirect_target()
+    {
+        var result = new BashParser().Parse("status-report ok > \"$?\"");
+
+        var command = Assert.Single(result.Commands);
+        var redirect = Assert.Single(command.Redirects);
+        Assert.IsType<ShellValueDomain.Unknown>(
+            Assert.IsType<FileRedirectAnalysis>(redirect).Target);
+    }
+
+    [Fact]
+    public void PowerShell_authored_projection_is_compatible()
+    {
+        var result = new PwshParser().Parse("Write-Output 'C:/work/file.txt'");
+
+        var argument = Assert.Single(Assert.Single(result.Commands).Arguments);
+        Assert.Equal(argument.Value, argument.AuthoredValue);
+        Assert.Equal(ShellPathShape.Unknown, argument.AuthoredPathShape);
+    }
+
+    [Fact]
+    public void Integer_range_rejects_reversed_bounds()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(
+            () => new ShellValueDomain.IntegerRange(1, 0));
+    }
+
+    [Fact]
+    public void Concatenation_factory_normalizes_literal_parts()
+    {
+        var domain = ShellValueDomainFacts.Concatenate(new[]
+        {
+            Exact(string.Empty),
+            Exact("prefix"),
+            Exact("-"),
+            ShellValueDomainFacts.IntegerRange(0, 255),
+            Exact(string.Empty),
+        });
+
+        Assert.Equal(ShellValueDomainKind.Concatenation, domain.Kind);
+        Assert.Collection(
+            domain.Parts,
+            part => Assert.Equal("prefix-", Assert.Single(part.Values)),
+            part => Assert.Equal(ShellValueDomainKind.IntegerRange, part.Kind));
+    }
+
+    [Fact]
+    public void Concatenation_factory_rejects_unbounded_or_oversized_parts()
+    {
+        Assert.Same(
+            ShellValueDomainFacts.Unknown,
+            ShellValueDomainFacts.Concatenate(new[]
+            {
+                Exact("prefix"),
+                ShellValueDomainFacts.Unknown,
+            }));
+        Assert.Same(
+            ShellValueDomainFacts.Unknown,
+            ShellValueDomainFacts.Concatenate(new[]
+            {
+                new ShellValueDomainFacts { Kind = ShellValueDomainKind.Exact },
+                ShellValueDomainFacts.IntegerRange(0, 255),
+            }));
+
+        var parts = new List<ShellValueDomainFacts>();
+        for (var index = 0; index < 17; index++)
+        {
+            parts.Add(ShellValueDomainFacts.IntegerRange(index, index));
+        }
+
+        Assert.Same(
+            ShellValueDomainFacts.Unknown,
+            ShellValueDomainFacts.Concatenate(parts));
+    }
+
+    [Fact]
+    public void Internal_domain_equality_includes_range_bounds_and_parts()
+    {
+        var zeroToOne = ShellValueDomainFacts.IntegerRange(0, 1);
+        var zeroToTwo = ShellValueDomainFacts.IntegerRange(0, 2);
+        var left = ShellValueDomainFacts.Concatenate(new[]
+        {
+            Exact("status="),
+            zeroToOne,
+        });
+        var same = ShellValueDomainFacts.Concatenate(new[]
+        {
+            Exact("status="),
+            ShellValueDomainFacts.IntegerRange(0, 1),
+        });
+        var different = ShellValueDomainFacts.Concatenate(new[]
+        {
+            Exact("status="),
+            zeroToTwo,
+        });
+
+        Assert.True(ShellValueDomainFacts.AreEqual(left, same));
+        Assert.False(ShellValueDomainFacts.AreEqual(left, different));
+    }
+
+    [Fact]
+    public void Default_options_preserve_static_loop_rejection()
+    {
+        var result = new BashParser().Parse("for f in a b; do show \"$f\"; done");
+
+        Assert.True(result.IsUnparseable);
+        Assert.Empty(result.Commands);
+        Assert.Empty(result.Clauses);
+    }
+
+    [Fact]
+    public void Opt_in_loop_publishes_authored_value_without_effective_value()
+    {
+        var parser = new BashParser(new BashParserOptions
+        {
+            PublishAuthoredSourceFacts = true,
+        });
+
+        var result = parser.Parse("for f in a b; do show \"$f\"; done");
+
+        Assert.False(result.IsUnparseable);
+        var command = Assert.Single(result.Commands);
+        Assert.True(command.IsComplete);
+        var argument = Assert.Single(command.Arguments);
+        Assert.IsType<ShellValueDomain.Unknown>(argument.Value);
+        AssertFinite(argument.AuthoredValue, "a", "b");
+        Assert.Equal(ShellPathShape.Unknown, argument.AuthoredPathShape);
+    }
+
+    [Fact]
+    public void Opt_in_loop_composes_unquoted_words_before_field_splitting()
+    {
+        var parser = new BashParser(new BashParserOptions
+        {
+            PublishAuthoredSourceFacts = true,
+        });
+
+        var result = parser.Parse(
+            "for f in src/A.cs src/B.cs; do cat /work/$f; done");
+
+        var argument = Assert.Single(Assert.Single(result.Commands).Arguments);
+        Assert.IsType<ShellValueDomain.Unknown>(argument.Value);
+        AssertFinite(argument.AuthoredValue, "/work/src/A.cs", "/work/src/B.cs");
+        Assert.Equal(ShellPathShape.Posix, argument.AuthoredPathShape);
+    }
+
+    [Fact]
+    public void Harvested_loop_case_publishes_four_authored_paths()
+    {
+        var parser = new BashParser(new BashParserOptions
+        {
+            PublishAuthoredSourceFacts = true,
+        });
+        const string source =
+            "for f in src/App/App.csproj src/Hosting/Hosting.csproj " +
+            "src/Discovery/Discovery.csproj tests/Hosting.Tests/Hosting.Tests.csproj; " +
+            "do echo \"=== $f ===\"; cat /work/$f; done";
+
+        var result = parser.Parse(source);
+
+        Assert.False(result.IsUnparseable);
+        var cat = Assert.Single(
+            result.Commands,
+            command => command.Clause.Verb.Joined == "cat");
+        var argument = Assert.Single(cat.Arguments);
+        Assert.IsType<ShellValueDomain.Unknown>(argument.Value);
+        AssertFinite(
+            argument.AuthoredValue,
+            "/work/src/App/App.csproj",
+            "/work/src/Hosting/Hosting.csproj",
+            "/work/src/Discovery/Discovery.csproj",
+            "/work/tests/Hosting.Tests/Hosting.Tests.csproj");
+        Assert.Equal(ShellPathShape.Posix, argument.AuthoredPathShape);
+    }
+
+    [Fact]
+    public void Isolated_loop_keeps_effective_proof()
+    {
+        var parser = new BashParser(new BashParserOptions
+        {
+            InitialStateMode = BashInitialStateMode.IsolatedNonInteractive,
+        });
+
+        var result = parser.Parse("for f in a b; do show \"$f\"; done");
+
+        var argument = Assert.Single(Assert.Single(result.Commands).Arguments);
+        AssertFinite(argument.Value, "a", "b");
+        Assert.Equal(argument.Value, argument.AuthoredValue);
+    }
+
+    [Theory]
+    [InlineData("C:/work/file.txt", ShellPathShape.Windows)]
+    [InlineData("C:\\work\\file.txt", ShellPathShape.Windows)]
+    [InlineData("/work/file.txt", ShellPathShape.Posix)]
+    [InlineData("./file.txt", ShellPathShape.Posix)]
+    [InlineData("../file.txt", ShellPathShape.Posix)]
+    [InlineData("work/file.txt", ShellPathShape.Posix)]
+    [InlineData("example/project", ShellPathShape.Posix)]
+    [InlineData("https://example.invalid/api/v1", ShellPathShape.Unknown)]
+    [InlineData("bare-name", ShellPathShape.Unknown)]
+    public void Bash_arguments_publish_lexical_shape_only(
+        string value,
+        ShellPathShape expected)
+    {
+        var result = new BashParser().Parse($"show '{value}'");
+
+        var argument = Assert.Single(Assert.Single(result.Commands).Arguments);
+        Assert.Equal(expected, argument.AuthoredPathShape);
+    }
+
+    [Theory]
+    [InlineData("~/repo/A.cs", "~/repo/B.cs")]
+    [InlineData("/home/user/repo/A.cs", "/home/user/repo/B.cs")]
+    public void Opt_in_loop_preserves_quoted_tilde_or_expands_eligible_tilde(
+        string first,
+        string second)
+    {
+        var parser = new BashParser(new BashParserOptions
+        {
+            PublishAuthoredSourceFacts = true,
+            HomeDirectory = "/home/user",
+        });
+        var quoted = first[0] == '~';
+        var word = quoted ? "\"~/repo/$f\"" : "~/\"repo/$f\"";
+
+        var result = parser.Parse($"for f in A.cs B.cs; do cat {word}; done");
+
+        var argument = Assert.Single(Assert.Single(result.Commands).Arguments);
+        AssertFinite(argument.AuthoredValue, first, second);
+        Assert.Equal(ShellPathShape.Posix, argument.AuthoredPathShape);
+    }
+
+    [Fact]
+    public void Mixed_path_shapes_and_partially_unknown_sets_are_unknown()
+    {
+        var mixed = new ShellValueDomain.FiniteSet(
+            new[] { "/tmp/a", "C:\\work\\b" });
+        var partial = new ShellValueDomain.FiniteSet(
+            new[] { "/tmp/a", "bare-name" });
+
+        Assert.Equal(ShellPathShape.Unknown, ShellPathShapeClassifier.Classify(mixed));
+        Assert.Equal(ShellPathShape.Unknown, ShellPathShapeClassifier.Classify(partial));
+    }
+
+    [Fact]
+    public void Path_prefixed_concatenation_has_a_uniform_shape()
+    {
+        var value = new ShellValueDomain.Concatenation(new ShellValueDomain[]
+        {
+            new ShellValueDomain.Exact("/tmp/status-"),
+            new ShellValueDomain.IntegerRange(0, 255),
+        });
+
+        Assert.Equal(ShellPathShape.Posix, ShellPathShapeClassifier.Classify(value));
+    }
+
+    [Fact]
+    public void Path_prefixed_concatenation_does_not_ignore_windows_suffixes()
+    {
+        var value = new ShellValueDomain.Concatenation(new ShellValueDomain[]
+        {
+            new ShellValueDomain.Exact("/tmp/"),
+            new ShellValueDomain.FiniteSet(new[] { "a", "C:\\work\\b" }),
+        });
+
+        Assert.Equal(ShellPathShape.Unknown, ShellPathShapeClassifier.Classify(value));
+    }
+
+    [Fact]
+    public void Unassigned_ambient_name_remains_strict_with_opt_in()
+    {
+        var parser = new BashParser(new BashParserOptions
+        {
+            PublishAuthoredSourceFacts = true,
+        });
+
+        var result = parser.Parse("show \"$external_value\"");
+
+        Assert.True(result.IsUnparseable);
+        Assert.Empty(result.Commands);
+    }
+
+    [Theory]
+    [InlineData("declare -n f=target; for f in a b; do show \"$f\"; done")]
+    [InlineData("declare -i f=0; for f in a b; do show \"$f\"; done")]
+    [InlineData("IFS=/; for f in a b; do show \"$f\"; done")]
+    public void Explicit_source_state_mutation_remains_strict(string source)
+    {
+        var parser = new BashParser(new BashParserOptions
+        {
+            PublishAuthoredSourceFacts = true,
+        });
+
+        var result = parser.Parse(source);
+
+        Assert.True(result.IsUnparseable);
+        Assert.Empty(result.Commands);
+    }
+
+    [Fact]
+    public void Option_shaped_authored_values_are_reported_only_as_data()
+    {
+        var parser = new BashParser(new BashParserOptions
+        {
+            PublishAuthoredSourceFacts = true,
+        });
+
+        var result = parser.Parse("for f in -o --execute; do show \"$f\"; done");
+
+        var argument = Assert.Single(Assert.Single(result.Commands).Arguments);
+        AssertFinite(argument.AuthoredValue, "-o", "--execute");
+        Assert.Equal(ShellPathShape.Unknown, argument.AuthoredPathShape);
+    }
+
+    [Fact]
+    public void Runtime_iterator_is_visible_but_authored_value_is_unknown()
+    {
+        var parser = new BashParser(new BashParserOptions
+        {
+            PublishAuthoredSourceFacts = true,
+        });
+
+        var result = parser.Parse(
+            "for f in $(find /work -name '*.cs'); do cat \"$f\"; done");
+
+        Assert.False(result.IsUnparseable);
+        Assert.Contains(
+            result.Commands,
+            command => command.Clause.Verb.Joined == "find" &&
+                       command.ImmediateRole == CommandOccurrenceRole.Substitution);
+        var cat = Assert.Single(
+            result.Commands,
+            command => command.Clause.Verb.Joined == "cat");
+        var argument = Assert.Single(cat.Arguments);
+        Assert.IsType<ShellValueDomain.Unknown>(argument.AuthoredValue);
+        Assert.Equal(ShellPathShape.Unknown, argument.AuthoredPathShape);
+    }
+
+    [Theory]
+    [InlineData("for f in echo; do \"$f\" safe; done")]
+    [InlineData("for f in 'echo hidden'; do eval \"$f\"; done")]
+    public void Authored_loop_fact_does_not_relax_hidden_command_identity(string source)
+    {
+        var parser = new BashParser(new BashParserOptions
+        {
+            PublishAuthoredSourceFacts = true,
+        });
+
+        var result = parser.Parse(source);
+
+        Assert.True(result.IsUnparseable);
+        Assert.Empty(result.Commands);
+    }
+
+    [Theory]
+    [InlineData("Write-Output $name")]
+    [InlineData("Get-Content C:\\work\\file.txt")]
+    [InlineData("Get-Item Env:PATH")]
+    public void PowerShell_all_argument_categories_keep_compatible_projection(string source)
+    {
+        var result = new PwshParser().Parse(source);
+
+        Assert.False(result.IsUnparseable);
+        foreach (var argument in Assert.Single(result.Commands).Arguments)
+        {
+            Assert.Equal(argument.Value, argument.AuthoredValue);
+            Assert.Equal(ShellPathShape.Unknown, argument.AuthoredPathShape);
+        }
+    }
+
+    [Fact]
+    public void Authored_only_loop_does_not_resolve_redirect_target()
+    {
+        var parser = new BashParser(new BashParserOptions
+        {
+            PublishAuthoredSourceFacts = true,
+        });
+
+        var result = parser.Parse("for f in a b; do show ok > \"$f\"; done");
+
+        var redirect = Assert.Single(Assert.Single(result.Commands).Redirects);
+        Assert.IsType<ShellValueDomain.Unknown>(
+            Assert.IsType<FileRedirectAnalysis>(redirect).Target);
+    }
+
+    [Fact]
+    public void Authored_only_loop_does_not_resolve_cwd_transfer()
+    {
+        var parser = new BashParser(new BashParserOptions
+        {
+            PublishAuthoredSourceFacts = true,
+            WorkingDirectory = "/work",
+        });
+
+        var result = parser.Parse("for f in a b; do cd \"$f\"; pwd; done");
+
+        Assert.False(result.IsUnparseable);
+        var pwd = Assert.Single(
+            result.Commands,
+            command => command.Clause.Verb.Joined == "pwd");
+        Assert.IsType<ShellValueDomain.Unknown>(pwd.WorkingDirectory);
+    }
+
+    private static int CountIntegerRanges(ShellValueDomain.Concatenation value)
+    {
+        var count = 0;
+        foreach (var part in value.Parts)
+        {
+            if (part is ShellValueDomain.IntegerRange)
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
+    private static void AssertFinite(ShellValueDomain domain, params string[] expected)
+    {
+        var finite = Assert.IsType<ShellValueDomain.FiniteSet>(domain);
+        Assert.Equal(expected, finite.Values);
+    }
+
+    private static ShellValueDomainFacts Exact(string value) => new()
+    {
+        Kind = ShellValueDomainKind.Exact,
+        Values = new[] { value },
+    };
+}

--- a/tests/ShellSyntaxTree.Tests/Parsing/BashAuthoredValueTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Parsing/BashAuthoredValueTests.cs
@@ -301,9 +301,29 @@ public class BashAuthoredValueTests
         Assert.Equal(argument.Value, argument.AuthoredValue);
     }
 
+    [Fact]
+    public void Isolated_loop_opt_in_keeps_separate_authored_proof()
+    {
+        var parser = new BashParser(new BashParserOptions
+        {
+            InitialStateMode = BashInitialStateMode.IsolatedNonInteractive,
+            PublishAuthoredSourceFacts = true,
+        });
+
+        var result = parser.Parse(
+            "for f in src/A.cs src/B.cs; do cat /work/$f; done");
+
+        var argument = Assert.Single(Assert.Single(result.Commands).Arguments);
+        Assert.IsType<ShellValueDomain.Unknown>(argument.Value);
+        AssertFinite(argument.AuthoredValue, "/work/src/A.cs", "/work/src/B.cs");
+        Assert.Equal(ShellPathShape.Posix, argument.AuthoredPathShape);
+    }
+
     [Theory]
     [InlineData("C:/work/file.txt", ShellPathShape.Windows)]
     [InlineData("C:\\work\\file.txt", ShellPathShape.Windows)]
+    [InlineData("C:foo", ShellPathShape.Windows)]
+    [InlineData("C:foo/bar", ShellPathShape.Windows)]
     [InlineData("/work/file.txt", ShellPathShape.Posix)]
     [InlineData("./file.txt", ShellPathShape.Posix)]
     [InlineData("../file.txt", ShellPathShape.Posix)]

--- a/tests/ShellSyntaxTree.Tests/Parsing/BashStructuralProjectionTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Parsing/BashStructuralProjectionTests.cs
@@ -1587,13 +1587,16 @@ public class BashStructuralProjectionTests
     }
 
     [Fact]
-    public void Runtime_parameter_publishes_unknown_effective_value()
+    public void Quoted_exit_status_publishes_bounded_effective_value()
     {
         var command = Assert.Single(Parse("cat \"$?\"").Commands);
 
         var effective = Assert.Single(command.EffectiveArguments);
         Assert.Equal(1, effective.ClauseElementIndex);
-        Assert.Equal(ShellValueDomainKind.Unknown, effective.Value.Kind);
+        Assert.Equal(ShellValueDomainKind.IntegerRange, effective.Value.Kind);
+        var range = Assert.IsType<ShellValueDomain.IntegerRange>(effective.Value);
+        Assert.Equal(0, range.MinimumInclusive);
+        Assert.Equal(255, range.MaximumInclusive);
         Assert.True(command.IsComplete);
     }
 

--- a/tests/ShellSyntaxTree.Tests/Parsing/ShellValueOracleTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Parsing/ShellValueOracleTests.cs
@@ -13,6 +13,70 @@ namespace ShellSyntaxTree.Tests.Parsing;
 public class ShellValueOracleTests
 {
     [Fact]
+    public void Bash_quoted_exit_status_is_one_field_and_single_quotes_are_literal()
+    {
+        if (!IsNativeBashAvailable())
+        {
+            return;
+        }
+
+        var output = Run(
+            "bash",
+            "--noprofile",
+            "--norc",
+            "-c",
+            "false; set -- \"left=$?\" '$?'; " +
+            "printf '<%s>\\n' \"$#\" \"$1\" \"$2\"");
+
+        Assert.Equal(new[] { "<2>", "<left=1>", "<$?>" }, Lines(output));
+    }
+
+    [Fact]
+    public void Bash_unquoted_status_observes_ifs_while_repeated_quoted_status_does_not()
+    {
+        if (!IsNativeBashAvailable())
+        {
+            return;
+        }
+
+        var unquoted = Run(
+            "bash",
+            "--noprofile",
+            "--norc",
+            "-c",
+            "IFS=1; false; set -- $?; printf '<%s>\\n' \"$#\" \"${1-unset}\"");
+        var quoted = Run(
+            "bash",
+            "--noprofile",
+            "--norc",
+            "-c",
+            "false; set -- \"left=$?;right=$?\"; printf '<%s>\\n' \"$#\" \"$1\"");
+
+        Assert.Equal(new[] { "<1>", "<>" }, Lines(unquoted));
+        Assert.Equal(new[] { "<1>", "<left=1;right=1>" }, Lines(quoted));
+    }
+
+    [Fact]
+    public void Bash_tilde_expands_only_at_an_eligible_unquoted_prefix()
+    {
+        if (!IsNativeBashAvailable())
+        {
+            return;
+        }
+
+        var output = Run(
+            "bash",
+            "--noprofile",
+            "--norc",
+            "-c",
+            "HOME=/home/user; printf '<%s>\\n' ~/\"repo/A.cs\" \"~/repo/A.cs\"");
+
+        Assert.Equal(
+            new[] { "</home/user/repo/A.cs>", "<~/repo/A.cs>" },
+            Lines(output));
+    }
+
+    [Fact]
     public void Bash_descriptor_duplicate_routes_stderr_to_stdout()
     {
         if (!IsNativeBashAvailable())

--- a/tests/ShellSyntaxTree.Tests/PublicApiSnapshotTests.cs
+++ b/tests/ShellSyntaxTree.Tests/PublicApiSnapshotTests.cs
@@ -209,12 +209,15 @@ public class PublicApiSnapshotTests
         AssertInitProperty(t, "HomeDirectory", typeof(string), nullable: true);
         AssertInitProperty(t, "WorkingDirectory", typeof(string), nullable: true);
         AssertInitProperty(t, "InitialStateMode", typeof(BashInitialStateMode));
+        AssertInitProperty(t, "PublishAuthoredSourceFacts", typeof(bool));
 
         var declaredProps = DeclaredInstanceProps(t)
             .Where(p => p.Name != "EqualityContract")
             .Select(p => p.Name)
             .ToArray();
-        Assert.Equal(new[] { "InitialStateMode" }, declaredProps);
+        Assert.Equal(
+            new[] { "InitialStateMode", "PublishAuthoredSourceFacts" },
+            declaredProps);
     }
 
     [Fact]
@@ -633,6 +636,7 @@ public class PublicApiSnapshotTests
             nameof(ShellBlockSyntax),
             nameof(ShellGroupKind),
             nameof(ShellParserOptions),
+            nameof(ShellPathShape),
             nameof(ShellSourceFragment),
             nameof(ShellSyntaxNode),
             nameof(ShellValueDomain),

--- a/tests/ShellSyntaxTree.Tests/ShellSyntaxProjectionTests.cs
+++ b/tests/ShellSyntaxTree.Tests/ShellSyntaxProjectionTests.cs
@@ -977,7 +977,7 @@ public class ShellSyntaxProjectionTests
     }
 
     [Fact]
-    public void Value_domain_validator_accepts_only_the_four_locked_shapes()
+    public void Value_domain_validator_accepts_only_the_six_locked_shapes()
     {
         var clause = ClauseFor("echo") with
         {
@@ -1008,6 +1008,16 @@ public class ShellSyntaxProjectionTests
                 Pattern = "/work/*.txt",
                 CoveringDirectory = "/work",
             },
+            ShellValueDomainFacts.IntegerRange(0, 255),
+            ShellValueDomainFacts.Concatenate(new[]
+            {
+                new ShellValueDomainFacts
+                {
+                    Kind = ShellValueDomainKind.Exact,
+                    Values = new[] { "status=" },
+                },
+                ShellValueDomainFacts.IntegerRange(0, 255),
+            }),
         };
 
         foreach (var domain in validDomains)
@@ -1040,6 +1050,12 @@ public class ShellSyntaxProjectionTests
             },
             new ShellValueDomainFacts
             {
+                Kind = ShellValueDomainKind.Exact,
+                Values = new[] { "one" },
+                MaximumInclusive = 1,
+            },
+            new ShellValueDomainFacts
+            {
                 Kind = ShellValueDomainKind.FiniteSet,
                 Values = new[] { "one" },
             },
@@ -1057,6 +1073,43 @@ public class ShellSyntaxProjectionTests
             {
                 Kind = ShellValueDomainKind.Pattern,
                 Pattern = "/work/*.txt",
+            },
+            new ShellValueDomainFacts
+            {
+                Kind = ShellValueDomainKind.IntegerRange,
+                MinimumInclusive = 1,
+                MaximumInclusive = 0,
+            },
+            new ShellValueDomainFacts
+            {
+                Kind = ShellValueDomainKind.Concatenation,
+                Parts = new[] { ShellValueDomainFacts.IntegerRange(0, 255) },
+            },
+            new ShellValueDomainFacts
+            {
+                Kind = ShellValueDomainKind.Concatenation,
+                Parts = new[]
+                {
+                    ShellValueDomainFacts.IntegerRange(0, 255),
+                    ShellValueDomainFacts.Unknown,
+                },
+            },
+            new ShellValueDomainFacts
+            {
+                Kind = ShellValueDomainKind.Concatenation,
+                Parts = new[]
+                {
+                    new ShellValueDomainFacts
+                    {
+                        Kind = ShellValueDomainKind.Exact,
+                        Values = new[] { "left" },
+                    },
+                    new ShellValueDomainFacts
+                    {
+                        Kind = ShellValueDomainKind.Exact,
+                        Values = new[] { "right" },
+                    },
+                },
             },
             new ShellValueDomainFacts { Kind = (ShellValueDomainKind)999 },
         };

--- a/tests/ShellSyntaxTree.Tests/ShellSyntaxTree.Tests.csproj
+++ b/tests/ShellSyntaxTree.Tests/ShellSyntaxTree.Tests.csproj
@@ -34,6 +34,10 @@
     <None Update="DesignCorpus\**\*.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="..\..\openspec\changes\v0-3-1-approval-facts\evidence\approval-matrix.json"
+          Link="Evidence\approval-matrix.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
 </Project>

--- a/tests/ShellSyntaxTree.Tests/V03PublicApiSnapshotTests.cs
+++ b/tests/ShellSyntaxTree.Tests/V03PublicApiSnapshotTests.cs
@@ -119,7 +119,11 @@ public class V03PublicApiSnapshotTests
             typeof(AnalyzedArgument),
             (nameof(AnalyzedArgument.Argument), typeof(Arg)),
             (nameof(AnalyzedArgument.Element), typeof(ClauseElement)),
-            (nameof(AnalyzedArgument.Value), typeof(ShellValueDomain)));
+            (nameof(AnalyzedArgument.Value), typeof(ShellValueDomain)),
+            (nameof(AnalyzedArgument.AuthoredValue), typeof(ShellValueDomain)),
+            (nameof(AnalyzedArgument.AuthoredPathShape), typeof(ShellPathShape)));
+
+        AssertEnum<ShellPathShape>("Unknown", "Posix", "Windows");
 
         AssertEnum<CommandOccurrenceRole>(
             "Unknown", "Ordinary", "PipelineStage", "Iterator", "LoopBody",
@@ -145,6 +149,14 @@ public class V03PublicApiSnapshotTests
             typeof(ShellValueDomain.PathPattern),
             (nameof(ShellValueDomain.PathPattern.Pattern), typeof(string), false),
             (nameof(ShellValueDomain.PathPattern.CoveringDirectory), typeof(string), false));
+        AssertResultRecordAccessors(
+            typeof(ShellValueDomain.IntegerRange),
+            (nameof(ShellValueDomain.IntegerRange.MinimumInclusive), typeof(long), false),
+            (nameof(ShellValueDomain.IntegerRange.MaximumInclusive), typeof(long), false));
+        AssertResultRecordAccessors(
+            typeof(ShellValueDomain.Concatenation),
+            (nameof(ShellValueDomain.Concatenation.Parts),
+                typeof(IReadOnlyList<ShellValueDomain>), false));
     }
 
     [Fact]
@@ -260,6 +272,16 @@ public class V03PublicApiSnapshotTests
         values[0] = "changed";
         Assert.Equal(new[] { "a", "b" }, finite.Values);
 
+        var part = new ShellValueDomain.IntegerRange(0, 255);
+        var parts = new ShellValueDomain[]
+        {
+            new ShellValueDomain.Exact("status="),
+            part,
+        };
+        var concatenation = new ShellValueDomain.Concatenation(parts);
+        parts[1] = new ShellValueDomain.Exact("changed");
+        Assert.Same(part, concatenation.Parts[1]);
+
         var readOnlyLists = new object[]
         {
             block.Statements,
@@ -272,6 +294,7 @@ public class V03PublicApiSnapshotTests
             occurrence.Redirects,
             parsed.Commands,
             finite.Values,
+            concatenation.Parts,
         };
         Assert.All(readOnlyLists, collection => Assert.False(collection.GetType().IsArray));
     }
@@ -341,6 +364,7 @@ public class V03PublicApiSnapshotTests
             typeof(ExecutionRegionCardinality),
             typeof(FileRedirectMode),
             typeof(HereDocumentExpansionMode),
+            typeof(ShellPathShape),
         };
 
         Assert.All(enums, type => Assert.False(Enum.IsDefined(type, 999)));


### PR DESCRIPTION
## Summary

- add bounded integer-range and concatenation value domains
- add opt-in Bash authored-source loop facts and lexical path shape without changing 0.3.0 defaults
- preserve PowerShell projection compatibility and expand the consumer guide
- prepare the 0.3.1 package and release metadata

## Verification

- Release build: passed
- Full test suite: 2,920 passed
- Header verification: passed
- Slopwatch: 0 findings
- Strict OpenSpec validation: passed
- API diff vs 0.3.0: exactly 6 additive changes on net8.0 and netstandard2.0
- Package inspection: ShellSyntaxTree 0.3.1, net8.0 + netstandard2.0
- Evidence parity: SHA-256 d2a6e64421af337d1c54f1f955934057398176b456e585bfce015ef7ffa24e7d