### PR TITLE
Release ShellSyntaxTree 0.3.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.3.1</VersionPrefix>
+    <VersionPrefix>0.3.2</VersionPrefix>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Target framework matrix -->

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -10,7 +10,7 @@ priorities.
 
 ---
 
-## NOW (0.3.1 bounded approval facts)
+## NOW (0.3.2 parser fix and downstream acceptance)
 
 - [x] **Create the v0.3.1 approval-fact OpenSpec.** Harvest and sanitize the
       Netclaw v0.26.0-beta.3 approval window. Classify all 18 distinct prompts
@@ -43,6 +43,9 @@ priorities.
       home-tilde prefix and a quoted or escaped literal tilde as static command
       text. Keep named-user, variable-derived, opaque, and unknown tilde forms
       fail closed. Direct parser tests pin both boundaries.
+- [ ] **Publish v0.3.2.** Package the static tilde command-identity fix, verify
+      the tag-driven NuGet release, and complete the downstream Netclaw clean-
+      restore gate before its approval-policy PR merges.
 
 ## Completed v0.3.0 host integration and release acceptance
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,30 @@
 #### Unreleased ####
 
+#### 0.3.2 2026-08-12 ####
+
+This patch release accepts statically proved Bash command identities that use
+the current user's home-tilde prefix. It preserves the existing fail-closed
+boundary for command identities that remain dynamic.
+
+## Fixed
+
+- Parse eligible `~/...` executable paths as static command identities when a
+  home directory is available to the resolver.
+- Preserve quoted or escaped tilde text as literal command identity.
+
+## Security and compatibility
+
+- Keep named-user tilde, variable-derived identity, unknown home state, and
+  other unresolved executable forms unparseable.
+- Preserve the public API and package layout from 0.3.1.
+
+## Consumer validation
+
+- Add direct positive and negative parser cases plus existing structural,
+  native Bash oracle, public API, and full-suite validation.
+- Unblock Netclaw approval analysis for ordinary agent commands that invoke a
+  static executable beneath the current user's home directory.
+
 #### 0.3.1 2026-08-11 ####
 
 This additive release supplies bounded shell facts needed to reduce approval


### PR DESCRIPTION
## Summary

- publish the merged static Bash home-tilde command identity fix as 0.3.2
- preserve dynamic and named-user tilde identities as unparseable
- record the downstream Netclaw clean-restore gate

## Validation

- `dotnet build -c Release`: clean
- `dotnet test -c Release`: 2,928 passed
- public API snapshots: 40 passed
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`: passed
- `dotnet pack -c Release`: created 0.3.2 nupkg and snupkg
- adversarial release review: PASS; both wording warnings resolved

## Downstream

Netclaw PR #1890 currently pins `0.3.2-local`; after publication it will move to the public `0.3.2` package and run a clean restore.