### PR TITLE
docs: specify v0.3.3 authored filesystem value projection

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -10,7 +10,7 @@ priorities.
 
 ---
 
-## NOW (0.3.2 parser fix and downstream acceptance)
+## NOW (0.3.3 authored filesystem facts and downstream acceptance)
 
 - [x] **Create the v0.3.1 approval-fact OpenSpec.** Harvest and sanitize the
       Netclaw v0.26.0-beta.3 approval window. Classify all 18 distinct prompts
@@ -55,6 +55,19 @@ priorities.
       public 0.3.2 from a fresh cache; its Release build and full runnable test
       suite passed. Exact D02/D10/D14 fixture binding remains tracked by the
       separate post-publication downstream gate above.
+- [ ] **Approve the v0.3.3 authored-filesystem-value contract.** Review
+      `openspec/changes/v0-3-3-authored-operand-role/` as the bounded D14 fix.
+      The public projection must require a separate audited local-path binder,
+      transform-safe authored candidates, exact local resolution, and strict
+      `Unknown` fallback. Compatibility `IsPath`, lexical path shape, broad
+      file-verb tables, and bounded pre-splitting words cannot supply the fact
+      by themselves.
+- [ ] **Implement, validate, and publish v0.3.3.** Add the single additive
+      `AnalyzedArgument.AuthoredFileSystemValue` property, the smallest audited
+      Bash and PowerShell binders, exact transform and resolver boundaries,
+      corpus and consumer-guide examples, public 0.3.2 API comparison, native
+      Windows coverage, downstream Netclaw D14 acceptance, and tag-driven
+      package publication.
 
 ## Completed v0.3.0 host integration and release acceptance
 

--- a/openspec/changes/v0-3-3-authored-operand-role/.openspec.yaml
+++ b/openspec/changes/v0-3-3-authored-operand-role/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-13

