### PR TITLE
Record 0.3.1 publication evidence

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -22,9 +22,17 @@ priorities.
       `AuthoredPathShape`, and `PublishAuthoredSourceFacts` names. Confirm that
       Netclaw may use the pre-field-splitting word fact for approval matching
       while effective facts retain runtime meaning.
-- [ ] **Implement and release v0.3.1.** Follow the OpenSpec task order. Run the
-      API, unit, corpus, PII, native-oracle, package, header, downstream
-      Netclaw, and adversarial gates before publication.
+- [x] **Implemented and released v0.3.1.**
+      [PR #153](https://github.com/Aaronontheweb/ShellSyntaxTree/pull/153)
+      merged as `a414cdda` after Linux and Windows CI passed. The bare `0.3.1`
+      tag completed
+      [workflow run 31530682715](https://github.com/Aaronontheweb/ShellSyntaxTree/actions/runs/31530682715).
+      The workflow published the package and symbols package. The public
+      [NuGet index](https://www.nuget.org/packages/ShellSyntaxTree/0.3.1)
+      lists version `0.3.1`. The non-draft, non-prerelease
+      [GitHub release](https://github.com/Aaronontheweb/ShellSyntaxTree/releases/tag/0.3.1)
+      contains both assets. API, unit, corpus, PII, native-oracle, package,
+      header, and adversarial checks passed before publication.
 
 ## Completed v0.3.0 host integration and release acceptance
 

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -33,6 +33,12 @@ priorities.
       [GitHub release](https://github.com/Aaronontheweb/ShellSyntaxTree/releases/tag/0.3.1)
       contains both assets. API, unit, corpus, PII, native-oracle, package,
       header, and adversarial checks passed before publication.
+- [ ] **Complete the post-publication Netclaw 0.3.1 gate.** Upgrade the
+      structured approval-policy branch to the public package. Pin D02, D10,
+      D14, dynamic identity, redirect, native PowerShell, and compatibility
+      outcomes in the downstream matrix. This gate was not run before the
+      package was published; it remains required before the Netclaw policy
+      implementation can merge.
 
 ## Completed v0.3.0 host integration and release acceptance
 

--- a/openspec/changes/v0-3-1-approval-facts/tasks.md
+++ b/openspec/changes/v0-3-1-approval-facts/tasks.md
@@ -76,5 +76,9 @@
 - [x] 7.3 Run Release pack and inspect the 0.3.1 package metadata.
 - [x] 7.4 Obtain adversarial review of API truthfulness, Bash semantics,
   sanitization, and consumer misuse boundaries.
-- [ ] 7.5 Push the SemVer tag, verify publish workflow success, and verify the
+- [x] 7.5 Push the SemVer tag, verify publish workflow success, and verify the
   package appears on nuget.org before marking release complete.
+  - PR #153 merged as `a414cdda` after Linux and Windows CI passed. Bare tag
+    `0.3.1` completed workflow run 31530682715. The public NuGet index lists
+    `0.3.1`. The non-draft, non-prerelease GitHub release contains
+    `ShellSyntaxTree.0.3.1.nupkg` and `ShellSyntaxTree.0.3.1.snupkg`.


### PR DESCRIPTION
Records the successful ShellSyntaxTree 0.3.1 release after PR #153 merged. The tag workflow passed, NuGet lists 0.3.1, and the GitHub release contains package and symbol assets. This PR changes documentation and OpenSpec task state only.