### PR TITLE
Keep authored facts out of child shells

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -43,6 +43,11 @@ priorities.
       home-tilde prefix and a quoted or escaped literal tilde as static command
       text. Keep named-user, variable-derived, opaque, and unknown tilde forms
       fail closed. Direct parser tests pin both boundaries.
+- [x] **Keep authored-source facts at their parser-call boundary.** Do not
+      carry the optional authored-only loop relaxation into decoded `bash -c`
+      or `sh -c` children. Direct root and child-shell regressions pin the
+      boundary while isolated-state child analysis remains independently
+      available.
 - [ ] **Publish v0.3.2.** Package the static tilde command-identity fix, verify
       the tag-driven NuGet release, and complete the downstream Netclaw clean-
       restore gate before its approval-policy PR merges.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,6 +16,9 @@ boundary for command identities that remain dynamic.
 
 - Keep named-user tilde, variable-derived identity, unknown home state, and
   other unresolved executable forms unparseable.
+- Keep authored-only loop publication scoped to the source submitted to the
+  parser. Decoded `bash -c` and `sh -c` children require their own proved
+  isolated state instead of inheriting the outer opt-in.
 - Preserve the public API and package layout from 0.3.1.
 
 ## Consumer validation

--- a/SPEC.md
+++ b/SPEC.md
@@ -806,7 +806,10 @@ effective `Value=Unknown` and a finite `AuthoredValue`. Explicit attribute
 mutation, hidden execution, dynamic identity, command substitution, runtime
 iteration, redirects, and unsupported control flow remain strict. The
 `IsolatedNonInteractive` mode retains its existing effective proof and does not
-require the option.
+require the option. The opt-in applies only to the source submitted to that
+`Parse` call. It does not cross into a decoded `bash -c` or `sh -c` child;
+without an independently asserted isolated state, a static loop in that child
+remains unparseable.
 
 `AuthoredPathShape` is lexical evidence only. URI-shaped words matching
 `^[A-Za-z][A-Za-z0-9+.-]*://` are `Unknown`; otherwise drive, UNC, or

--- a/src/ShellSyntaxTree/Internal/Bash/Parsing/BashStructuralCoordinator.cs
+++ b/src/ShellSyntaxTree/Internal/Bash/Parsing/BashStructuralCoordinator.cs
@@ -513,9 +513,17 @@ internal static partial class BashCommandParser
                     return false;
                 }
 
-                var innerOptions = _hasUnmodeledVariableStateMutation
-                    ? _options with { InitialStateMode = BashInitialStateMode.Unknown }
-                    : _options;
+                var innerOptions = _options with
+                {
+                    InitialStateMode = _hasUnmodeledVariableStateMutation
+                        ? BashInitialStateMode.Unknown
+                        : _options.InitialStateMode,
+                    // This opt-in describes the source submitted to this parser call.
+                    // A decoded child shell is a separate execution boundary and must
+                    // receive its own caller assertion before it can publish authored-
+                    // only loop facts.
+                    PublishAuthoredSourceFacts = false,
+                };
                 var innerResult = ParseInternal(
                     innerCommand!,
                     innerOptions,

--- a/tests/ShellSyntaxTree.Tests/Parsing/BashAuthoredValueTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Parsing/BashAuthoredValueTests.cs
@@ -320,6 +320,44 @@ public class BashAuthoredValueTests
     }
 
     [Theory]
+    [InlineData("bash")]
+    [InlineData("sh")]
+    public void Authored_source_opt_in_does_not_cross_a_decoded_child_shell(
+        string shell)
+    {
+        var parser = new BashParser(new BashParserOptions
+        {
+            PublishAuthoredSourceFacts = true,
+        });
+
+        var result = parser.Parse(
+            $"{shell} -c 'for f in a b; do show \"$f\"; done'");
+
+        Assert.True(result.IsUnparseable);
+        Assert.Empty(result.Commands);
+        Assert.Empty(result.Clauses);
+        Assert.Contains("proved isolated", result.UnparseableReason);
+    }
+
+    [Fact]
+    public void Isolated_state_proof_crosses_a_decoded_child_shell_independently()
+    {
+        var parser = new BashParser(new BashParserOptions
+        {
+            InitialStateMode = BashInitialStateMode.IsolatedNonInteractive,
+            PublishAuthoredSourceFacts = true,
+        });
+
+        var result = parser.Parse(
+            "bash --noprofile --norc -c 'for f in a b; do show \"$f\"; done'");
+
+        Assert.False(result.IsUnparseable);
+        var argument = Assert.Single(Assert.Single(result.Commands).Arguments);
+        AssertFinite(argument.Value, "a", "b");
+        AssertFinite(argument.AuthoredValue, "a", "b");
+    }
+
+    [Theory]
     [InlineData("C:/work/file.txt", ShellPathShape.Windows)]
     [InlineData("C:\\work\\file.txt", ShellPathShape.Windows)]
     [InlineData("C:foo", ShellPathShape.Windows)]


### PR DESCRIPTION
## Summary
- keep the optional authored-source loop relaxation scoped to the submitted parser source
- require decoded bash/sh child shells to prove their own isolated state
- pin bash and sh fail-closed boundaries plus isolated-state propagation
- align the canonical spec, 0.3.2 notes, and implementation plan

## Validation
- Release build: 0 warnings, 0 errors
- full suite: 2,931 passed
- headers: pass
- pack: ShellSyntaxTree 0.3.2 nupkg and snupkg
- public API diff from 0.3.1: no changes
- adversarial review: PASS

The 0.3.2 tag has not been pushed. This PR must merge before publication.