--- a/openspec/changes/v0-3-3-authored-operand-role/design.md
+++ b/openspec/changes/v0-3-3-authored-operand-role/design.md
@@ -1,0 +1,263 @@
+## Context
+
+`AnalyzedArgument.Argument.IsPath` is part of the v0.2 compatibility leaf. It
+uses broad heuristics so old consumers can find likely paths. Those heuristics
+also classify values such as an interpreter payload, a numeric count, a remote
+endpoint, or a PowerShell filter as paths. They cannot support a new strong
+local-filesystem claim.
+
+ShellSyntaxTree 0.3.2 separately publishes `AuthoredValue` and
+`AuthoredPathShape`. Neither says that a value occupies a proved local
+filesystem slot. `AuthoredValue` also precedes field splitting and pathname
+expansion, so bounded source words are not automatically bounded runtime path
+arguments.
+
+Both gaps appear around Netclaw evidence row D14:
+
+```bash
+for f in src/App/App.csproj src/Hosting/Hosting.csproj; do
+  cat /work/$f
+done
+```
+
+With `PublishAuthoredSourceFacts=true`, the parser proves two authored words
+but reports an unknown effective value and `Argument.IsPath=false`. Netclaw
+must not infer local path authority from `cat`, slash characters, or the broad
+compatibility tables.
+
+The public API is stable at 0.3.2. The change must be additive, preserve
+fail-closed defaults, and avoid a consumer-side executable parser.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Expose bounded, resolver-normalized local filesystem values derived from an
+  authored argument.
+- Require an audited parser-owned local-path binder and a transform-safe value
+  proof before publication.
+- Let a consumer evaluate D14 through its path policy without guessing from
+  command identity or lexical shape.
+- Use one public shape for Bash and PowerShell.
+- Preserve source and binary compatibility with 0.3.2.
+
+**Non-Goals:**
+
+- Strengthen or reinterpret compatibility `Arg.IsPath` or
+  `ClauseElement.IsPath`.
+- Claim that a path exists, is allowed, or remains within a trust zone.
+- Treat a remote endpoint or non-filesystem PowerShell provider as a local
+  path.
+- Add a full grammar for every executable.
+- Publish a path domain for field-split, glob-expanded, ambiguous, or
+  unbounded authored values in this slice.
+- Add a parallel authored projection for redirects; the redirect hierarchy
+  already owns their path relevance.
+- Relax dynamic identity, hidden execution, runtime iterators, unsupported
+  control flow, or incomplete occurrences.
+
+## Decisions
+
+### 1. Add one bounded filesystem-value projection
+
+The public API adds one property and reuses the existing closed value union:
+
+```csharp
+public sealed record AnalyzedArgument
+{
+    // Existing members remain unchanged.
+    public ShellValueDomain AuthoredFileSystemValue { get; internal init; }
+}
+```
+
+Parser results always set the property. `ShellValueDomain.Unknown` means the
+parser supplies no bounded local-filesystem fact. The positive alternatives in
+this release are `Exact` and `FiniteSet`; later support for `PathPattern` needs
+a separate contract because it models pathname expansion. `IntegerRange` and
+`Concatenation` are invalid for this property and fail projection closed.
+
+An enum plus `AuthoredValue` was rejected. That shape would force every
+consumer to recombine binding, field-split, glob, resolution, and value-domain
+rules. A direct domain answers the consumer's actual question while it remains
+a parser fact rather than an authorization result.
+
+### 2. Separate strong binders from compatibility path heuristics
+
+The positive projection uses a new internal audited binder catalog. It does
+not copy `Arg.IsPath`, `ClauseElement.IsPath`, `FileVerbs`, or generic
+path-shape output. An entry must prove that the accepted argument position is a
+local filesystem path for every syntax shape that the binder accepts.
+
+The catalog uses general binding categories, such as all non-option operands
+or one exact named/positional parameter. Commands opt into a category through
+data. An option with special grammar remains unknown until a reviewed binder
+models that complete option shape. The initial Bash slice must cover D14's
+ordinary `cat` operand. The initial PowerShell slice must cover one exact
+filesystem parameter in each supported dialect.
+
+The broad compatibility results stay unchanged:
+
+```text
+python -c 'print(1)'
+test 1 -eq 1
+head -n 10 README
+scp user@example.test:/srv/file .
+Get-ChildItem C:\work *.cs
+Rename-Item C:\old new
+```
+
+Their unaudited, remote, count, payload, filter, or relational positions have
+`AuthoredFileSystemValue=Unknown`, even when compatibility `IsPath` is true.
+`curl --output=-` and `tar --file=-` also remain unknown because `-` denotes a
+stream rather than a local file. The audited `cat` binder applies the same
+boundary to `cat -` and `cat -- -`.
+
+This is a general parser-owned catalog, not a Netclaw command parser. It may
+grow only through full-shape tests and an invariant that applies to every
+accepted argument for that entry.
+
+### 3. Require transform-safe authored candidates
+
+`PublishAuthoredSourceFacts` remains an explicit consumer assertion that
+ambient Bash variable attributes and ambient `IFS` are outside the approval
+claim. The new projection adds a stricter rule under that boundary: each
+candidate must remain one filesystem argument under ordinary Bash field and
+pathname semantics.
+
+For an unquoted tracked expansion, each candidate must contain no default-IFS
+whitespace and no active glob character. Quoted expansions may contain
+whitespace because they remain one field. Any unresolved cardinality,
+zero-or-many expansion, active glob, or opaque fragment produces `Unknown`.
+This slice does not enumerate the filesystem.
+
+The proof follows fragment provenance and never reparses a substituted value
+as shell source. A loop binding whose literal value is `$HOME/literal` remains
+a filename containing `$`; it does not expand `HOME` a second time. A quoted
+`*.txt` candidate may likewise be one literal filename, while an unquoted
+candidate keeps active pathname expansion and remains unknown.
+
+Therefore the positive D14 values are supported, while this value is not:
+
+```bash
+for f in 'src/A.cs /etc/passwd'; do cat /work/$f; done
+```
+
+The unquoted expansion can produce `/work/src/A.cs` and `/etc/passwd` under
+ordinary splitting, so `AuthoredFileSystemValue` is `Unknown`. The property
+does not reinterpret `AuthoredValue`; it is a separate derived fact.
+
+### 4. Normalize only with exact local context
+
+Positive `Exact` and `FiniteSet` values contain absolute local filesystem
+paths. The parser uses its existing shell-specific resolver and the
+occurrence's exact working directory. An unknown cwd, remote endpoint,
+provider ambiguity, invalid path, or platform-style conflict produces
+`Unknown`.
+
+Lexical `AuthoredPathShape` can reject a mismatch but cannot create the
+projection. A path-shaped API route remains unknown. A bare `cat README` can
+produce an exact local path when the binder and cwd are both proved, even
+though its lexical path shape is unknown.
+
+### 5. Preserve argument coordinates and join rules
+
+One authored element may project a flag plus its bound value. Only the value
+receives a positive filesystem domain. The flag remains unknown.
+
+Abstract-state analysis recomputes the complete argument vector for each
+reachable loop visit. The joined filesystem domain is positive only when every
+visit binds the same analyzed argument to a proved local-path slot and each
+visit has transform-safe candidates. A binding conflict, missing visit fact, or
+over-limit union becomes `Unknown`.
+
+The exact audited adversarial join is:
+
+```bash
+for f in -n README; do cat "$f"; done
+```
+
+The expansion is an option in one visit and an audited `cat` filesystem
+operand in the other, so its joined projection is unknown. The paired
+all-filesystem `cat` loop remains finite and positive. PowerShell's
+`Get-Content -LiteralPath:C:\work\a.txt` separately proves that inline
+projection assigns the positive domain to the value argument, not the flag.
+
+An unaudited `curl --output=/work/out` / `curl --data=/api/v1` loop remains a
+useful compatibility negative, but cannot by itself prove join behavior because
+both alternatives are already unknown at the audited-binder gate.
+
+### 6. Apply one public contract to Bash and PowerShell
+
+Bash uses the audited binder, shell-value provenance, ordinary transform
+proof, and its local path resolver.
+
+PowerShell uses an audited dialect-aware cmdlet/native binder and its resolver.
+An exact filesystem-qualified target can be positive. A non-filesystem
+provider, an unproved provider, a filter, a rename fragment, a remote native
+endpoint, or dialect-unknown parameter binding remains unknown. PowerShell
+effective and authored value semantics do not otherwise change.
+
+### 7. Keep authorization in the consumer
+
+A positive `AuthoredFileSystemValue` is not an allow decision. A security
+consumer must still:
+
+1. require a complete parse and occurrence;
+2. explicitly accept the authored-source threat-model boundary;
+3. accept only the documented domain alternatives;
+4. evaluate each absolute path through its own path and trust-zone policy;
+5. evaluate redirects and every other command occurrence independently; and
+6. fail closed on `Unknown` or an unrecognized domain type.
+
+The consumer may not use `AuthoredValue`, `AuthoredPathShape`, or compatibility
+`IsPath` as a substitute for the new projection.
+
+### 8. Preserve compatibility through an additive release
+
+No existing public member or signature changes. The property uses a closed
+type that 0.3.2 consumers already understand. As with existing record members,
+it participates in generated equality, hashing, `ToString()`, reflection, and
+default JSON shape. Parser results remain an in-memory API, not a stable wire
+format.
+
+The implementation adds exact public API snapshots and compares both target
+frameworks against public 0.3.2. The intended release is 0.3.3.
+
+## Risks / Trade-offs
+
+- **Risk: compatibility heuristics leak into the strong projection.** → The
+  new binder catalog is separate and false-positive compatibility cases stay
+  unknown.
+- **Risk: an authored word splits into an external path.** → Positive domains
+  require one-field candidates under ordinary transforms; exact whitespace and
+  glob counterexamples remain unknown.
+- **Risk: a remote or provider path is treated as local.** → Local resolver,
+  provider, remote-endpoint, and dialect checks precede publication.
+- **Risk: loop visits disagree about option binding.** → Whole-vector replay
+  joins every visit and returns unknown on any conflict.
+- **Risk: consumers treat the domain as authorization.** → The guide and tests
+  require independent path policy and complete-call checks.
+- **Trade-off: the initial audited catalog is small.** → False negatives are
+  recoverable. Each later catalog entry needs full-shape positive and negative
+  evidence.
+
+## Migration Plan
+
+1. Add the property with a parser-emitted unknown default and public API
+   snapshots.
+2. Add internal audited Bash and PowerShell local-path binders.
+3. Add transform and local-resolution projection after authored-value
+   analysis.
+4. Add direct, corpus, oracle, consumer-guide, and adversarial coverage.
+5. Validate source and binary compatibility against public 0.3.2.
+6. Publish 0.3.3 after Linux and native Windows CI pass.
+7. Let Netclaw opt into the property in a separate package-upgrade change.
+
+Rollback needs no data migration. Netclaw can ignore the property or pin
+0.3.2. Existing consumers continue to compile and run.
+
+## Open Questions
+
+None. Implementation must stop for design revision if the positive catalog
+needs executable-private control flow rather than bounded table data, or if
+PowerShell cannot prove a local target from existing dialect metadata.

