### PR TITLE
Fix static Bash tilde command identities

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -39,6 +39,10 @@ priorities.
       outcomes in the downstream matrix. This gate was not run before the
       package was published; it remains required before the Netclaw policy
       implementation can merge.
+- [x] **Accept proved Bash tilde command identities.** Treat an eligible
+      home-tilde prefix and a quoted or escaped literal tilde as static command
+      text. Keep named-user, variable-derived, opaque, and unknown tilde forms
+      fail closed. Direct parser tests pin both boundaries.
 
 ## Completed v0.3.0 host integration and release acceptance
 

--- a/src/ShellSyntaxTree/Internal/Bash/Parsing/BashCommandParser.cs
+++ b/src/ShellSyntaxTree/Internal/Bash/Parsing/BashCommandParser.cs
@@ -529,7 +529,7 @@ internal static partial class BashCommandParser
         var firstToken = segment.Tokens[0];
         if ((firstToken.Kind == BashTokenKind.Word
                 || firstToken.Kind == BashTokenKind.QuotedString)
-            && !HasStaticCommandIdentity(firstToken))
+            && !HasStaticCommandIdentity(firstToken, options))
         {
             return ClauseResult.Fail(
                 "dynamic Bash command identity is not supported in v0.2");
@@ -691,20 +691,40 @@ internal static partial class BashCommandParser
         return ClauseResult.Ok(clause, pathResolutions);
     }
 
-    private static bool HasStaticCommandIdentity(BashToken token)
+    private static bool HasStaticCommandIdentity(
+        BashToken token,
+        BashParserOptions options)
     {
         if (token.ResolverValue is null)
         {
             return true;
         }
 
-        foreach (var fragment in token.ResolverValue.Fragments)
+        for (var index = 0; index < token.ResolverValue.Fragments.Count; index++)
         {
-            if (fragment.Kind != ShellValueFragmentKind.Literal
-                || fragment.Cardinality != ShellValueCardinality.ExactlyOne)
+            var fragment = token.ResolverValue.Fragments[index];
+            if (fragment.Kind == ShellValueFragmentKind.Literal
+                && fragment.Cardinality == ShellValueCardinality.ExactlyOne)
             {
-                return false;
+                continue;
             }
+
+            if (fragment.Kind == ShellValueFragmentKind.Expansion
+                && fragment.Cardinality == ShellValueCardinality.ExactlyOne
+                && fragment.Expansion is { Kind: ShellExpansionKind.Tilde })
+            {
+                var tildeKind = BashResolver.ClassifyTildeExpansion(
+                    token.ResolverValue,
+                    index);
+                if (tildeKind == BashTildeExpansionKind.Literal
+                    || tildeKind == BashTildeExpansionKind.Home
+                    && BashResolver.GetHomeDirectory(options).Length > 0)
+                {
+                    continue;
+                }
+            }
+
+            return false;
         }
 
         return true;

--- a/tests/ShellSyntaxTree.Tests/Parsing/BashCommandParserTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Parsing/BashCommandParserTests.cs
@@ -174,6 +174,30 @@ public class BashCommandParserTests
         Assert.Empty(clause.Args);
     }
 
+    [Theory]
+    [InlineData("~/.dotnet/dotnet test")]
+    [InlineData("~/bin/\"tool\" status")]
+    [InlineData("~\\/bin/tool status")]
+    public void Static_tilde_command_identity_is_supported(string source)
+    {
+        var result = Parse(source);
+
+        Assert.False(result.IsUnparseable, result.UnparseableReason);
+        Assert.NotEmpty(result.Commands);
+    }
+
+    [Theory]
+    [InlineData("~other/bin/tool status")]
+    [InlineData("~/$tool status")]
+    public void Dynamic_tilde_command_identity_stays_unparseable(string source)
+    {
+        var result = Parse(source);
+
+        Assert.True(result.IsUnparseable);
+        Assert.Empty(result.Commands);
+        Assert.Empty(result.Clauses);
+    }
+
     [Fact]
     public void Known_file_suffix_wins_over_an_extension_shaped_subcommand()
     {


### PR DESCRIPTION
## Summary

- accept proved home-tilde executable paths such as `~/.dotnet/dotnet`
- retain strict rejection for named-user and variable-derived command identities
- pin quoted and escaped literal boundaries

## Validation

- `dotnet build -c Release`
- `dotnet test -c Release` (2,928 passed)
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`
- Slopwatch
- adversarial review: PASS