### PR TITLE
fix: classify openssl -subj value as non-path

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -68,6 +68,11 @@ priorities.
       corpus and consumer-guide examples, public 0.3.2 API comparison, native
       Windows coverage, downstream Netclaw D14 acceptance, and tag-driven
       package publication.
+- [x] **Keep OpenSSL subject data out of path classification.** Treat the
+      slash-prefixed `-subj` Distinguished Name as non-path data without
+      assigning verb-wide arity or path roles to subcommand-specific options.
+      Direct `req`, `x509`, and `ca` regressions pin the shared subject rule,
+      the valueless `x509 -serial` switch, and the non-path `ca -key` operand.
 
 ## Completed v0.3.0 host integration and release acceptance
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1890,6 +1890,7 @@ internal static readonly IReadOnlyDictionary<string, HashSet<string>>
     ["wget"]  = new HashSet<string>(StringComparer.Ordinal) { "-o", "--output-file", "-O", "--output-document" },
     ["docker"]= new HashSet<string>(StringComparer.Ordinal) { "-v", "--volume", "-f", "--file" },
     ["tar"]   = new HashSet<string>(StringComparer.Ordinal) { "-f", "--file", "-C", "--directory", "-F", "--info-script", "--new-volume-script" },
+    ["openssl"] = new HashSet<string>(StringComparer.Ordinal) { "-subj" },
     // Add as corpus surfaces real cases.
 };
 ```
@@ -1929,6 +1930,13 @@ internal static readonly IReadOnlyDictionary<string, HashSet<string>>
 > generic table preserves the established `docker run` projection; a
 > Docker-aware consumer uses `Clause.Elements` to interpret placement and MUST
 > NOT treat the table as universal Docker semantics.
+
+> **OpenSSL subcommands.** The table includes only `-subj`, whose operand is
+> X.509 Distinguished Name data for the documented `req`, `x509`, and `ca`
+> subcommands. A slash-prefixed DN is therefore non-path data. Other OpenSSL
+> options remain outside this verb-wide heuristic when their arity or role is
+> subcommand-specific: `openssl x509 -serial` is valueless, and `openssl ca
+> -key` consumes private-key password data rather than a filesystem path.
 
 > **Note:** the verb-chain walk consumes flag-with-value pairs
 > transparently. For `git -C /repo log`, the walk consumes `-C /repo`

--- a/src/ShellSyntaxTree/Internal/Bash/Verbs/BashPerVerbRules.cs
+++ b/src/ShellSyntaxTree/Internal/Bash/Verbs/BashPerVerbRules.cs
@@ -159,6 +159,12 @@ internal static class BashPerVerbRules
             [("tar", "--file")] = true,
             [("tar", "-C")] = true,
             [("tar", "--directory")] = true,
+
+            // OpenSSL req, x509, and ca consistently use -subj for X.509
+            // Distinguished Name data. A DN may start with '/', but it is not
+            // a filesystem path. No other OpenSSL option receives a universal
+            // path role here because those semantics are subcommand-specific.
+            [("openssl", "-subj")] = false,
         };
 
     /// <summary>

--- a/src/ShellSyntaxTree/Internal/Bash/Verbs/BashVerbs.cs
+++ b/src/ShellSyntaxTree/Internal/Bash/Verbs/BashVerbs.cs
@@ -120,6 +120,14 @@ internal static class BashVerbs
                 "-f", "--file", "-C", "--directory", "-F",
                 "--info-script", "--new-volume-script",
             },
+            ["openssl"] = new HashSet<string>(StringComparer.Ordinal)
+            {
+                // req, x509, and ca consistently bind -subj to X.509
+                // Distinguished Name data. Other OpenSSL options stay out:
+                // their arity or role can vary by subcommand (-serial is a
+                // valueless x509 switch, while ca -key consumes password data).
+                "-subj",
+            },
         };
 
     /// <summary>

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/310_openssl_subject_is_data.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/310_openssl_subject_is_data.json
@@ -1,0 +1,154 @@
+{
+  "name": "OpenSSL subject Distinguished Name remains non-path data",
+  "input": "openssl req -subj \"/O=Example/CN=host.invalid\"",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": [
+          "openssl",
+          "req"
+        ],
+        "args": [
+          {
+            "raw": "-subj",
+            "kind": "Literal",
+            "isPath": false,
+            "resolved": "__NULL__",
+            "isFlag": true
+          },
+          {
+            "raw": "\"/O=Example/CN=host.invalid\"",
+            "kind": "Literal",
+            "isPath": false,
+            "resolved": "__NULL__",
+            "isFlag": false
+          }
+        ],
+        "redirects": [],
+        "elements": [
+          {
+            "raw": "openssl",
+            "value": "openssl",
+            "role": "Verb",
+            "sourceStart": 0,
+            "sourceLength": 7,
+            "precedingVerbElementCount": 0,
+            "kind": "Literal",
+            "isFlag": false,
+            "isPath": false
+          },
+          {
+            "raw": "req",
+            "value": "req",
+            "role": "Verb",
+            "sourceStart": 8,
+            "sourceLength": 3,
+            "precedingVerbElementCount": 1,
+            "kind": "Literal",
+            "isFlag": false,
+            "isPath": false
+          },
+          {
+            "raw": "-subj",
+            "value": "-subj",
+            "role": "Argument",
+            "sourceStart": 12,
+            "sourceLength": 5,
+            "precedingVerbElementCount": 2,
+            "kind": "Literal",
+            "isFlag": true,
+            "isPath": false
+          },
+          {
+            "raw": "\"/O=Example/CN=host.invalid\"",
+            "value": "/O=Example/CN=host.invalid",
+            "role": "Argument",
+            "sourceStart": 18,
+            "sourceLength": 28,
+            "precedingVerbElementCount": 2,
+            "kind": "Literal",
+            "isFlag": false,
+            "isPath": false
+          }
+        ]
+      }
+    ],
+    "syntax": [
+      {
+        "kind": "Block",
+        "parentIndex": null,
+        "region": "Unknown",
+        "childIndex": null,
+        "sourceStart": 0,
+        "sourceLength": 46,
+        "clauseIndex": null,
+        "groupKind": null,
+        "listOperator": null
+      },
+      {
+        "kind": "SimpleCommand",
+        "parentIndex": 0,
+        "region": "Root",
+        "childIndex": 0,
+        "sourceStart": 0,
+        "sourceLength": 46,
+        "clauseIndex": 0,
+        "groupKind": null,
+        "listOperator": null
+      }
+    ],
+    "commands": [
+      {
+        "clauseIndex": 0,
+        "immediateRole": "Ordinary",
+        "isComplete": true,
+        "ancestry": [
+          {
+            "ancestorKind": "Block",
+            "region": "Root",
+            "childIndex": 0,
+            "sourceStart": 0,
+            "sourceLength": 46
+          }
+        ],
+        "arguments": [
+          {
+            "clauseArgumentIndex": 0,
+            "clauseElementIndex": 2,
+            "value": {
+              "kind": "Exact",
+              "values": [
+                "-subj"
+              ],
+              "pattern": null,
+              "coveringDirectory": null
+            }
+          },
+          {
+            "clauseArgumentIndex": 1,
+            "clauseElementIndex": 3,
+            "value": {
+              "kind": "Exact",
+              "values": [
+                "/O=Example/CN=host.invalid"
+              ],
+              "pattern": null,
+              "coveringDirectory": null
+            }
+          }
+        ],
+        "workingDirectory": {
+          "kind": "Exact",
+          "values": [
+            "/work"
+          ],
+          "pattern": null,
+          "coveringDirectory": null
+        }
+      }
+    ]
+  },
+  "notes": "OpenSSL req -subj consumes Distinguished Name data. A leading slash is DN syntax, not filesystem evidence."
+}

--- a/tests/ShellSyntaxTree.Tests/Parsing/BashCommandParserTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Parsing/BashCommandParserTests.cs
@@ -1324,6 +1324,69 @@ public class BashCommandParserTests
     }
 
     [Fact]
+    public void Openssl_req_subj_dn_value_is_not_a_path_keyout_and_out_values_are()
+    {
+        // Repro for the trust-zone flag-value false positive: -subj carries
+        // an X.509 Distinguished Name, not a filesystem path, even though a
+        // DN often starts with '/' and looks path-shaped. -keyout and -out
+        // are the genuine path operands and must stay IsPath=true.
+        var result = Parse(
+            "openssl req -x509 -newkey rsa:2048 -keyout /app/ssl/server.key "
+            + "-out /app/ssl/server.crt -days 365 -nodes "
+            + "-subj \"/O=DevOps Team/CN=host.local\"");
+        var clause = Assert.Single(result.Clauses);
+        Assert.Equal(new[] { "openssl", "req" }, clause.Verb.Tokens);
+
+        var args = clause.Args;
+        var keyoutValue = args[args.ToList().FindIndex(a => a.Raw == "-keyout") + 1];
+        var outValue = args[args.ToList().FindIndex(a => a.Raw == "-out") + 1];
+        var subjValue = args[args.ToList().FindIndex(a => a.Raw == "-subj") + 1];
+
+        Assert.True(keyoutValue.IsPath);
+        Assert.Equal("/app/ssl/server.key", keyoutValue.Resolved);
+        Assert.True(outValue.IsPath);
+        Assert.Equal("/app/ssl/server.crt", outValue.Resolved);
+        Assert.False(subjValue.IsPath);
+    }
+
+    [Theory]
+    [InlineData("req")]
+    [InlineData("x509")]
+    [InlineData("ca")]
+    public void Openssl_subj_is_non_path_data_across_documented_subcommands(
+        string subcommand)
+    {
+        var result = Parse($"openssl {subcommand} -subj '/O=Example/CN=host.invalid'");
+
+        var clause = Assert.Single(result.Clauses);
+        var value = Assert.Single(clause.Args, arg => !arg.IsFlag);
+        Assert.False(value.IsPath);
+        Assert.Null(value.Resolved);
+    }
+
+    [Fact]
+    public void Openssl_x509_serial_does_not_consume_the_following_path()
+    {
+        var result = Parse("openssl x509 -serial /tmp/certificate.pem");
+
+        var clause = Assert.Single(result.Clauses);
+        var certificate = Assert.Single(clause.Args, arg => arg.Raw == "/tmp/certificate.pem");
+        Assert.True(certificate.IsPath);
+        Assert.Equal("/tmp/certificate.pem", certificate.Resolved);
+    }
+
+    [Fact]
+    public void Openssl_ca_key_does_not_claim_universal_path_semantics()
+    {
+        var result = Parse("openssl ca -key secret-value");
+
+        var clause = Assert.Single(result.Clauses);
+        var key = Assert.Single(clause.Args, arg => arg.Raw == "secret-value");
+        Assert.False(key.IsPath);
+        Assert.Null(key.Resolved);
+    }
+
+    [Fact]
     public void Docker_volume_value_is_not_a_path_per_locked_interpretation_8()
     {
         var result = Parse("docker run -v /host:/container nginx");

--- a/tests/ShellSyntaxTree.Tests/Parsing/BashPerVerbRulesTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Parsing/BashPerVerbRulesTests.cs
@@ -280,6 +280,20 @@ public class BashPerVerbRulesTests
         Assert.True(BashPerVerbRules.ValueOfFlagIsPath("tar", "--directory"));
     }
 
+    [Theory]
+    [InlineData("-subj", true, false)]
+    [InlineData("-serial", false, false)]
+    [InlineData("-key", false, false)]
+    public void Openssl_option_table_contains_only_stable_cross_subcommand_semantics(
+        string flag,
+        bool consumesValue,
+        bool valueIsPath)
+    {
+        Assert.True(BashVerbs.FlagsWithValue.TryGetValue("openssl", out var flags));
+        Assert.Equal(consumesValue, flags.Contains(flag));
+        Assert.Equal(valueIsPath, BashPerVerbRules.ValueOfFlagIsPath("openssl", flag));
+    }
+
     [Fact]
     public void Unknown_verb_or_flag_returns_false()
     {

--- a/tests/ShellSyntaxTree.Tests/Parsing/PwshCommandParserTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Parsing/PwshCommandParserTests.cs
@@ -186,6 +186,39 @@ public class PwshCommandParserTests
         Assert.False(clause.Args[1].IsPath);
     }
 
+    [Theory]
+    [InlineData("req")]
+    [InlineData("x509")]
+    [InlineData("ca")]
+    public void Openssl_subj_is_non_path_data_across_native_subcommands(string subcommand)
+    {
+        var clause = Assert.Single(Parse($"openssl {subcommand} -subj \"/O=Example/CN=host.invalid\"").Clauses);
+
+        var subject = Assert.Single(clause.Args, arg => arg.Raw == "\"/O=Example/CN=host.invalid\"");
+        Assert.False(subject.IsPath);
+        Assert.Null(subject.Resolved);
+    }
+
+    [Fact]
+    public void Openssl_x509_serial_does_not_consume_the_following_native_path()
+    {
+        var clause = Assert.Single(Parse("openssl x509 -serial C:/work/certificate.pem").Clauses);
+
+        var certificate = Assert.Single(clause.Args, arg => arg.Raw == "C:/work/certificate.pem");
+        Assert.True(certificate.IsPath);
+        Assert.Equal("C:/work/certificate.pem", certificate.Resolved);
+    }
+
+    [Fact]
+    public void Openssl_ca_key_does_not_claim_universal_native_path_semantics()
+    {
+        var clause = Assert.Single(Parse("openssl ca -key secret-value").Clauses);
+
+        var password = Assert.Single(clause.Args, arg => arg.Raw == "secret-value");
+        Assert.False(password.IsPath);
+        Assert.Null(password.Resolved);
+    }
+
     // ---------------------------------------------------------------- pipelines
 
     [Fact]


### PR DESCRIPTION
## Problem

`openssl req -subj` consumes an X.509 Distinguished Name. A DN such as
`/O=Example/CN=host.invalid` starts with `/`, so the generic path-shape
heuristic falsely classified it as a filesystem path.

The first version of this PR corrected that case by adding a broad verb-wide
OpenSSL option table. That table was unsafe because OpenSSL option arity and
roles vary by subcommand: for example, `openssl x509 -serial` is valueless,
while `openssl ca -key` consumes private-key password data rather than a path.

## Corrected fix

- Add exactly one verb-wide OpenSSL rule: `-subj` consumes non-path DN data.
- Pin that stable behavior across the documented `req`, `x509`, and `ca`
  subcommands.
- Leave every subcommand-specific OpenSSL option outside the generic table.
- Add negative regressions proving `x509 -serial` does not swallow a following
  certificate path and `ca -key` gains no universal path semantics.
- Exercise the shared native-option table through both Bash and PowerShell
  parsers.
- Add a sanitized Bash corpus case and synchronize `SPEC.md` and
  `IMPLEMENTATION_PLAN.md`.

This changes no public API and contains no Netclaw-specific policy logic.

## Validation

- Focused OpenSSL and verb-table tests: 73 passed
- `dotnet build -c Release`: 0 warnings, 0 errors
- `dotnet test -c Release --no-build`: 2,946 passed
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`: pass
- Slopwatch over all modified C# files: 0 issues
- `dotnet pack -c Release --no-build`: package and symbols package created;
  package contains the expected `net8.0` and `netstandard2.0` assemblies

The package remains version `0.3.2` on this maintenance branch. The separate
0.3.3 implementation branch owns the version bump and release-note
consolidation.