--- a/openspec/changes/v0-3-3-authored-operand-role/proposal.md
+++ b/openspec/changes/v0-3-3-authored-operand-role/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+ShellSyntaxTree 0.3.2 can publish a finite authored word while clearing the
+effective `Arg.IsPath` bit when Bash field splitting prevents an exact runtime
+path claim. A policy consumer then cannot distinguish a parser-owned
+filesystem operand from data that merely looks path-shaped, so it must prompt
+for safe bounded loops such as D14.
+
+## What Changes
+
+- Add a shell-neutral `AnalyzedArgument.AuthoredFileSystemValue` domain.
+- Publish a bounded local path domain only when an audited parser-owned binder
+  and transform-safe authored candidates both hold.
+- Keep the broad compatibility `IsPath` tables separate; they cannot supply
+  this stronger fact without an explicit audit.
+- Keep effective value, authored value, lexical path shape, and the authored
+  filesystem projection as independent facts.
+- Cover Bash and PowerShell boundaries without adding executable-private
+  grammar for the motivating command.
+- Update the consumer guide and D14 corpus evidence.
+
+## Capabilities
+
+### New Capabilities
+
+- `authored-filesystem-value`: Expose bounded parser-owned local filesystem values
+  for authored arguments, with strict unknown defaults and cross-shell
+  consumer rules.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Public API: one additive `AnalyzedArgument` property that reuses the closed
+  `ShellValueDomain` family. Existing members and signatures remain unchanged.
+  Generated record equality, hashing, `ToString()`, reflection, and default
+  serializer shape will include the new property.
+- Parser internals: Bash and PowerShell must retain audited local-path binding
+  and transform provenance even when effective resolution clears `Arg.IsPath`.
+- Tests and corpus: public API snapshots, direct parser cases, executable
+  corpus DTOs, D14, and adversarial path-shaped data cases change.
+- Consumer guidance: policy code may send each represented value through path
+  policy only when `AuthoredFileSystemValue` is `Exact` or `FiniteSet`.
+- Version: the intended package is an additive 0.3.3 release.

--- a/openspec/changes/v0-3-3-authored-operand-role/specs/authored-filesystem-value/spec.md
+++ b/openspec/changes/v0-3-3-authored-operand-role/specs/authored-filesystem-value/spec.md
@@ -1,0 +1,317 @@
+## ADDED Requirements
+
+### Requirement: Authored filesystem value is additive and fail-closed
+
+`AnalyzedArgument` SHALL expose an additive `AuthoredFileSystemValue` property
+of type `ShellValueDomain` with an assembly-owned setter. Every parser-produced
+argument SHALL set the property to a non-null domain. The strict result SHALL
+be `ShellValueDomain.Unknown`.
+
+The only positive alternatives in this release SHALL be `Exact` and
+`FiniteSet`. A parser path that would produce `IntegerRange`, `Concatenation`,
+`PathPattern`, an unrecognized alternative, or no domain SHALL publish
+`Unknown` instead. Existing public members and signatures SHALL remain
+unchanged. The property SHALL participate in generated record equality,
+hashing, `ToString()`, reflection, and default serializer shape.
+
+#### Scenario: Ordinary unknown argument remains strict
+
+- **WHEN** an argument lacks a complete authored local-filesystem proof
+- **THEN** `AuthoredFileSystemValue` is `Unknown`
+- **AND** no consumer can infer filesystem authority from that default
+
+#### Scenario: Public API extends 0.3.2
+
+- **WHEN** the 0.3.3 public surface is compared with public 0.3.2
+- **THEN** `AuthoredFileSystemValue` is the only public API addition for this
+  capability
+- **AND** no 0.3.2 member or signature changes
+
+#### Scenario: Unsupported value-domain alternative fails closed
+
+- **WHEN** projection encounters a value-domain alternative other than
+  `Exact` or `FiniteSet`
+- **THEN** `AuthoredFileSystemValue` is `Unknown`
+
+### Requirement: Strong local-path binding is separate from compatibility heuristics
+
+A positive `AuthoredFileSystemValue` SHALL require a parser-owned binding that
+proves the accepted argument position is a local filesystem value for every
+syntax shape accepted by that binding. The implementation SHALL keep this
+audited binding catalog separate from compatibility `Arg.IsPath`,
+`ClauseElement.IsPath`, `FileVerbs`, generic lexical path shape, and generic
+positional fallback rules. None of those compatibility facts SHALL create a
+positive domain by themselves.
+
+The audited catalog MAY use reusable binding categories and data entries. Each
+entry SHALL define the complete accepted argument shape needed to distinguish
+local path values from flags, flag values, stream sentinels, remote endpoints,
+filters, names relative to another operand, and ordinary data. An unaudited or
+ambiguous position SHALL remain `Unknown`.
+
+#### Scenario: Audited cat operand supplies a local value
+
+- **GIVEN** the occurrence cwd is exactly `/work`
+- **WHEN** Bash parses `cat README.md`
+- **THEN** the `README.md` argument has
+  `AuthoredFileSystemValue=Exact("/work/README.md")`
+- **AND** its lexical `AuthoredPathShape` may remain `Unknown`
+
+#### Scenario: Broad compatibility path result does not supply the strong fact
+
+- **WHEN** Bash parses each of
+  `python -c 'print(1)'`, `test 1 -eq 1`, and `head -n 10 README`
+- **THEN** `print(1)`, `1`, `10`, and every other unaudited position have
+  `AuthoredFileSystemValue=Unknown`
+- **AND** any compatibility `IsPath` result is unchanged
+
+#### Scenario: Remote endpoint is not a local path
+
+- **WHEN** Bash parses `scp user@example.invalid:/srv/file .`
+- **THEN** the remote endpoint has `AuthoredFileSystemValue=Unknown`
+- **AND** no lexical slash or compatibility path bit turns it into a local
+  filesystem value
+
+#### Scenario: Path-shaped data remains unknown
+
+- **WHEN** an argument is `/api/v1`, `example/project`, `org/image`, or a URL
+  without an audited local-path binding
+- **THEN** `AuthoredFileSystemValue` is `Unknown`
+
+#### Scenario: Stream sentinels remain unknown
+
+- **WHEN** Bash parses `curl --output=-` or `tar --file=-`
+- **THEN** the inline value has `AuthoredFileSystemValue=Unknown`
+
+#### Scenario: Audited cat stream sentinel remains unknown
+
+- **WHEN** Bash parses `cat -` or `cat -- -`
+- **THEN** the `-` operand has `AuthoredFileSystemValue=Unknown`
+- **AND** the audited binder does not reinterpret standard input as a local
+  filesystem path
+
+### Requirement: Positive authored paths are transform-safe
+
+A positive `AuthoredFileSystemValue` SHALL prove that every represented
+authored candidate remains exactly one filesystem argument under the standard
+field-splitting and pathname-expansion semantics accepted by
+`PublishAuthoredSourceFacts`. The proof SHALL use shell-value provenance, not
+only the final characters of `AuthoredValue`.
+
+An active unquoted split, active pathname expansion, zero-or-many field
+cardinality, unresolved fragment, opaque source, or explicit shell-state
+mutation that invalidates the proof SHALL produce `Unknown`. The parser SHALL
+NOT enumerate the filesystem to create this fact. Quoting or escaping MAY
+prove that whitespace or metacharacters remain literal.
+
+#### Scenario: D14 candidates are transform-safe
+
+- **GIVEN** `PublishAuthoredSourceFacts=true`
+- **AND** the occurrence cwd is exact
+- **WHEN** Bash parses
+  `for f in src/A.cs src/B.cs; do cat /work/$f; done`
+- **THEN** the `cat` argument has effective `Value=Unknown`
+- **AND** its compatibility `Argument.IsPath` is false
+- **AND** its `AuthoredValue` is the finite set
+  `[/work/src/A.cs, /work/src/B.cs]`
+- **AND** its `AuthoredFileSystemValue` is the normalized finite set
+  `[/work/src/A.cs, /work/src/B.cs]`
+
+#### Scenario: Unquoted field splitting blocks the projection
+
+- **GIVEN** `PublishAuthoredSourceFacts=true`
+- **WHEN** Bash parses
+  `for f in 'src/A.cs /etc/passwd'; do cat /work/$f; done`
+- **THEN** `AuthoredValue` may contain the bounded authored word
+  `/work/src/A.cs /etc/passwd`
+- **BUT** `AuthoredFileSystemValue` is `Unknown`
+- **AND** the parser does not claim one runtime path argument
+
+#### Scenario: Active glob remains strict
+
+- **WHEN** an audited path position contains an active unquoted glob
+- **THEN** `AuthoredFileSystemValue` is `Unknown`
+- **AND** this release does not enumerate matches or publish a `PathPattern`
+
+#### Scenario: Substituted text is not recursively expanded
+
+- **GIVEN** an exact occurrence cwd of `/work`
+- **WHEN** Bash analyzes
+  `for f in '$HOME/literal'; do cat "$f"; done`
+- **THEN** `AuthoredFileSystemValue` is
+  `Exact("/work/$HOME/literal")`
+- **AND** the parser does not expand the substituted `$HOME` text again
+
+#### Scenario: Quoting controls literal glob provenance
+
+- **GIVEN** an exact occurrence cwd of `/work`
+- **WHEN** Bash analyzes
+  `for f in '*.txt'; do cat "$f"; done`
+- **THEN** `AuthoredFileSystemValue` is `Exact("/work/*.txt")`
+- **BUT WHEN** the loop body uses unquoted `cat $f`
+- **THEN** `AuthoredFileSystemValue` is `Unknown`
+
+#### Scenario: Quoted whitespace can remain one field
+
+- **WHEN** an audited path argument has an exact quoted value
+  `"/work/file name.txt"`
+- **AND** the local resolver accepts it
+- **THEN** the whitespace does not by itself force the domain to `Unknown`
+
+### Requirement: Positive values are normalized local filesystem paths
+
+Every `Exact` or `FiniteSet` value in `AuthoredFileSystemValue` SHALL be an
+absolute local filesystem path normalized by the existing shell-specific
+resolver against the occurrence's exact cwd. An unknown cwd, invalid path,
+remote endpoint, non-filesystem provider, unresolved provider, or path-style
+conflict SHALL produce `Unknown`. `AuthoredPathShape` MAY reject a candidate
+but SHALL NOT create a positive domain.
+
+#### Scenario: Relative audited path uses the exact occurrence cwd
+
+- **GIVEN** an exact occurrence cwd of `/work/project`
+- **WHEN** Bash parses `cat src/App.cs`
+- **THEN** `AuthoredFileSystemValue` is
+  `Exact("/work/project/src/App.cs")`
+
+#### Scenario: Unknown cwd remains strict
+
+- **WHEN** an audited relative path has no exact occurrence cwd
+- **THEN** `AuthoredFileSystemValue` is `Unknown`
+
+#### Scenario: Unknown executable does not gain authority from path shape
+
+- **WHEN** an unknown executable receives `/work/value`
+- **THEN** `AuthoredFileSystemValue` is `Unknown`
+- **AND** the absolute spelling alone does not supply binding proof
+
+### Requirement: Inline projection and abstract joins preserve exact argument semantics
+
+When one authored element projects a flag and a bound value, the parser SHALL
+assign `AuthoredFileSystemValue` to each `AnalyzedArgument` independently.
+Only an audited local-path value MAY receive a positive domain. Abstract-state
+analysis SHALL replay the complete argument vector for every reachable visit.
+The joined result SHALL be positive only when every visit binds the same
+analyzed argument to an audited local-path slot and every represented value is
+transform-safe and locally resolved. A binding conflict, missing visit fact,
+over-limit union, or ambiguous option binding SHALL produce `Unknown`.
+
+#### Scenario: Unmodeled inline output remains strict
+
+- **WHEN** Bash parses `curl --output=/work/out`
+- **THEN** the projected inline value has
+  `AuthoredFileSystemValue=Unknown` until a complete audited binding models
+  that option shape
+
+#### Scenario: Inline data remains strict
+
+- **WHEN** Bash parses `curl --data=/api/v1`
+- **THEN** the projected inline value has
+  `AuthoredFileSystemValue=Unknown`
+
+#### Scenario: Audited PowerShell inline value retains argument coordinates
+
+- **WHEN** the selected dialect parses
+  `Get-Content -LiteralPath:C:\work\a.txt`
+- **THEN** the projected parameter argument has
+  `AuthoredFileSystemValue=Unknown`
+- **AND** the projected value argument has
+  `AuthoredFileSystemValue=Exact("C:/work/a.txt")`
+
+#### Scenario: Audited loop visits disagree about option and operand meaning
+
+- **WHEN** Bash analyzes
+  `for f in -n README; do cat "$f"; done`
+- **THEN** the expansion is an option in one visit and an audited filesystem
+  operand in the other
+- **AND** its joined `AuthoredFileSystemValue` is `Unknown`
+
+#### Scenario: Every audited loop visit is a filesystem operand
+
+- **GIVEN** an exact occurrence cwd of `/work`
+- **WHEN** Bash analyzes
+  `for f in README LICENSE; do cat "$f"; done`
+- **THEN** the joined `AuthoredFileSystemValue` is the finite set
+  `[/work/README, /work/LICENSE]`
+
+#### Scenario: Over-limit finite union remains strict
+
+- **WHEN** reachable audited path values exceed the existing finite-domain cap
+- **THEN** `AuthoredFileSystemValue` is `Unknown`
+
+### Requirement: Bash and PowerShell share one filesystem-value contract
+
+Bash and PowerShell SHALL publish the same `ShellValueDomain` vocabulary for
+`AuthoredFileSystemValue`. PowerShell SHALL require an audited binding from the
+selected dialect and a target that its resolver proves is a local filesystem
+path. A filter, rename fragment, non-filesystem provider, unresolved provider,
+remote native endpoint, or dialect-ambiguous binding SHALL remain `Unknown`.
+
+#### Scenario: PowerShell filesystem parameter supplies a local value
+
+- **GIVEN** the selected PowerShell dialect binds `-LiteralPath`
+- **AND** its resolver proves `C:\work\a.txt` is a local Windows path
+- **WHEN** PowerShell parses
+  `Get-Content -LiteralPath C:\work\a.txt`
+- **THEN** the path argument has
+  `AuthoredFileSystemValue=Exact("C:/work/a.txt")`
+
+#### Scenario: PowerShell filter is not a path
+
+- **WHEN** PowerShell parses `Get-ChildItem C:\work *.cs`
+- **THEN** the audited local path, if proved, is independent from the filter
+- **AND** the `*.cs` filter has `AuthoredFileSystemValue=Unknown`
+
+#### Scenario: Rename fragment is not an independently resolved path
+
+- **WHEN** PowerShell parses `Rename-Item C:\old new`
+- **THEN** the `new` argument has `AuthoredFileSystemValue=Unknown`
+
+#### Scenario: Non-filesystem provider remains strict
+
+- **WHEN** an audited PowerShell parameter targets `Registry::HKEY_LOCAL_MACHINE`
+  or another non-filesystem provider
+- **THEN** `AuthoredFileSystemValue` is `Unknown`
+
+#### Scenario: Native remote endpoint remains strict
+
+- **WHEN** native PowerShell parses `scp user@example.invalid:/srv/file .`
+- **THEN** the remote endpoint has `AuthoredFileSystemValue=Unknown`
+
+#### Scenario: Selected dialect controls binding
+
+- **WHEN** Windows PowerShell 5.1 is the selected dialect
+- **THEN** no PowerShell 7-only parameter binding creates a positive domain
+
+### Requirement: Consumers apply their own policy after the parser proof
+
+A positive `AuthoredFileSystemValue` SHALL NOT mean that a path exists, is
+safe, is authorized, or lies inside a trust zone. A security consumer that
+accepts this source-oriented fact SHALL require a complete occurrence, accept
+the documented authored-source environment assumption, accept only `Exact`
+or `FiniteSet`, and evaluate every represented path through its own path and
+trust-zone policy. It SHALL independently evaluate command identity,
+redirects, substitutions, other arguments, and every other occurrence.
+
+`AuthoredValue`, `AuthoredPathShape`, compatibility `IsPath`, and executable
+names SHALL NOT substitute for `AuthoredFileSystemValue`.
+
+#### Scenario: D14 enters path policy without becoming an allow decision
+
+- **GIVEN** D14 publishes a finite `AuthoredFileSystemValue`
+- **WHEN** a consumer accepts the authored-source contract
+- **THEN** it checks each normalized path through its path policy
+- **AND** the parser fact alone does not allow the invocation
+
+#### Scenario: One unsafe finite path blocks reuse
+
+- **GIVEN** a finite domain contains one path outside consumer authority
+- **WHEN** the consumer evaluates the domain
+- **THEN** it does not reuse approval for the invocation
+
+#### Scenario: All other policy-relevant facts remain required
+
+- **GIVEN** an argument has a positive `AuthoredFileSystemValue`
+- **WHEN** identity, redirect, substitution, ancestry, or completeness facts
+  remain unresolved
+- **THEN** the filesystem value does not relax those facts

--- a/openspec/changes/v0-3-3-authored-operand-role/tasks.md
+++ b/openspec/changes/v0-3-3-authored-operand-role/tasks.md
@@ -1,0 +1,102 @@
+## 1. Public Contract
+
+- [ ] 1.1 Add `AnalyzedArgument.AuthoredFileSystemValue` to `SPEC.md`, source,
+  XML docs, and public API snapshots without changing any 0.3.2 signature.
+- [ ] 1.2 Pin the non-null `Unknown` default, permitted `Exact` and `FiniteSet`
+  alternatives, unsupported-domain fallback, equality, hashing, `ToString()`,
+  reflection, and default JSON participation.
+- [ ] 1.3 Compare both target-framework API surfaces against public 0.3.2 and
+  prove that this capability adds only the property.
+
+## 2. Audited Local-Path Binding
+
+- [ ] 2.1 Add a separate internal local-filesystem binder catalog whose
+  results cannot be sourced from compatibility `IsPath`, `FileVerbs`, lexical
+  path shape, or generic positional fallback.
+- [ ] 2.2 Define reusable binding categories plus full-shape invariants for
+  flags, bound values, positionals, stream sentinels, remote endpoints, and
+  ambiguous positions.
+- [ ] 2.3 Add the smallest Bash entry that covers ordinary `cat` operands and
+  the smallest dialect-aware PowerShell entry that proves one local
+  filesystem parameter.
+- [ ] 2.4 Keep unaudited entries and positions unknown; do not add
+  consumer-specific or executable-private branching.
+- [ ] 2.5 Preserve per-argument binding through PowerShell inline parameter
+  projection and join audited Bash binding across every reachable
+  abstract-state visit.
+
+## 3. Transform and Resolution Proof
+
+- [ ] 3.1 Extend internal authored provenance with an exact one-field proof
+  under the declared standard field-splitting and pathname-expansion model.
+- [ ] 3.2 Reject active unquoted splitting, active globs, zero-or-many fields,
+  opaque fragments, invalidated shell state, unresolved cardinality, and
+  over-limit unions without filesystem enumeration.
+- [ ] 3.3 Resolve positive candidates to normalized absolute local paths using
+  the occurrence cwd and existing shell-specific resolver; reject unknown cwd,
+  invalid paths, remote endpoints, providers, and path-style conflicts.
+- [ ] 3.4 Emit only `Exact`, deduplicated bounded `FiniteSet`, or `Unknown`.
+
+## 4. Bash Acceptance
+
+- [ ] 4.1 Add exact D14 coverage for effective `Value=Unknown`, compatibility
+  `Argument.IsPath=false`, finite `AuthoredValue`, and finite normalized
+  `AuthoredFileSystemValue`.
+- [ ] 4.2 Add direct positive cases for `cat README.md`, an absolute `cat`
+  operand, exact cwd resolution, quoted whitespace, non-recursive `$HOME`
+  text, literal quoted glob text, and loop finite-set joins.
+- [ ] 4.3 Add transform negatives for an unquoted candidate containing
+  `/etc/passwd` after whitespace, active glob, zero-or-many expansion, explicit
+  field-splitting state mutation, runtime iterator, and over-limit union.
+- [ ] 4.4 Add audited-binding negatives for `python -c 'print(1)'`,
+  `test 1 -eq 1`, `head -n 10 README`, remote `scp`, path-shaped data, unknown
+  executables, `cat -`, `cat -- -`, `curl --output=-`,
+  `curl --data=/api/v1`, `tar --file=-`,
+  an unaudited `--output`/`--data` shape, and the audited `cat -n` versus
+  operand loop.
+- [ ] 4.5 Preserve dynamic identity, substitutions, redirects, unsupported
+  control flow, and incomplete occurrence behavior in paired negatives.
+- [ ] 4.6 Extend the executable corpus DTO and exact Bash corpus entries with
+  authored-filesystem expectations. Run the corpus PII audit.
+
+## 5. PowerShell Acceptance
+
+- [ ] 5.1 Add selected-dialect positives for spaced and inline exact local
+  filesystem `-LiteralPath` values; prove that only the inline value argument
+  receives the domain and verify normalization on native Windows.
+- [ ] 5.2 Add negatives for `Get-ChildItem C:\work *.cs`,
+  `Rename-Item C:\old new`, non-filesystem and unresolved providers, remote
+  native `scp`, path-shaped data, stream sentinels, and dialect ambiguity.
+- [ ] 5.3 Prove PowerShell 7 and Windows PowerShell 5.1 use their selected
+  metadata without cross-dialect widening.
+- [ ] 5.4 Regenerate PowerShell corpus expectations through the owned corpus
+  tool, inspect the exact temporary-directory diff, and run the PII audit.
+
+## 6. Consumer Contract
+
+- [ ] 6.1 Update `docs/CONSUMER_GUIDE.md` with input, parser output, and policy
+  examples for D14, direct Bash, direct PowerShell, transform-sensitive words,
+  path-shaped data, remote endpoints, filters, and rename fragments.
+- [ ] 6.2 Show a consumer accepting only `Exact` and `FiniteSet`, checking each
+  normalized path through its own policy, and independently enforcing complete
+  occurrences, identity, redirects, substitutions, and ancestry.
+- [ ] 6.3 State the exact authored-source environment assumption and that no
+  parser fact grants authority or proves existence.
+- [ ] 6.4 Update paired sanitized approval evidence without source identity or
+  private repository data.
+- [ ] 6.5 Validate the public 0.3.3 package through Netclaw's exact D14 policy
+  fixture before the downstream policy PR merges.
+
+## 7. Validation and Release
+
+- [ ] 7.1 Run `openspec validate v0-3-3-authored-operand-role --strict` and
+  synchronize the accepted contract into `SPEC.md` before implementation is
+  declared complete.
+- [ ] 7.2 Run the Release build, full unit and corpus suite, header check,
+  Slopwatch, package build, public API diff, and PII audit sequentially.
+- [ ] 7.3 Obtain adversarial reviews of the API contract, audited binders,
+  transform proof, Bash and PowerShell behavior, consumer guidance, and final
+  frozen diff.
+- [ ] 7.4 Update `IMPLEMENTATION_PLAN.md` and release notes with exact evidence.
+- [ ] 7.5 Merge only after Linux and native Windows CI pass; tag and publish
+  0.3.3 through the release workflow.


### PR DESCRIPTION
## Summary

Defines the bounded ShellSyntaxTree v0.3.3 fact needed for Netclaw evidence row D14 without turning Netclaw into an executable parser.

The public shape is one additive property:

```csharp
public ShellValueDomain AuthoredFileSystemValue { get; internal init; }
```

A positive `Exact` or `FiniteSet` requires all three parser-owned proofs:

1. an audited, data-driven local-filesystem argument binding;
2. an authored value that remains exactly one argument under the declared field-splitting and pathname-expansion model; and
3. normalization through the existing shell resolver with an exact cwd.

Everything else is `Unknown`. Compatibility `IsPath`, broad `FileVerbs`, lexical path shape, and a bounded pre-splitting word cannot create this stronger fact.

## Security boundaries

The specification pins negative cases for interpreter payloads, numeric counts, remote endpoints, stream sentinels, PowerShell filters and rename fragments, field-split paths, active globs, non-recursive substitutions, ambiguous inline binding, and conflicting loop visits. Consumers still own path policy, trust zones, completeness, redirects, substitutions, and authorization.

## Validation

- `openspec validate v0-3-3-authored-operand-role --strict`
- `dotnet build -c Release` — 0 warnings/errors
- `dotnet test -c Release --no-build` — 2,931 passed
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`
- `git diff --check`
- adversarial review: PASS after two design revisions
