### PR TITLE
Publish audited authored filesystem facts in v0.3.3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.3.2</VersionPrefix>
+    <VersionPrefix>0.3.3</VersionPrefix>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Target framework matrix -->

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -55,7 +55,12 @@ priorities.
       public 0.3.2 from a fresh cache; its Release build and full runnable test
       suite passed. Exact D02/D10/D14 fixture binding remains tracked by the
       separate post-publication downstream gate above.
-- [ ] **Approve the v0.3.3 authored-filesystem-value contract.** Review
+- [x] **Approve the v0.3.3 authored-filesystem-value contract.**
+      [PR #163](https://github.com/Aaronontheweb/ShellSyntaxTree/pull/163)
+      merged as `767e15b7` after strict OpenSpec, full unit and corpus, header,
+      Linux CI, Windows CI, and adversarial review passed. The accepted design
+      keeps the public surface to one additive property and requires a separate
+      audited binder plus transform and resolver proof. The contract lives at
       `openspec/changes/v0-3-3-authored-operand-role/` as the bounded D14 fix.
       The public projection must require a separate audited local-path binder,
       transform-safe authored candidates, exact local resolution, and strict

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -72,7 +72,13 @@ priorities.
       Bash and PowerShell binders, exact transform and resolver boundaries,
       corpus and consumer-guide examples, public 0.3.2 API comparison, native
       Windows coverage, downstream Netclaw D14 acceptance, and tag-driven
-      package publication.
+      package publication. The frozen local implementation passes a zero-warning
+      Release build, all 2,995 unit and corpus tests, the corpus PII audit,
+      header verification, strict OpenSpec validation, Slopwatch, and a 0.3.3
+      package build. Both target-framework API comparisons report exactly the
+      one approved additive property. Adversarial review, native Windows CI,
+      public package publication, and downstream Netclaw acceptance remain
+      required before this item is complete.
 - [x] **Keep OpenSSL subject data out of path classification.** Treat the
       slash-prefixed `-subj` Distinguished Name as non-path data without
       assigning verb-wide arity or path roles to subcommand-specific options.

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -73,7 +73,7 @@ priorities.
       corpus and consumer-guide examples, public 0.3.2 API comparison, native
       Windows coverage, downstream Netclaw D14 acceptance, and tag-driven
       package publication. The frozen local implementation passes a zero-warning
-      Release build, all 2,995 unit and corpus tests, the corpus PII audit,
+      Release build, all 2,996 unit and corpus tests, the corpus PII audit,
       header verification, strict OpenSpec validation, Slopwatch, and a 0.3.3
       package build. Both target-framework API comparisons report exactly the
       one approved additive property. Adversarial review, native Windows CI,

--- a/README.md
+++ b/README.md
@@ -13,11 +13,12 @@ Hand-rolled, AOT-trim friendly, zero native dependencies. Multi-targets
 
 ```bash
 # Current package
-dotnet add package ShellSyntaxTree --version 0.3.1
+dotnet add package ShellSyntaxTree --version 0.3.3
 ```
 
-Version `0.3.1` includes the typed syntax tree, command-occurrence API, and
-bounded authored-value analysis documented below.
+Version `0.3.3` includes the typed syntax tree, command-occurrence API,
+bounded authored-value analysis, and audited authored-filesystem projection
+documented below.
 
 ## What you get
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,53 @@
 #### Unreleased ####
 
+#### 0.3.3 2026-08-13 ####
+
+This additive release publishes bounded local-filesystem values for audited
+authored arguments. It lets security consumers evaluate static loop operands
+through their own path policy without treating broad compatibility heuristics
+or pre-field-splitting words as filesystem authority.
+
+## Added
+
+- Add `AnalyzedArgument.AuthoredFileSystemValue`. The non-null default is
+  `Unknown`; v0.3.3 publishes only normalized `Exact` and `FiniteSet` domains.
+- Add a separate audited local-filesystem binding catalog. The initial entries
+  cover Bash `cat` operands and the selected PowerShell dialect's exact
+  `Get-Content -LiteralPath` value.
+- Add generated Bash and PowerShell corpus expectations plus consumer-guide
+  input/output examples for bounded loops, inline parameters, filters,
+  rename fragments, remote endpoints, and transform-sensitive words.
+
+## Fixed
+
+- Keep slash-prefixed OpenSSL `-subj` Distinguished Names classified as
+  non-path data in Bash and native PowerShell.
+- Preserve subcommand-specific OpenSSL boundaries: `x509 -serial` remains a
+  valueless switch and `ca -key` gains no universal filesystem role.
+
+## Security and compatibility
+
+- Require an audited parser-owned operand binding, exact one-field transform
+  proof, an exact occurrence working directory, and successful local path
+  resolution before publishing the stronger filesystem value.
+- Do not derive the fact from compatibility `IsPath`, `FileVerbs`, lexical
+  path shape, generic positional fallback, or executable-private policy.
+- Keep active field splitting, pathname expansion, stream sentinels, unknown
+  cwd, remote endpoints, non-filesystem providers, dynamic identity,
+  substitutions, unresolved redirects, incomplete control flow, and
+  over-limit unions strict.
+- Preserve all 0.3.2 public signatures. Both target-framework API comparisons
+  report exactly one additive member: `AuthoredFileSystemValue`.
+
+## Consumer validation
+
+- Require consumers to accept only `Exact` or `FiniteSet`, check every path
+  through their own trust-zone policy, and independently enforce occurrence
+  completeness, identity, redirects, substitutions, ancestry, and every other
+  argument.
+- Update the sanitized D14 approval evidence so downstream Netclaw validation
+  can bind the new parser fact without accepting raw `AuthoredValue` as a path.
+
 #### 0.3.2 2026-08-12 ####
 
 This patch release accepts statically proved Bash command identities that use

--- a/SPEC.md
+++ b/SPEC.md
@@ -634,6 +634,8 @@ public sealed record AnalyzedArgument
     public ClauseElement Element { get; internal init; } = null!;
     public ShellValueDomain Value { get; internal init; } = null!;
     public ShellValueDomain AuthoredValue { get; internal init; } = null!;
+    public ShellValueDomain AuthoredFileSystemValue { get; internal init; } =
+        new ShellValueDomain.Unknown();
     public ShellPathShape AuthoredPathShape { get; internal init; }
 }
 
@@ -822,6 +824,32 @@ are `Unknown`. This fact does not claim filesystem operand semantics or grant
 authority: repository slugs, container images, API routes, and other data can
 be path-shaped. PowerShell 0.3.1 sets `AuthoredValue=Value` and
 `AuthoredPathShape=Unknown` for exact compatibility.
+
+`AnalyzedArgument.AuthoredFileSystemValue` is a stronger, independent parser
+fact. `Unknown` means the parser proves no bounded local-filesystem value. In
+v0.3.3, only `Exact` and `FiniteSet` are positive. Every represented value is
+an absolute path normalized by the existing shell resolver. Publication
+requires an audited local-filesystem binding, one-field authored transform
+semantics, and an exact occurrence working directory. Compatibility
+`Arg.IsPath`, `ClauseElement.IsPath`, `FileVerbs`, lexical path shape, and
+generic positional fallback never create this fact by themselves.
+
+The initial audited catalog contains Bash `cat` file operands and the selected
+PowerShell dialect's exact `Get-Content -LiteralPath` value. Bash option values,
+`-` stream operands, active field splitting or pathname expansion, remote
+endpoints, and unaudited executable positions remain `Unknown`. PowerShell
+filters, rename fragments, non-filesystem or unresolved providers, remote
+native endpoints, and ambiguous parameter bindings remain `Unknown`. The
+catalog is parser-owned data, not an authorization policy or a full executable
+grammar.
+
+A positive authored filesystem value does not prove existence, safety,
+trust-zone membership, or authority. Security consumers still require a
+complete occurrence, explicitly accept the authored-source initial-state
+contract, check every represented path through their own path policy, and
+independently evaluate executable identity, redirects, substitutions,
+ancestry, and all other occurrences. `AuthoredValue`, `AuthoredPathShape`, and
+compatibility `IsPath` are not substitutes for this fact.
 
 #### Bash bounded loop state
 

--- a/docs/CONSUMER_GUIDE.md
+++ b/docs/CONSUMER_GUIDE.md
@@ -586,9 +586,10 @@ for f in src/A.cs src/B.cs; do cat /work/$f; done
 the loop-body argument is:
 
 ```text
-Value:             Unknown
-AuthoredValue:     FiniteSet("/work/src/A.cs", "/work/src/B.cs")
-AuthoredPathShape: Posix
+Value:                      Unknown
+AuthoredValue:              FiniteSet("/work/src/A.cs", "/work/src/B.cs")
+AuthoredPathShape:          Posix
+AuthoredFileSystemValue:    FiniteSet("/work/src/A.cs", "/work/src/B.cs")
 ```
 
 `AuthoredValue` is the word proved from submitted source before ambient
@@ -599,17 +600,83 @@ explicit source attribute mutation, redirects, and unsupported control flow
 stay strict. With the default `false`, the same loop retains the 0.3.0 result:
 `IsUnparseable=true` with empty `Commands` and `Clauses`.
 
-Choose the projection explicitly per policy-sensitive argument:
+Do not hand `AuthoredValue` directly to filesystem policy. It is intentionally
+pre-field-splitting and pre-pathname-expansion. For example:
 
-```csharp
-var domain = productPolicyAcceptsPreFieldSplittingWords
-    ? analyzed.AuthoredValue
-    : analyzed.Value;
-
-var decision = EvaluateDomain(domain); // recursive and fail closed
+```bash
+for f in 'src/A.cs /etc/passwd'; do cat /work/$f; done
 ```
 
-`AuthoredPathShape` is lexical evidence only:
+can have one bounded authored word, `/work/src/A.cs /etc/passwd`, while
+ordinary unquoted splitting supplies two runtime arguments, including
+`/etc/passwd`. ShellSyntaxTree therefore publishes:
+
+```text
+AuthoredValue:           Exact("/work/src/A.cs /etc/passwd")
+AuthoredFileSystemValue: Unknown
+```
+
+Use the dedicated filesystem projection. It combines an audited parser-owned
+argument binding, one-field transform provenance, and the existing path
+resolver:
+
+```csharp
+static GateDecision EvaluateAuthoredFileSystemValue(
+    AnalyzedArgument analyzed,
+    Func<string, GateDecision> evaluatePath)
+{
+    return analyzed.AuthoredFileSystemValue switch
+    {
+        ShellValueDomain.Exact exact => evaluatePath(exact.Value),
+        ShellValueDomain.FiniteSet finite => finite.Values
+            .Select(evaluatePath)
+            .Aggregate(GateDecision.Allow(), MostRestrictive),
+        ShellValueDomain.Unknown =>
+            GateDecision.Prompt("local filesystem value is unknown"),
+        _ => GateDecision.Prompt("unsupported filesystem value domain"),
+    };
+}
+```
+
+The positive v0.3.3 alternatives are only `Exact` and `FiniteSet`. Evaluate
+every represented path. Do not accept `IntegerRange`, `Concatenation`,
+`PathPattern`, or a future alternative by default. The property does not prove
+that a path exists, is trusted, or is authorized, and it does not relax
+identity, occurrence completeness, redirects, substitutions, or ancestry.
+
+The initial audited catalog is deliberately small. These examples show why a
+compatibility path bit or slash characters are not enough:
+
+| Input | Relevant `AuthoredFileSystemValue` | Reason |
+|---|---|---|
+| `cat README.md` with cwd `/work` | `Exact("/work/README.md")` | Audited `cat` operand plus exact cwd. |
+| `cat -` | `Unknown` | `-` means standard input, not a local path. |
+| `python -c 'print(1)'` | `Unknown` | Interpreter payload is data. |
+| `head -n 10 README` | `Unknown` for `10` | Numeric count is not a path. |
+| `scp user@example.invalid:/srv/file .` | `Unknown` for the remote endpoint | Remote syntax is not a local filesystem path. |
+| `show /api/v1` | `Unknown` | Path-shaped data has no audited binding. |
+
+PowerShell uses the same public property and the selected dialect's argument
+binding. For example:
+
+```powershell
+Get-Content -LiteralPath:C:\work\a.txt
+```
+
+projects the combined authored element into two analyzed arguments:
+
+```text
+Arguments[0] "-LiteralPath"  -> AuthoredFileSystemValue: Unknown
+Arguments[1] "C:\work\a.txt" -> AuthoredFileSystemValue: Exact("C:/work/a.txt")
+```
+
+The existing resolver normalizes Windows separators to `/`. By contrast,
+`Get-ChildItem C:\work *.cs` keeps the `*.cs` filter unknown, and
+`Rename-Item C:\old new` keeps `new` unknown because it is a name interpreted
+relative to another operand rather than an independently resolved path.
+Non-filesystem providers and native remote endpoints also remain unknown.
+
+`AuthoredPathShape` stays lexical evidence only:
 
 | Authored word | Shape |
 |---|---|
@@ -620,11 +687,9 @@ var decision = EvaluateDomain(domain); // recursive and fail closed
 | `bare-name` | `Unknown` |
 
 A repository slug, container image, API route, or other slash-bearing data can
-be path-shaped. Shape may trigger more conservative path review; it never says
-the executable treats the argument as a filesystem operand and never grants
-filesystem authority. PowerShell 0.3.1 sets `AuthoredValue=Value` and
-`AuthoredPathShape=Unknown`, so the shared ingestion surface remains uniform
-without inventing new PowerShell semantics.
+be path-shaped. Shape may trigger more conservative review; it never says the
+executable treats the argument as a filesystem operand and cannot substitute
+for `AuthoredFileSystemValue`.
 
 Loops also affect later state even when their body facts are static. With an
 incoming cwd of `/work`:

--- a/openspec/changes/v0-3-1-approval-facts/evidence/approval-matrix.json
+++ b/openspec/changes/v0-3-1-approval-facts/evidence/approval-matrix.json
@@ -132,8 +132,8 @@
       "observed": "Once",
       "classification": "ShellSyntaxTreeFactGap",
       "owner": "ShellSyntaxTree",
-      "sstExpectation": "With PublishAuthoredSourceFacts enabled, effective cat value is Unknown; AuthoredValue is the four pre-field-splitting /work words and AuthoredPathShape is Posix.",
-      "netclawExpectation": "Allow only if product policy accepts pre-field-splitting authored words, applies path checks conservatively, and covers cat plus echo."
+      "sstExpectation": "With ShellSyntaxTree 0.3.3 and PublishAuthoredSourceFacts enabled, effective cat Value is Unknown; AuthoredValue is the four pre-field-splitting /work words; AuthoredFileSystemValue is the same normalized finite set.",
+      "netclawExpectation": "Accept only Exact or FiniteSet AuthoredFileSystemValue alternatives, check every path through product policy, and independently cover cat plus echo."
     },
     {
       "id": "D15",

--- a/openspec/changes/v0-3-3-authored-operand-role/tasks.md
+++ b/openspec/changes/v0-3-3-authored-operand-role/tasks.md
@@ -92,11 +92,11 @@
 - [x] 7.1 Run `openspec validate v0-3-3-authored-operand-role --strict` and
   synchronize the accepted contract into `SPEC.md` before implementation is
   declared complete.
-- [ ] 7.2 Run the Release build, full unit and corpus suite, header check,
+- [x] 7.2 Run the Release build, full unit and corpus suite, header check,
   Slopwatch, package build, public API diff, and PII audit sequentially.
 - [ ] 7.3 Obtain adversarial reviews of the API contract, audited binders,
   transform proof, Bash and PowerShell behavior, consumer guidance, and final
   frozen diff.
-- [ ] 7.4 Update `IMPLEMENTATION_PLAN.md` and release notes with exact evidence.
+- [x] 7.4 Update `IMPLEMENTATION_PLAN.md` and release notes with exact evidence.
 - [ ] 7.5 Merge only after Linux and native Windows CI pass; tag and publish
   0.3.3 through the release workflow.

--- a/openspec/changes/v0-3-3-authored-operand-role/tasks.md
+++ b/openspec/changes/v0-3-3-authored-operand-role/tasks.md
@@ -1,62 +1,62 @@
 ## 1. Public Contract
 
-- [ ] 1.1 Add `AnalyzedArgument.AuthoredFileSystemValue` to `SPEC.md`, source,
+- [x] 1.1 Add `AnalyzedArgument.AuthoredFileSystemValue` to `SPEC.md`, source,
   XML docs, and public API snapshots without changing any 0.3.2 signature.
-- [ ] 1.2 Pin the non-null `Unknown` default, permitted `Exact` and `FiniteSet`
+- [x] 1.2 Pin the non-null `Unknown` default, permitted `Exact` and `FiniteSet`
   alternatives, unsupported-domain fallback, equality, hashing, `ToString()`,
   reflection, and default JSON participation.
-- [ ] 1.3 Compare both target-framework API surfaces against public 0.3.2 and
+- [x] 1.3 Compare both target-framework API surfaces against public 0.3.2 and
   prove that this capability adds only the property.
 
 ## 2. Audited Local-Path Binding
 
-- [ ] 2.1 Add a separate internal local-filesystem binder catalog whose
+- [x] 2.1 Add a separate internal local-filesystem binder catalog whose
   results cannot be sourced from compatibility `IsPath`, `FileVerbs`, lexical
   path shape, or generic positional fallback.
-- [ ] 2.2 Define reusable binding categories plus full-shape invariants for
+- [x] 2.2 Define reusable binding categories plus full-shape invariants for
   flags, bound values, positionals, stream sentinels, remote endpoints, and
   ambiguous positions.
-- [ ] 2.3 Add the smallest Bash entry that covers ordinary `cat` operands and
+- [x] 2.3 Add the smallest Bash entry that covers ordinary `cat` operands and
   the smallest dialect-aware PowerShell entry that proves one local
   filesystem parameter.
-- [ ] 2.4 Keep unaudited entries and positions unknown; do not add
+- [x] 2.4 Keep unaudited entries and positions unknown; do not add
   consumer-specific or executable-private branching.
-- [ ] 2.5 Preserve per-argument binding through PowerShell inline parameter
+- [x] 2.5 Preserve per-argument binding through PowerShell inline parameter
   projection and join audited Bash binding across every reachable
   abstract-state visit.
 
 ## 3. Transform and Resolution Proof
 
-- [ ] 3.1 Extend internal authored provenance with an exact one-field proof
+- [x] 3.1 Extend internal authored provenance with an exact one-field proof
   under the declared standard field-splitting and pathname-expansion model.
-- [ ] 3.2 Reject active unquoted splitting, active globs, zero-or-many fields,
+- [x] 3.2 Reject active unquoted splitting, active globs, zero-or-many fields,
   opaque fragments, invalidated shell state, unresolved cardinality, and
   over-limit unions without filesystem enumeration.
-- [ ] 3.3 Resolve positive candidates to normalized absolute local paths using
+- [x] 3.3 Resolve positive candidates to normalized absolute local paths using
   the occurrence cwd and existing shell-specific resolver; reject unknown cwd,
   invalid paths, remote endpoints, providers, and path-style conflicts.
-- [ ] 3.4 Emit only `Exact`, deduplicated bounded `FiniteSet`, or `Unknown`.
+- [x] 3.4 Emit only `Exact`, deduplicated bounded `FiniteSet`, or `Unknown`.
 
 ## 4. Bash Acceptance
 
-- [ ] 4.1 Add exact D14 coverage for effective `Value=Unknown`, compatibility
+- [x] 4.1 Add exact D14 coverage for effective `Value=Unknown`, compatibility
   `Argument.IsPath=false`, finite `AuthoredValue`, and finite normalized
   `AuthoredFileSystemValue`.
-- [ ] 4.2 Add direct positive cases for `cat README.md`, an absolute `cat`
+- [x] 4.2 Add direct positive cases for `cat README.md`, an absolute `cat`
   operand, exact cwd resolution, quoted whitespace, non-recursive `$HOME`
   text, literal quoted glob text, and loop finite-set joins.
-- [ ] 4.3 Add transform negatives for an unquoted candidate containing
+- [x] 4.3 Add transform negatives for an unquoted candidate containing
   `/etc/passwd` after whitespace, active glob, zero-or-many expansion, explicit
   field-splitting state mutation, runtime iterator, and over-limit union.
-- [ ] 4.4 Add audited-binding negatives for `python -c 'print(1)'`,
+- [x] 4.4 Add audited-binding negatives for `python -c 'print(1)'`,
   `test 1 -eq 1`, `head -n 10 README`, remote `scp`, path-shaped data, unknown
   executables, `cat -`, `cat -- -`, `curl --output=-`,
   `curl --data=/api/v1`, `tar --file=-`,
   an unaudited `--output`/`--data` shape, and the audited `cat -n` versus
   operand loop.
-- [ ] 4.5 Preserve dynamic identity, substitutions, redirects, unsupported
+- [x] 4.5 Preserve dynamic identity, substitutions, redirects, unsupported
   control flow, and incomplete occurrence behavior in paired negatives.
-- [ ] 4.6 Extend the executable corpus DTO and exact Bash corpus entries with
+- [x] 4.6 Extend the executable corpus DTO and exact Bash corpus entries with
   authored-filesystem expectations. Run the corpus PII audit.
 
 ## 5. PowerShell Acceptance
@@ -64,32 +64,32 @@
 - [ ] 5.1 Add selected-dialect positives for spaced and inline exact local
   filesystem `-LiteralPath` values; prove that only the inline value argument
   receives the domain and verify normalization on native Windows.
-- [ ] 5.2 Add negatives for `Get-ChildItem C:\work *.cs`,
+- [x] 5.2 Add negatives for `Get-ChildItem C:\work *.cs`,
   `Rename-Item C:\old new`, non-filesystem and unresolved providers, remote
   native `scp`, path-shaped data, stream sentinels, and dialect ambiguity.
-- [ ] 5.3 Prove PowerShell 7 and Windows PowerShell 5.1 use their selected
+- [x] 5.3 Prove PowerShell 7 and Windows PowerShell 5.1 use their selected
   metadata without cross-dialect widening.
-- [ ] 5.4 Regenerate PowerShell corpus expectations through the owned corpus
+- [x] 5.4 Regenerate PowerShell corpus expectations through the owned corpus
   tool, inspect the exact temporary-directory diff, and run the PII audit.
 
 ## 6. Consumer Contract
 
-- [ ] 6.1 Update `docs/CONSUMER_GUIDE.md` with input, parser output, and policy
+- [x] 6.1 Update `docs/CONSUMER_GUIDE.md` with input, parser output, and policy
   examples for D14, direct Bash, direct PowerShell, transform-sensitive words,
   path-shaped data, remote endpoints, filters, and rename fragments.
-- [ ] 6.2 Show a consumer accepting only `Exact` and `FiniteSet`, checking each
+- [x] 6.2 Show a consumer accepting only `Exact` and `FiniteSet`, checking each
   normalized path through its own policy, and independently enforcing complete
   occurrences, identity, redirects, substitutions, and ancestry.
-- [ ] 6.3 State the exact authored-source environment assumption and that no
+- [x] 6.3 State the exact authored-source environment assumption and that no
   parser fact grants authority or proves existence.
-- [ ] 6.4 Update paired sanitized approval evidence without source identity or
+- [x] 6.4 Update paired sanitized approval evidence without source identity or
   private repository data.
 - [ ] 6.5 Validate the public 0.3.3 package through Netclaw's exact D14 policy
   fixture before the downstream policy PR merges.
 
 ## 7. Validation and Release
 
-- [ ] 7.1 Run `openspec validate v0-3-3-authored-operand-role --strict` and
+- [x] 7.1 Run `openspec validate v0-3-3-authored-operand-role --strict` and
   synchronize the accepted contract into `SPEC.md` before implementation is
   declared complete.
 - [ ] 7.2 Run the Release build, full unit and corpus suite, header check,

--- a/src/ShellSyntaxTree/CommandOccurrence.cs
+++ b/src/ShellSyntaxTree/CommandOccurrence.cs
@@ -163,6 +163,13 @@ public sealed record AnalyzedArgument
     /// </summary>
     public ShellValueDomain AuthoredValue { get; internal init; } = null!;
 
+    /// <summary>
+    /// Gets bounded, normalized local-filesystem values proved from this
+    /// authored argument. This parser fact does not grant authority.
+    /// </summary>
+    public ShellValueDomain AuthoredFileSystemValue { get; internal init; } =
+        new ShellValueDomain.Unknown();
+
     /// <summary>Gets the authored word's uniform lexical path shape.</summary>
     public ShellPathShape AuthoredPathShape { get; internal init; }
 

--- a/src/ShellSyntaxTree/Internal/Bash/Parsing/BashStructuralCoordinator.cs
+++ b/src/ShellSyntaxTree/Internal/Bash/Parsing/BashStructuralCoordinator.cs
@@ -47,6 +47,7 @@ internal static partial class BashCommandParser
             !ShellSyntaxProjection.TryProject(
                 analyzedSyntax,
                 analyzedFacts,
+                ShellProjectionLanguage.Bash,
                 out var projection))
         {
             return StructuralFailure(

--- a/src/ShellSyntaxTree/Internal/Pwsh/Parsing/PwshStructuralCoordinator.cs
+++ b/src/ShellSyntaxTree/Internal/Pwsh/Parsing/PwshStructuralCoordinator.cs
@@ -59,6 +59,7 @@ internal static partial class PwshCommandParser
             !ShellSyntaxProjection.TryProject(
                 analyzedSyntax,
                 analyzedFacts,
+                ShellProjectionLanguage.PowerShell,
                 out var projection))
         {
             return StructuralFailure(

--- a/src/ShellSyntaxTree/Internal/Resolving/AuthoredFileSystemValueProjection.cs
+++ b/src/ShellSyntaxTree/Internal/Resolving/AuthoredFileSystemValueProjection.cs
@@ -8,11 +8,54 @@ using System.Collections.Generic;
 
 namespace ShellSyntaxTree.Internal.Resolving;
 
-internal enum AuditedFileSystemBinding
+internal enum AuditedFileSystemBindingCategory
 {
     Unknown,
-    BashCatArgument,
-    PowerShellLiteralPath,
+    AllNonOptionOperands,
+    ExactNamedParameterValue,
+}
+
+internal sealed class AuthoredFileSystemBindingCatalogEntry
+{
+    internal AuthoredFileSystemBindingCatalogEntry(
+        ShellProjectionLanguage language,
+        string canonicalVerb,
+        StringComparison verbComparison,
+        AuditedFileSystemBindingCategory category,
+        string? parameterName = null)
+    {
+        if (category == AuditedFileSystemBindingCategory.ExactNamedParameterValue &&
+            string.IsNullOrEmpty(parameterName))
+        {
+            throw new ArgumentException(
+                "An exact named-parameter binding requires a parameter name.",
+                nameof(parameterName));
+        }
+
+        if (category != AuditedFileSystemBindingCategory.ExactNamedParameterValue &&
+            parameterName != null)
+        {
+            throw new ArgumentException(
+                "Only an exact named-parameter binding accepts a parameter name.",
+                nameof(parameterName));
+        }
+
+        Language = language;
+        CanonicalVerb = canonicalVerb;
+        VerbComparison = verbComparison;
+        Category = category;
+        ParameterName = parameterName;
+    }
+
+    internal ShellProjectionLanguage Language { get; }
+
+    internal string CanonicalVerb { get; }
+
+    internal StringComparison VerbComparison { get; }
+
+    internal AuditedFileSystemBindingCategory Category { get; }
+
+    internal string? ParameterName { get; }
 }
 
 /// <summary>
@@ -21,66 +64,105 @@ internal enum AuditedFileSystemBinding
 /// </summary>
 internal static class AuthoredFileSystemBindingCatalog
 {
-    internal static IReadOnlyList<AuditedFileSystemBinding> Bind(
+    private static readonly IReadOnlyList<AuthoredFileSystemBindingCatalogEntry> Entries =
+        new[]
+        {
+            new AuthoredFileSystemBindingCatalogEntry(
+                ShellProjectionLanguage.Bash,
+                "cat",
+                StringComparison.Ordinal,
+                AuditedFileSystemBindingCategory.AllNonOptionOperands),
+            new AuthoredFileSystemBindingCatalogEntry(
+                ShellProjectionLanguage.PowerShell,
+                "Get-Content",
+                StringComparison.OrdinalIgnoreCase,
+                AuditedFileSystemBindingCategory.ExactNamedParameterValue,
+                "-LiteralPath"),
+        };
+
+    internal static IReadOnlyList<AuditedFileSystemBindingCategory> Bind(
         ShellProjectionLanguage language,
         Clause clause,
         IReadOnlyList<AnalyzedArgument> arguments)
     {
-        var bindings = new AuditedFileSystemBinding[arguments.Count];
+        var bindings = new AuditedFileSystemBindingCategory[arguments.Count];
         if (clause.Verb.IsDynamic || clause.Verb.Tokens.Count != 1)
         {
             return bindings;
         }
 
-        return language switch
+        var canonicalVerb = language == ShellProjectionLanguage.PowerShell
+            ? clause.Verb.CanonicalVerb ?? clause.Verb.Tokens[0]
+            : clause.Verb.Tokens[0];
+        for (var index = 0; index < Entries.Count; index++)
         {
-            ShellProjectionLanguage.Bash when string.Equals(
-                clause.Verb.Tokens[0], "cat", StringComparison.Ordinal) =>
-                BindBashCat(bindings),
-            ShellProjectionLanguage.PowerShell when string.Equals(
-                clause.Verb.CanonicalVerb ?? clause.Verb.Tokens[0],
-                "Get-Content",
-                StringComparison.OrdinalIgnoreCase) =>
-                BindPowerShellLiteralPath(arguments, bindings),
-            _ => bindings,
-        };
-    }
+            var entry = Entries[index];
+            if (entry.Language != language ||
+                !string.Equals(canonicalVerb, entry.CanonicalVerb, entry.VerbComparison))
+            {
+                continue;
+            }
 
-    private static IReadOnlyList<AuditedFileSystemBinding> BindBashCat(
-        AuditedFileSystemBinding[] bindings)
-    {
-        for (var index = 0; index < bindings.Length; index++)
-        {
-            bindings[index] = AuditedFileSystemBinding.BashCatArgument;
+            return Bind(entry, arguments);
         }
 
         return bindings;
     }
 
-    private static IReadOnlyList<AuditedFileSystemBinding> BindPowerShellLiteralPath(
-        IReadOnlyList<AnalyzedArgument> arguments,
-        AuditedFileSystemBinding[] bindings)
+    internal static IReadOnlyList<AuditedFileSystemBindingCategory> Bind(
+        AuthoredFileSystemBindingCatalogEntry entry,
+        IReadOnlyList<AnalyzedArgument> arguments)
     {
-        var expectsLiteralPath = false;
+        var bindings = new AuditedFileSystemBindingCategory[arguments.Count];
+        return entry.Category switch
+        {
+            AuditedFileSystemBindingCategory.AllNonOptionOperands =>
+                BindAllNonOptionOperands(bindings),
+            AuditedFileSystemBindingCategory.ExactNamedParameterValue =>
+                BindExactNamedParameterValue(
+                    arguments,
+                    bindings,
+                    entry.ParameterName!),
+            _ => bindings,
+        };
+    }
+
+    private static IReadOnlyList<AuditedFileSystemBindingCategory> BindAllNonOptionOperands(
+        AuditedFileSystemBindingCategory[] bindings)
+    {
+        for (var index = 0; index < bindings.Length; index++)
+        {
+            bindings[index] = AuditedFileSystemBindingCategory.AllNonOptionOperands;
+        }
+
+        return bindings;
+    }
+
+    private static IReadOnlyList<AuditedFileSystemBindingCategory> BindExactNamedParameterValue(
+        IReadOnlyList<AnalyzedArgument> arguments,
+        AuditedFileSystemBindingCategory[] bindings,
+        string parameterName)
+    {
+        var expectsValue = false;
         for (var index = 0; index < arguments.Count; index++)
         {
             var argument = arguments[index];
-            if (expectsLiteralPath)
+            if (expectsValue)
             {
                 if (!argument.Argument.IsFlag)
                 {
-                    bindings[index] = AuditedFileSystemBinding.PowerShellLiteralPath;
+                    bindings[index] = AuditedFileSystemBindingCategory.ExactNamedParameterValue;
                 }
 
-                expectsLiteralPath = false;
+                expectsValue = false;
             }
 
             if (argument.Argument.IsFlag && string.Equals(
                     argument.Argument.Raw,
-                    "-LiteralPath",
+                    parameterName,
                     StringComparison.OrdinalIgnoreCase))
             {
-                expectsLiteralPath = true;
+                expectsValue = true;
             }
         }
 
@@ -122,8 +204,8 @@ internal static class AuthoredFileSystemValueProjection
             var candidates = Values(argument.AuthoredValue);
             switch (bindings[index])
             {
-                case AuditedFileSystemBinding.BashCatArgument:
-                    var allCandidatesArePaths = ClassifyBashCatArgument(
+                case AuditedFileSystemBindingCategory.AllNonOptionOperands:
+                    var allCandidatesArePaths = ClassifyNonOptionOperand(
                         candidates,
                         bashOptionsEnded,
                         out var nextStates);
@@ -141,7 +223,7 @@ internal static class AuthoredFileSystemValueProjection
                     }
 
                     break;
-                case AuditedFileSystemBinding.PowerShellLiteralPath:
+                case AuditedFileSystemBindingCategory.ExactNamedParameterValue:
                     if (candidates.Count > 0 &&
                         TryGetProvenance(argument, clause, provenanceByElement, out var pwshValue) &&
                         IsSingleField(pwshValue) &&
@@ -164,11 +246,11 @@ internal static class AuthoredFileSystemValueProjection
     }
 
     private static bool HasAuditedBinding(
-        IReadOnlyList<AuditedFileSystemBinding> bindings)
+        IReadOnlyList<AuditedFileSystemBindingCategory> bindings)
     {
         for (var index = 0; index < bindings.Count; index++)
         {
-            if (bindings[index] != AuditedFileSystemBinding.Unknown)
+            if (bindings[index] != AuditedFileSystemBindingCategory.Unknown)
             {
                 return true;
             }
@@ -220,7 +302,7 @@ internal static class AuthoredFileSystemValueProjection
         _ => Array.Empty<string>(),
     };
 
-    private static bool ClassifyBashCatArgument(
+    private static bool ClassifyNonOptionOperand(
         IReadOnlyList<string> candidates,
         IReadOnlyCollection<bool> currentStates,
         out HashSet<bool> nextStates)

--- a/src/ShellSyntaxTree/Internal/Resolving/AuthoredFileSystemValueProjection.cs
+++ b/src/ShellSyntaxTree/Internal/Resolving/AuthoredFileSystemValueProjection.cs
@@ -1,0 +1,393 @@
+// -----------------------------------------------------------------------
+// <copyright file="AuthoredFileSystemValueProjection.cs" company="Aaron Stannard">
+//      Copyright (C) 2026 - 2026 Aaron Stannard <https://github.com/Aaronontheweb>
+// </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+
+namespace ShellSyntaxTree.Internal.Resolving;
+
+internal enum AuditedFileSystemBinding
+{
+    Unknown,
+    BashCatArgument,
+    PowerShellLiteralPath,
+}
+
+/// <summary>
+/// Owns the deliberately small catalog whose entries prove local-filesystem
+/// argument semantics. Compatibility path tables do not feed this catalog.
+/// </summary>
+internal static class AuthoredFileSystemBindingCatalog
+{
+    internal static IReadOnlyList<AuditedFileSystemBinding> Bind(
+        ShellProjectionLanguage language,
+        Clause clause,
+        IReadOnlyList<AnalyzedArgument> arguments)
+    {
+        var bindings = new AuditedFileSystemBinding[arguments.Count];
+        if (clause.Verb.IsDynamic || clause.Verb.Tokens.Count != 1)
+        {
+            return bindings;
+        }
+
+        return language switch
+        {
+            ShellProjectionLanguage.Bash when string.Equals(
+                clause.Verb.Tokens[0], "cat", StringComparison.Ordinal) =>
+                BindBashCat(bindings),
+            ShellProjectionLanguage.PowerShell when string.Equals(
+                clause.Verb.CanonicalVerb ?? clause.Verb.Tokens[0],
+                "Get-Content",
+                StringComparison.OrdinalIgnoreCase) =>
+                BindPowerShellLiteralPath(arguments, bindings),
+            _ => bindings,
+        };
+    }
+
+    private static IReadOnlyList<AuditedFileSystemBinding> BindBashCat(
+        AuditedFileSystemBinding[] bindings)
+    {
+        for (var index = 0; index < bindings.Length; index++)
+        {
+            bindings[index] = AuditedFileSystemBinding.BashCatArgument;
+        }
+
+        return bindings;
+    }
+
+    private static IReadOnlyList<AuditedFileSystemBinding> BindPowerShellLiteralPath(
+        IReadOnlyList<AnalyzedArgument> arguments,
+        AuditedFileSystemBinding[] bindings)
+    {
+        var expectsLiteralPath = false;
+        for (var index = 0; index < arguments.Count; index++)
+        {
+            var argument = arguments[index];
+            if (expectsLiteralPath)
+            {
+                if (!argument.Argument.IsFlag)
+                {
+                    bindings[index] = AuditedFileSystemBinding.PowerShellLiteralPath;
+                }
+
+                expectsLiteralPath = false;
+            }
+
+            if (argument.Argument.IsFlag && string.Equals(
+                    argument.Argument.Raw,
+                    "-LiteralPath",
+                    StringComparison.OrdinalIgnoreCase))
+            {
+                expectsLiteralPath = true;
+            }
+        }
+
+        return bindings;
+    }
+}
+
+/// <summary>
+/// Combines an audited binding, transform provenance, and the existing path
+/// resolver into one fail-closed public value domain.
+/// </summary>
+internal static class AuthoredFileSystemValueProjection
+{
+    internal static IReadOnlyList<AnalyzedArgument> Apply(
+        ShellProjectionLanguage language,
+        Clause clause,
+        IReadOnlyList<ShellValueElementProvenance> provenance,
+        ShellValueDomainFacts workingDirectory,
+        IReadOnlyList<AnalyzedArgument> arguments)
+    {
+        if (language == ShellProjectionLanguage.Unknown || arguments.Count == 0)
+        {
+            return arguments;
+        }
+
+        var bindings = AuthoredFileSystemBindingCatalog.Bind(language, clause, arguments);
+        if (!HasAuditedBinding(bindings))
+        {
+            return arguments;
+        }
+
+        var provenanceByElement = IndexProvenance(provenance);
+        var projected = new AnalyzedArgument[arguments.Count];
+        var bashOptionsEnded = new HashSet<bool> { false };
+        for (var index = 0; index < arguments.Count; index++)
+        {
+            var argument = arguments[index];
+            ShellValueDomain domain = new ShellValueDomain.Unknown();
+            var candidates = Values(argument.AuthoredValue);
+            switch (bindings[index])
+            {
+                case AuditedFileSystemBinding.BashCatArgument:
+                    var allCandidatesArePaths = ClassifyBashCatArgument(
+                        candidates,
+                        bashOptionsEnded,
+                        out var nextStates);
+                    bashOptionsEnded = nextStates;
+                    if (allCandidatesArePaths &&
+                        TryGetProvenance(argument, clause, provenanceByElement, out var bashValue) &&
+                        IsBashTransformSafe(bashValue, candidates) &&
+                        TryResolve(
+                            ShellProjectionLanguage.Bash,
+                            candidates,
+                            workingDirectory,
+                            out var bashDomain))
+                    {
+                        domain = bashDomain;
+                    }
+
+                    break;
+                case AuditedFileSystemBinding.PowerShellLiteralPath:
+                    if (candidates.Count > 0 &&
+                        TryGetProvenance(argument, clause, provenanceByElement, out var pwshValue) &&
+                        IsSingleField(pwshValue) &&
+                        TryResolve(
+                            ShellProjectionLanguage.PowerShell,
+                            candidates,
+                            workingDirectory,
+                            out var pwshDomain))
+                    {
+                        domain = pwshDomain;
+                    }
+
+                    break;
+            }
+
+            projected[index] = argument with { AuthoredFileSystemValue = domain };
+        }
+
+        return projected;
+    }
+
+    private static bool HasAuditedBinding(
+        IReadOnlyList<AuditedFileSystemBinding> bindings)
+    {
+        for (var index = 0; index < bindings.Count; index++)
+        {
+            if (bindings[index] != AuditedFileSystemBinding.Unknown)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static Dictionary<int, ShellValue> IndexProvenance(
+        IReadOnlyList<ShellValueElementProvenance> provenance)
+    {
+        var indexed = new Dictionary<int, ShellValue>();
+        for (var index = 0; index < provenance.Count; index++)
+        {
+            var current = provenance[index];
+            if (current.ClauseElementIndex >= 0 &&
+                !indexed.ContainsKey(current.ClauseElementIndex))
+            {
+                indexed.Add(current.ClauseElementIndex, current.Value);
+            }
+        }
+
+        return indexed;
+    }
+
+    private static bool TryGetProvenance(
+        AnalyzedArgument argument,
+        Clause clause,
+        IReadOnlyDictionary<int, ShellValue> provenance,
+        out ShellValue value)
+    {
+        for (var index = 0; index < clause.Elements.Count; index++)
+        {
+            if (ReferenceEquals(clause.Elements[index], argument.Element) &&
+                provenance.TryGetValue(index, out value!))
+            {
+                return true;
+            }
+        }
+
+        value = ShellValue.Literal(string.Empty);
+        return false;
+    }
+
+    private static IReadOnlyList<string> Values(ShellValueDomain domain) => domain switch
+    {
+        ShellValueDomain.Exact exact => new[] { exact.Value },
+        ShellValueDomain.FiniteSet finite => finite.Values,
+        _ => Array.Empty<string>(),
+    };
+
+    private static bool ClassifyBashCatArgument(
+        IReadOnlyList<string> candidates,
+        IReadOnlyCollection<bool> currentStates,
+        out HashSet<bool> nextStates)
+    {
+        nextStates = new HashSet<bool>();
+        if (candidates.Count == 0)
+        {
+            nextStates.Add(false);
+            nextStates.Add(true);
+            return false;
+        }
+
+        var allArePaths = true;
+        foreach (var optionsEnded in currentStates)
+        {
+            for (var index = 0; index < candidates.Count; index++)
+            {
+                var candidate = candidates[index];
+                if (!optionsEnded && string.Equals(candidate, "--", StringComparison.Ordinal))
+                {
+                    nextStates.Add(true);
+                    allArePaths = false;
+                }
+                else
+                {
+                    nextStates.Add(optionsEnded);
+                    if (string.Equals(candidate, "-", StringComparison.Ordinal) ||
+                        !optionsEnded && candidate.StartsWith("-", StringComparison.Ordinal))
+                    {
+                        allArePaths = false;
+                    }
+                }
+            }
+        }
+
+        return allArePaths;
+    }
+
+    private static bool IsBashTransformSafe(
+        ShellValue value,
+        IReadOnlyList<string> candidates)
+    {
+        if (!IsSingleField(value))
+        {
+            return false;
+        }
+
+        for (var fragmentIndex = 0; fragmentIndex < value.Fragments.Count; fragmentIndex++)
+        {
+            var fragment = value.Fragments[fragmentIndex];
+            if ((fragment.AllowedTransforms & ShellLexicalTransform.Glob) != 0)
+            {
+                return false;
+            }
+
+            if ((fragment.AllowedTransforms & ShellLexicalTransform.FieldSplit) == 0)
+            {
+                continue;
+            }
+
+            for (var candidateIndex = 0; candidateIndex < candidates.Count; candidateIndex++)
+            {
+                if (ContainsFieldSplitOrGlobCharacter(candidates[candidateIndex]))
+                {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private static bool IsSingleField(ShellValue value)
+    {
+        for (var index = 0; index < value.Fragments.Count; index++)
+        {
+            var fragment = value.Fragments[index];
+            if (fragment.Kind == ShellValueFragmentKind.Opaque ||
+                fragment.Cardinality != ShellValueCardinality.ExactlyOne)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static bool ContainsFieldSplitOrGlobCharacter(string value)
+    {
+        for (var index = 0; index < value.Length; index++)
+        {
+            if (value[index] is ' ' or '\t' or '\n' or '*' or '?' or '[')
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static bool TryResolve(
+        ShellProjectionLanguage language,
+        IReadOnlyList<string> candidates,
+        ShellValueDomainFacts workingDirectory,
+        out ShellValueDomain domain)
+    {
+        domain = new ShellValueDomain.Unknown();
+        if (workingDirectory.Kind != ShellValueDomainKind.Exact ||
+            workingDirectory.Values.Count != 1 ||
+            candidates.Count == 0 ||
+            candidates.Count > ShellAnalysisLimits.MaxValueCandidates)
+        {
+            return false;
+        }
+
+        var distinct = new HashSet<string>(StringComparer.Ordinal);
+        var normalized = new List<string>(candidates.Count);
+        for (var index = 0; index < candidates.Count; index++)
+        {
+            var resolved = ResolveCandidate(
+                language,
+                candidates[index],
+                workingDirectory.Values[0]);
+            if (resolved is null)
+            {
+                return false;
+            }
+
+            if (distinct.Add(resolved))
+            {
+                normalized.Add(resolved);
+            }
+        }
+
+        domain = normalized.Count == 1
+            ? new ShellValueDomain.Exact(normalized[0])
+            : new ShellValueDomain.FiniteSet(normalized);
+        return true;
+    }
+
+    private static string? ResolveCandidate(
+        ShellProjectionLanguage language,
+        string candidate,
+        string workingDirectory)
+    {
+        var value = ShellValue.Literal(candidate);
+        var resolution = language switch
+        {
+            ShellProjectionLanguage.Bash => BashResolver.Resolve(
+                value,
+                treatAsPath: true,
+                new BashParserOptions { WorkingDirectory = workingDirectory },
+                workingDirectoryUnknown: false,
+                ShellResolutionConsumer.BashArgument),
+            ShellProjectionLanguage.PowerShell => PwshResolver.Resolve(
+                value,
+                treatAsPath: true,
+                new PwshParserOptions { WorkingDirectory = workingDirectory },
+                workingDirectoryUnknown: false,
+                ShellResolutionConsumer.PowerShellCmdletLiteralPath),
+            _ => (ArgKind.DynamicSkip, null, false),
+        };
+
+        return resolution.Kind == ArgKind.Literal &&
+               resolution.IsPath &&
+               resolution.Resolved is not null
+            ? resolution.Resolved
+            : null;
+    }
+}

--- a/src/ShellSyntaxTree/ShellSyntaxProjection.cs
+++ b/src/ShellSyntaxTree/ShellSyntaxProjection.cs
@@ -425,6 +425,13 @@ internal sealed class ShellProjectionResult
     internal IReadOnlyList<Clause> Clauses { get; init; } = Array.Empty<Clause>();
 }
 
+internal enum ShellProjectionLanguage
+{
+    Unknown,
+    Bash,
+    PowerShell,
+}
+
 /// <summary>
 /// Owns executable-command discovery so security consumers never need to
 /// recursively match syntax-node types.
@@ -440,20 +447,29 @@ internal static class ShellSyntaxProjection
         ShellBlockSyntax syntax,
         Func<SimpleCommandSyntax, CommandOccurrenceFacts> factsFactory,
         out ShellProjectionResult result)
+        => TryProject(syntax, factsFactory, ShellProjectionLanguage.Unknown, out result);
+
+    internal static bool TryProject(
+        ShellBlockSyntax syntax,
+        Func<SimpleCommandSyntax, CommandOccurrenceFacts> factsFactory,
+        ShellProjectionLanguage language,
+        out ShellProjectionResult result)
     {
-        if (syntax is null || factsFactory is null)
+        if (syntax is null || factsFactory is null ||
+            !Enum.IsDefined(typeof(ShellProjectionLanguage), language))
         {
             result = ShellProjectionResult.Empty;
             return false;
         }
 
-        var walker = new ProjectionWalker(factsFactory);
+        var walker = new ProjectionWalker(factsFactory, language);
         return walker.TryProject(syntax, out result);
     }
 
     private sealed class ProjectionWalker
     {
         private readonly Func<SimpleCommandSyntax, CommandOccurrenceFacts> _factsFactory;
+        private readonly ShellProjectionLanguage _language;
         private readonly List<CommandAncestryFrame> _ancestry = new();
         private readonly List<CommandOccurrence> _commands = new();
         private readonly List<Clause> _clauses = new();
@@ -464,9 +480,11 @@ internal static class ShellSyntaxProjection
             new(ClauseReferenceComparer.Instance);
 
         internal ProjectionWalker(
-            Func<SimpleCommandSyntax, CommandOccurrenceFacts> factsFactory)
+            Func<SimpleCommandSyntax, CommandOccurrenceFacts> factsFactory,
+            ShellProjectionLanguage language)
         {
             _factsFactory = factsFactory;
+            _language = language;
         }
 
         internal bool TryProject(
@@ -616,6 +634,7 @@ internal static class ShellSyntaxProjection
             if (!TryCopyFacts(
                     simple.Clause,
                     facts,
+                    _language,
                     out var arguments,
                     out var workingDirectory,
                     out var redirects))
@@ -885,6 +904,7 @@ internal static class ShellSyntaxProjection
         private static bool TryCopyFacts(
             Clause clause,
             CommandOccurrenceFacts facts,
+            ShellProjectionLanguage language,
             out IReadOnlyList<AnalyzedArgument> arguments,
             out ShellValueDomain workingDirectory,
             out IReadOnlyList<RedirectAnalysis> redirects)
@@ -897,6 +917,7 @@ internal static class ShellSyntaxProjection
                 facts.AuthoredArguments is null ||
                 facts.WorkingDirectory is null ||
                 facts.Redirects is null ||
+                facts.ValueProvenance is null ||
                 ContainsNull(facts.EffectiveArguments) ||
                 ContainsNull(facts.AuthoredArguments) ||
                 ContainsNull(facts.Redirects) ||
@@ -918,6 +939,9 @@ internal static class ShellSyntaxProjection
                     facts.EffectiveArguments,
                     facts.AuthoredArguments,
                     facts.PublishAuthoredPathShape,
+                    facts.ValueProvenance,
+                    facts.WorkingDirectory,
+                    language,
                     out arguments) &&
                 TryCreateRedirectAnalyses(clause, facts.Redirects, out redirects);
         }
@@ -939,6 +963,9 @@ internal static class ShellSyntaxProjection
             IReadOnlyList<EffectiveArgumentFacts> effective,
             IReadOnlyList<EffectiveArgumentFacts> authored,
             bool publishAuthoredPathShape,
+            IReadOnlyList<ShellValueElementProvenance> provenance,
+            ShellValueDomainFacts workingDirectory,
+            ShellProjectionLanguage language,
             out IReadOnlyList<AnalyzedArgument> arguments)
         {
             arguments = Array.Empty<AnalyzedArgument>();
@@ -1026,6 +1053,7 @@ internal static class ShellSyntaxProjection
                         Element = element,
                         Value = value,
                         AuthoredValue = authoredValue,
+                        AuthoredFileSystemValue = new ShellValueDomain.Unknown(),
                         AuthoredPathShape = publishAuthoredPathShape
                             ? ShellPathShapeClassifier.Classify(authoredValue)
                             : ShellPathShape.Unknown,
@@ -1041,7 +1069,12 @@ internal static class ShellSyntaxProjection
                 return false;
             }
 
-            arguments = projected;
+            arguments = AuthoredFileSystemValueProjection.Apply(
+                language,
+                clause,
+                provenance,
+                workingDirectory,
+                projected);
             return true;
         }
 

--- a/tests/ShellSyntaxTree.Tests/Corpus/AstAssert.cs
+++ b/tests/ShellSyntaxTree.Tests/Corpus/AstAssert.cs
@@ -462,6 +462,13 @@ internal static class AstAssert
                         expectedArgument.Value,
                         actualArgument.Value,
                         prefix + $"commands[{index}].arguments[{argumentIndex}].value");
+                    if (expectedArgument.AuthoredFileSystemValue is not null)
+                    {
+                        AssertValueDomainEqual(
+                            expectedArgument.AuthoredFileSystemValue,
+                            actualArgument.AuthoredFileSystemValue,
+                            prefix + $"commands[{index}].arguments[{argumentIndex}].authoredFileSystemValue");
+                    }
                 }
             }
 

--- a/tests/ShellSyntaxTree.Tests/Corpus/CorpusRunnerTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Corpus/CorpusRunnerTests.cs
@@ -37,6 +37,7 @@ public class CorpusRunnerTests
         if (shell != "bash")
         {
             Assert.Null(entry.BashInitialStateMode);
+            Assert.False(entry.PublishAuthoredSourceFacts);
         }
 
         if (shell != "powershell")
@@ -49,7 +50,8 @@ public class CorpusRunnerTests
             shell,
             entry.BashInitialStateMode,
             entry.PowerShellInitialStateMode,
-            entry.PowerShellDialect).Parse(entry.Input);
+            entry.PowerShellDialect,
+            entry.PublishAuthoredSourceFacts).Parse(entry.Input);
         AstAssert.Equal(entry.Expected!, actual, $"{shell}/{fileName}");
         AssertClauseElementInvariants(actual, $"{shell}/{fileName}");
         AssertAuthoredTokenCoverage(shell, actual, $"{shell}/{fileName}");
@@ -884,7 +886,8 @@ public class CorpusRunnerTests
         string shell,
         BashInitialStateMode? bashInitialStateMode = null,
         PwshInitialStateMode? powerShellInitialStateMode = null,
-        PwshDialect? powerShellDialect = null) => shell switch
+        PwshDialect? powerShellDialect = null,
+        bool publishAuthoredSourceFacts = false) => shell switch
         {
             "bash" => new BashParser(new BashParserOptions
             {
@@ -892,6 +895,7 @@ public class CorpusRunnerTests
                 WorkingDirectory = "/work",
                 InitialStateMode = bashInitialStateMode ??
                     BashInitialStateMode.IsolatedNonInteractive,
+                PublishAuthoredSourceFacts = publishAuthoredSourceFacts,
             }),
             "powershell" => new PwshParser(new PwshParserOptions
             {
@@ -963,6 +967,8 @@ public sealed record CorpusEntry
     public PwshInitialStateMode? PowerShellInitialStateMode { get; init; }
 
     public PwshDialect? PowerShellDialect { get; init; }
+
+    public bool PublishAuthoredSourceFacts { get; init; }
 
     public ExpectedParsedCommand? Expected { get; init; }
 
@@ -1110,6 +1116,8 @@ public sealed record ExpectedAnalyzedArgument
     public int ClauseElementIndex { get; init; } = -1;
 
     public ExpectedValueDomain Value { get; init; } = new();
+
+    public ExpectedValueDomain? AuthoredFileSystemValue { get; init; }
 }
 
 public sealed record ExpectedValueDomain

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/314_v03_authored_filesystem_d14.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/314_v03_authored_filesystem_d14.json
@@ -1,0 +1,87 @@
+{
+  "name": "v0.3.3 bounded authored filesystem loop",
+  "input": "for f in src/A.cs src/B.cs; do cat /work/$f; done",
+  "bashInitialStateMode": "Unknown",
+  "publishAuthoredSourceFacts": true,
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": [
+          "cat"
+        ],
+        "args": [
+          {
+            "raw": "/work/$f",
+            "kind": "DynamicSkip",
+            "isPath": false,
+            "resolved": "__NULL__",
+            "isFlag": false
+          }
+        ],
+        "redirects": []
+      }
+    ],
+    "commands": [
+      {
+        "clauseIndex": 0,
+        "immediateRole": "LoopBody",
+        "isComplete": true,
+        "ancestry": [
+          {
+            "ancestorKind": "Block",
+            "region": "Root",
+            "childIndex": 0,
+            "sourceStart": 0,
+            "sourceLength": 49
+          },
+          {
+            "ancestorKind": "ForEach",
+            "region": "LoopBody",
+            "childIndex": null,
+            "sourceStart": 0,
+            "sourceLength": 49
+          },
+          {
+            "ancestorKind": "Block",
+            "region": "Statement",
+            "childIndex": 0,
+            "sourceStart": 30,
+            "sourceLength": 15
+          }
+        ],
+        "arguments": [
+          {
+            "clauseArgumentIndex": 0,
+            "clauseElementIndex": 1,
+            "value": {
+              "kind": "Unknown",
+              "values": [],
+              "pattern": null,
+              "coveringDirectory": null
+            },
+            "authoredFileSystemValue": {
+              "kind": "FiniteSet",
+              "values": [
+                "/work/src/A.cs",
+                "/work/src/B.cs"
+              ],
+              "pattern": null,
+              "coveringDirectory": null
+            }
+          }
+        ],
+        "workingDirectory": {
+          "kind": "Exact",
+          "values": [
+            "/work"
+          ],
+          "pattern": null,
+          "coveringDirectory": null
+        }
+      }
+    ]
+  },
+  "notes": "Sanitized D14 evidence: a transform-safe cat loop publishes bounded local paths without changing effective runtime facts."
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/powershell/435_v03_design_cmdlet_literalpath_quoted_wildcard.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/powershell/435_v03_design_cmdlet_literalpath_quoted_wildcard.json
@@ -123,6 +123,14 @@
               ],
               "pattern": null,
               "coveringDirectory": null
+            },
+            "authoredFileSystemValue": {
+              "kind": "Exact",
+              "values": [
+                "C:/work/*.txt"
+              ],
+              "pattern": null,
+              "coveringDirectory": null
             }
           }
         ],

--- a/tests/ShellSyntaxTree.Tests/Corpus/powershell/541_v03_authored_filesystem_literalpath.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/powershell/541_v03_authored_filesystem_literalpath.json
@@ -1,6 +1,6 @@
 {
-  "name": "V03 design cmdlet literalpath provider",
-  "input": "Get-Content -LiteralPath \u0022FileSystem::C:\\logs\\x.txt\u0022",
+  "name": "V03 authored filesystem literalpath",
+  "input": "Get-Content -LiteralPath C:\\work\\a.txt",
   "powerShellInitialStateMode": "IsolatedNonInteractiveNoProfile",
   "expected": {
     "isUnparseable": false,
@@ -17,10 +17,10 @@
             "isPath": false
           },
           {
-            "raw": "\u0022FileSystem::C:\\logs\\x.txt\u0022",
+            "raw": "C:\\work\\a.txt",
             "kind": "Literal",
             "isPath": true,
-            "resolved": "C:/logs/x.txt"
+            "resolved": "C:/work/a.txt"
           }
         ],
         "redirects": [],
@@ -48,16 +48,16 @@
             "isPath": false
           },
           {
-            "raw": "\u0022FileSystem::C:\\logs\\x.txt\u0022",
-            "value": "FileSystem::C:\\logs\\x.txt",
+            "raw": "C:\\work\\a.txt",
+            "value": "C:\\work\\a.txt",
             "role": "Argument",
             "sourceStart": 25,
-            "sourceLength": 27,
+            "sourceLength": 13,
             "precedingVerbElementCount": 1,
             "kind": "Literal",
             "isFlag": false,
             "isPath": true,
-            "resolved": "C:/logs/x.txt"
+            "resolved": "C:/work/a.txt"
           }
         ]
       }
@@ -69,7 +69,7 @@
         "region": "Unknown",
         "childIndex": null,
         "sourceStart": 0,
-        "sourceLength": 52,
+        "sourceLength": 38,
         "clauseIndex": null,
         "groupKind": null,
         "listOperator": null
@@ -80,7 +80,7 @@
         "region": "Root",
         "childIndex": 0,
         "sourceStart": 0,
-        "sourceLength": 52,
+        "sourceLength": 38,
         "clauseIndex": 0,
         "groupKind": null,
         "listOperator": null
@@ -97,7 +97,7 @@
             "region": "Root",
             "childIndex": 0,
             "sourceStart": 0,
-            "sourceLength": 52
+            "sourceLength": 38
           }
         ],
         "arguments": [
@@ -119,7 +119,7 @@
             "value": {
               "kind": "Exact",
               "values": [
-                "FileSystem::C:\\logs\\x.txt"
+                "C:\\work\\a.txt"
               ],
               "pattern": null,
               "coveringDirectory": null
@@ -127,7 +127,7 @@
             "authoredFileSystemValue": {
               "kind": "Exact",
               "values": [
-                "C:/logs/x.txt"
+                "C:/work/a.txt"
               ],
               "pattern": null,
               "coveringDirectory": null
@@ -145,5 +145,5 @@
       }
     ]
   },
-  "notes": "Promotes stable design case pwsh-cmdlet-literalpath-provider."
+  "notes": "Pins the v0.3.3 audited authored-filesystem value for an exact cmdlet LiteralPath binding."
 }

--- a/tests/ShellSyntaxTree.Tests/Parsing/AuthoredFileSystemValueTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Parsing/AuthoredFileSystemValueTests.cs
@@ -1,0 +1,319 @@
+// -----------------------------------------------------------------------
+// <copyright file="AuthoredFileSystemValueTests.cs" company="Aaron Stannard">
+//      Copyright (C) 2026 - 2026 Aaron Stannard <https://github.com/Aaronontheweb>
+// </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Linq;
+using Xunit;
+
+namespace ShellSyntaxTree.Tests.Parsing;
+
+public class AuthoredFileSystemValueTests
+{
+    [Theory]
+    [InlineData("cat README.md", "/work/README.md")]
+    [InlineData("cat /work/README.md", "/work/README.md")]
+    [InlineData("cat \"/work/file name.txt\"", "/work/file name.txt")]
+    public void Audited_bash_cat_operands_publish_normalized_local_paths(
+        string source,
+        string expected)
+    {
+        var result = Bash().Parse(source);
+
+        AssertExact(Assert.Single(Assert.Single(result.Commands).Arguments), expected);
+    }
+
+    [Theory]
+    [InlineData("cat -")]
+    [InlineData("cat -- -")]
+    [InlineData("cat *.txt")]
+    public void Cat_stream_and_active_glob_arguments_remain_unknown(string source)
+    {
+        var result = Bash().Parse(source);
+
+        AssertUnknown(Assert.Single(result.Commands).Arguments.Last());
+    }
+
+    [Fact]
+    public void Cat_option_state_preserves_only_proved_operands()
+    {
+        var result = Bash().Parse("cat -n README -- -n");
+
+        var arguments = Assert.Single(result.Commands).Arguments;
+        Assert.Equal(4, arguments.Count);
+        AssertUnknown(arguments[0]);
+        AssertExact(arguments[1], "/work/README");
+        AssertUnknown(arguments[2]);
+        AssertExact(arguments[3], "/work/-n");
+    }
+
+    [Fact]
+    public void Bash_native_verb_binding_is_case_sensitive()
+    {
+        var result = Bash().Parse("CAT README");
+
+        Assert.All(Assert.Single(result.Commands).Arguments, AssertUnknown);
+    }
+
+    [Theory]
+    [InlineData("show /api/v1")]
+    [InlineData("python -c 'print(1)'")]
+    [InlineData("test 1 -eq 1")]
+    [InlineData("head -n 10 README")]
+    [InlineData("scp user@example.invalid:/srv/file .")]
+    [InlineData("curl --output=- https://example.invalid")]
+    [InlineData("curl --data=/api/v1 https://example.invalid")]
+    [InlineData("tar --file=- -cf - README")]
+    public void Compatibility_path_heuristics_do_not_publish_the_strong_fact(string source)
+    {
+        var result = Bash().Parse(source);
+
+        Assert.False(result.IsUnparseable);
+        Assert.All(result.Commands.SelectMany(command => command.Arguments), AssertUnknown);
+    }
+
+    [Fact]
+    public void D14_publishes_a_finite_authored_filesystem_domain()
+    {
+        var result = Bash(authoredFacts: true).Parse(
+            "for f in src/A.cs src/B.cs; do cat /work/$f; done");
+
+        var argument = Assert.Single(Assert.Single(result.Commands).Arguments);
+        Assert.IsType<ShellValueDomain.Unknown>(argument.Value);
+        Assert.False(argument.Argument.IsPath);
+        AssertFinite(
+            argument.AuthoredFileSystemValue,
+            "/work/src/A.cs",
+            "/work/src/B.cs");
+    }
+
+    [Fact]
+    public void Unquoted_field_split_candidate_remains_unknown()
+    {
+        var result = Bash(authoredFacts: true).Parse(
+            "for f in 'src/A.cs /etc/passwd'; do cat /work/$f; done");
+
+        AssertUnknown(Assert.Single(Assert.Single(result.Commands).Arguments));
+    }
+
+    [Fact]
+    public void Unquoted_empty_expansion_does_not_claim_one_filesystem_argument()
+    {
+        var result = Bash(authoredFacts: true).Parse(
+            "for f in ''; do cat $f; done");
+
+        AssertUnknown(Assert.Single(Assert.Single(result.Commands).Arguments));
+    }
+
+    [Fact]
+    public void Quoted_binding_text_is_not_recursively_expanded()
+    {
+        var result = Bash(authoredFacts: true).Parse(
+            "for f in '$HOME/literal'; do cat \"$f\"; done");
+
+        AssertExact(
+            Assert.Single(Assert.Single(result.Commands).Arguments),
+            "/work/$HOME/literal");
+    }
+
+    [Fact]
+    public void Quoted_and_unquoted_binding_globs_have_different_provenance()
+    {
+        var quoted = Bash(authoredFacts: true).Parse(
+            "for f in '*.txt'; do cat \"$f\"; done");
+        var unquoted = Bash(authoredFacts: true).Parse(
+            "for f in '*.txt'; do cat $f; done");
+
+        AssertExact(
+            Assert.Single(Assert.Single(quoted.Commands).Arguments),
+            "/work/*.txt");
+        AssertUnknown(Assert.Single(Assert.Single(unquoted.Commands).Arguments));
+    }
+
+    [Fact]
+    public void All_path_loop_visits_join_to_a_finite_domain()
+    {
+        var result = Bash(authoredFacts: true).Parse(
+            "for f in README LICENSE; do cat \"$f\"; done");
+
+        AssertFinite(
+            Assert.Single(Assert.Single(result.Commands).Arguments)
+                .AuthoredFileSystemValue,
+            "/work/README",
+            "/work/LICENSE");
+    }
+
+    [Fact]
+    public void Option_and_path_loop_visits_join_to_unknown()
+    {
+        var result = Bash(authoredFacts: true).Parse(
+            "for f in -n README; do cat \"$f\"; done");
+
+        AssertUnknown(Assert.Single(Assert.Single(result.Commands).Arguments));
+    }
+
+    [Fact]
+    public void Runtime_iterator_keeps_cat_filesystem_value_unknown()
+    {
+        var result = Bash(authoredFacts: true).Parse(
+            "for f in $(find /work -name '*.cs'); do cat \"$f\"; done");
+
+        var cat = Assert.Single(
+            result.Commands,
+            command => command.Clause.Verb.Joined == "cat");
+        AssertUnknown(Assert.Single(cat.Arguments));
+    }
+
+    [Theory]
+    [InlineData("IFS=/; for f in a b; do cat \"$f\"; done")]
+    [InlineData("for f in a b; do \"$f\" README; done")]
+    public void State_mutation_and_dynamic_identity_do_not_gain_the_fact(string source)
+    {
+        var result = Bash(authoredFacts: true).Parse(source);
+
+        Assert.True(result.IsUnparseable);
+        Assert.Empty(result.Commands);
+    }
+
+    [Fact]
+    public void Authored_operand_fact_does_not_relax_an_unresolved_redirect()
+    {
+        var result = Bash(authoredFacts: true).Parse(
+            "for f in a b; do cat \"$f\" > \"$f\"; done");
+
+        var command = Assert.Single(result.Commands);
+        AssertFinite(
+            Assert.Single(command.Arguments).AuthoredFileSystemValue,
+            "/work/a",
+            "/work/b");
+        Assert.IsType<ShellValueDomain.Unknown>(
+            Assert.IsType<FileRedirectAnalysis>(Assert.Single(command.Redirects)).Target);
+    }
+
+    [Fact]
+    public void Authored_operand_fact_does_not_relax_command_substitution()
+    {
+        var result = Bash().Parse("cat \"$(printf README)\"");
+
+        Assert.Contains(
+            result.Commands,
+            command => command.ImmediateRole == CommandOccurrenceRole.Substitution);
+        var cat = Assert.Single(
+            result.Commands,
+            command => command.Clause.Verb.Joined == "cat");
+        AssertUnknown(Assert.Single(cat.Arguments));
+    }
+
+    [Theory]
+    [InlineData("cat README |")]
+    [InlineData("if cat README; then echo ok; fi")]
+    public void Incomplete_or_unsupported_control_flow_publishes_no_filesystem_fact(
+        string source)
+    {
+        var result = Bash(authoredFacts: true).Parse(source);
+
+        Assert.True(result.IsUnparseable);
+        Assert.Empty(result.Commands);
+    }
+
+    [Fact]
+    public void Unknown_occurrence_cwd_keeps_relative_operand_unknown()
+    {
+        var result = Bash(authoredFacts: true).Parse(
+            "for d in /work /tmp; do cd \"$d\"; cat README; done");
+
+        var cat = Assert.Single(
+            result.Commands,
+            command => command.Clause.Verb.Joined == "cat");
+        Assert.IsType<ShellValueDomain.Unknown>(cat.WorkingDirectory);
+        AssertUnknown(Assert.Single(cat.Arguments));
+    }
+
+    [Fact]
+    public void Over_limit_authored_union_remains_unknown()
+    {
+        var values = Enumerable.Range(1, ShellAnalysisLimits.MaxValueCandidates + 1)
+            .Select(index => $"f{index:00}");
+        var result = Bash(authoredFacts: true).Parse(
+            $"for f in {string.Join(" ", values)}; do cat \"$f\"; done");
+
+        AssertUnknown(Assert.Single(Assert.Single(result.Commands).Arguments));
+    }
+
+    [Theory]
+    [InlineData(PwshDialect.PowerShell7)]
+    [InlineData(PwshDialect.WindowsPowerShell51)]
+    public void PowerShell_literal_path_uses_the_selected_dialect(PwshDialect dialect)
+    {
+        var result = PowerShell(dialect).Parse(
+            "Get-Content -LiteralPath C:\\work\\a.txt");
+
+        AssertExact(Assert.Single(result.Commands).Arguments.Last(), "C:/work/a.txt");
+    }
+
+    [Theory]
+    [InlineData(PwshDialect.PowerShell7)]
+    [InlineData(PwshDialect.WindowsPowerShell51)]
+    public void PowerShell_inline_literal_path_preserves_flag_value_coordinates(
+        PwshDialect dialect)
+    {
+        var result = PowerShell(dialect).Parse(
+            "Get-Content -LiteralPath:C:\\work\\a.txt");
+
+        var arguments = Assert.Single(result.Commands).Arguments;
+        Assert.Equal(2, arguments.Count);
+        AssertUnknown(arguments[0]);
+        AssertExact(arguments[1], "C:/work/a.txt");
+        Assert.Same(arguments[0].Element, arguments[1].Element);
+    }
+
+    [Theory]
+    [InlineData("Get-ChildItem C:\\work *.cs")]
+    [InlineData("Rename-Item C:\\old new")]
+    [InlineData("Get-Content -LiteralPath Registry::HKEY_LOCAL_MACHINE")]
+    [InlineData("scp user@example.invalid:/srv/file .")]
+    [InlineData("curl --output=- https://example.invalid")]
+    [InlineData("Write-Output /api/v1")]
+    public void PowerShell_ambiguous_or_nonlocal_positions_remain_unknown(string source)
+    {
+        var result = PowerShell(PwshDialect.PowerShell7).Parse(source);
+
+        Assert.False(result.IsUnparseable);
+        Assert.All(result.Commands.SelectMany(command => command.Arguments), AssertUnknown);
+    }
+
+    [Theory]
+    [InlineData("Get-Content -LiteralPath -Force C:\\work\\a.txt")]
+    [InlineData("Get-Content -LiteralPath")]
+    [InlineData("Get-Content -Lit C:\\work\\a.txt")]
+    public void PowerShell_incomplete_literal_path_binding_remains_unknown(string source)
+    {
+        var result = PowerShell(PwshDialect.PowerShell7).Parse(source);
+
+        Assert.All(result.Commands.SelectMany(command => command.Arguments), AssertUnknown);
+    }
+
+    private static BashParser Bash(bool authoredFacts = false) => new(new BashParserOptions
+    {
+        WorkingDirectory = "/work",
+        PublishAuthoredSourceFacts = authoredFacts,
+    });
+
+    private static PwshParser PowerShell(PwshDialect dialect) => new(new PwshParserOptions
+    {
+        WorkingDirectory = "C:/work",
+        Dialect = dialect,
+    });
+
+    private static void AssertUnknown(AnalyzedArgument argument) =>
+        Assert.IsType<ShellValueDomain.Unknown>(argument.AuthoredFileSystemValue);
+
+    private static void AssertExact(AnalyzedArgument argument, string expected) =>
+        Assert.Equal(
+            expected,
+            Assert.IsType<ShellValueDomain.Exact>(argument.AuthoredFileSystemValue).Value);
+
+    private static void AssertFinite(ShellValueDomain domain, params string[] expected) =>
+        Assert.Equal(expected, Assert.IsType<ShellValueDomain.FiniteSet>(domain).Values);
+}

--- a/tests/ShellSyntaxTree.Tests/Parsing/AuthoredFileSystemValueTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Parsing/AuthoredFileSystemValueTests.cs
@@ -5,12 +5,48 @@
 // -----------------------------------------------------------------------
 using System;
 using System.Linq;
+using ShellSyntaxTree.Internal.Resolving;
 using Xunit;
 
 namespace ShellSyntaxTree.Tests.Parsing;
 
 public class AuthoredFileSystemValueTests
 {
+    [Fact]
+    public void Audited_commands_opt_into_reusable_binding_categories_through_data()
+    {
+        var operandArguments = Assert.Single(
+            Bash().Parse("example-command README.md").Commands).Arguments;
+        var operandEntry = new AuthoredFileSystemBindingCatalogEntry(
+            ShellProjectionLanguage.Bash,
+            "example-command",
+            StringComparison.Ordinal,
+            AuditedFileSystemBindingCategory.AllNonOptionOperands);
+
+        Assert.Equal(
+            new[] { AuditedFileSystemBindingCategory.AllNonOptionOperands },
+            AuthoredFileSystemBindingCatalog.Bind(operandEntry, operandArguments));
+
+        var parameterArguments = Assert.Single(
+            PowerShell(PwshDialect.PowerShell7)
+                .Parse("Example-Command -Source C:\\work\\a.txt")
+                .Commands).Arguments;
+        var parameterEntry = new AuthoredFileSystemBindingCatalogEntry(
+            ShellProjectionLanguage.PowerShell,
+            "Example-Command",
+            StringComparison.OrdinalIgnoreCase,
+            AuditedFileSystemBindingCategory.ExactNamedParameterValue,
+            "-Source");
+
+        Assert.Equal(
+            new[]
+            {
+                AuditedFileSystemBindingCategory.Unknown,
+                AuditedFileSystemBindingCategory.ExactNamedParameterValue,
+            },
+            AuthoredFileSystemBindingCatalog.Bind(parameterEntry, parameterArguments));
+    }
+
     [Theory]
     [InlineData("cat README.md", "/work/README.md")]
     [InlineData("cat /work/README.md", "/work/README.md")]

--- a/tests/ShellSyntaxTree.Tests/ShellSyntaxProjectionTests.cs
+++ b/tests/ShellSyntaxTree.Tests/ShellSyntaxProjectionTests.cs
@@ -962,6 +962,10 @@ public class ShellSyntaxProjectionTests
                     },
                 },
             },
+            () => new CommandOccurrenceFacts
+            {
+                ValueProvenance = null!,
+            },
         };
 
         foreach (var createFacts in invalidFacts)
@@ -974,6 +978,32 @@ public class ShellSyntaxProjectionTests
             Assert.Empty(result.Commands);
             Assert.Empty(result.Clauses);
         }
+    }
+
+    [Fact]
+    public void Unknown_projection_language_keeps_strong_filesystem_facts_disabled()
+    {
+        var clause = ClauseFor("cat") with
+        {
+            Args = new[] { new Arg { Raw = "README", Kind = ArgKind.Literal } },
+            Elements = new[]
+            {
+                new ClauseElement { Role = ClauseElementRole.Verb },
+                new ClauseElement { Role = ClauseElementRole.Argument },
+            },
+        };
+        var root = Block(0, Leaf(clause, 0));
+
+        Assert.True(ShellSyntaxProjection.TryProject(root, out var result));
+        Assert.IsType<ShellValueDomain.Unknown>(
+            Assert.Single(Assert.Single(result.Commands).Arguments)
+                .AuthoredFileSystemValue);
+        Assert.False(ShellSyntaxProjection.TryProject(
+            root,
+            _ => new CommandOccurrenceFacts(),
+            (ShellProjectionLanguage)int.MaxValue,
+            out var invalid));
+        Assert.Empty(invalid.Commands);
     }
 
     [Fact]

--- a/tests/ShellSyntaxTree.Tests/V03PublicApiSnapshotTests.cs
+++ b/tests/ShellSyntaxTree.Tests/V03PublicApiSnapshotTests.cs
@@ -121,6 +121,7 @@ public class V03PublicApiSnapshotTests
             (nameof(AnalyzedArgument.Element), typeof(ClauseElement)),
             (nameof(AnalyzedArgument.Value), typeof(ShellValueDomain)),
             (nameof(AnalyzedArgument.AuthoredValue), typeof(ShellValueDomain)),
+            (nameof(AnalyzedArgument.AuthoredFileSystemValue), typeof(ShellValueDomain)),
             (nameof(AnalyzedArgument.AuthoredPathShape), typeof(ShellPathShape)));
 
         AssertEnum<ShellPathShape>("Unknown", "Posix", "Windows");
@@ -348,6 +349,28 @@ public class V03PublicApiSnapshotTests
 
         Assert.Throws<NotSupportedException>(() =>
             JsonSerializer.Deserialize<ShellValueDomain>(json));
+    }
+
+    [Fact]
+    public void Authored_filesystem_value_is_non_null_and_part_of_record_shape()
+    {
+        var strict = new AnalyzedArgument();
+        var positive = strict with
+        {
+            AuthoredFileSystemValue = new ShellValueDomain.Exact("/work/a.txt"),
+        };
+
+        Assert.IsType<ShellValueDomain.Unknown>(strict.AuthoredFileSystemValue);
+        Assert.NotEqual(strict, positive);
+        Assert.NotEqual(strict.GetHashCode(), positive.GetHashCode());
+        Assert.Contains(
+            "AuthoredFileSystemValue = Exact",
+            positive.ToString(),
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "\"AuthoredFileSystemValue\"",
+            JsonSerializer.Serialize(positive),
+            StringComparison.Ordinal);
     }
 
     [Fact]

--- a/tools/PwshCorpusTool/CorpusJson.cs
+++ b/tools/PwshCorpusTool/CorpusJson.cs
@@ -352,7 +352,7 @@ internal static class CorpusJson
                 var arguments = new JsonArray();
                 foreach (var analyzed in command.Arguments)
                 {
-                    arguments.Add(new JsonObject
+                    var argument = new JsonObject
                     {
                         ["clauseArgumentIndex"] = FindClauseArgumentIndex(
                             command.Clause,
@@ -361,7 +361,14 @@ internal static class CorpusJson
                             command.Clause,
                             analyzed.Element),
                         ["value"] = BuildValueDomain(analyzed.Value),
-                    });
+                    };
+                    if (analyzed.AuthoredFileSystemValue is not ShellValueDomain.Unknown)
+                    {
+                        argument["authoredFileSystemValue"] =
+                            BuildValueDomain(analyzed.AuthoredFileSystemValue);
+                    }
+
+                    arguments.Add(argument);
                 }
 
                 commandJson["arguments"] = arguments;

--- a/tools/PwshCorpusTool/CorpusManifest.cs
+++ b/tools/PwshCorpusTool/CorpusManifest.cs
@@ -1530,5 +1530,8 @@ internal static class CorpusManifest
         OosI("v03_design_invoke_command_local_asjob_invalid_parameter_set",
             "Invoke-Command -ScriptBlock { Get-Date } -AsJob",
             "Promotes stable fail-closed design case pwsh-invoke-command-local-asjob-invalid-parameter-set."),
+        VIE("v03_authored_filesystem_literalpath",
+            "Get-Content -LiteralPath C:\\work\\a.txt",
+            "Pins the v0.3.3 audited authored-filesystem value for an exact cmdlet LiteralPath binding."),
     };
 }


### PR DESCRIPTION
## Summary

- add the single additive AnalyzedArgument.AuthoredFileSystemValue API
- publish Exact or FiniteSet only when an audited binder, transform proof, exact cwd, and existing resolver all agree
- model reusable binder categories through immutable catalog data; initial entries cover Bash cat operands and PowerShell Get-Content -LiteralPath
- keep compatibility IsPath, FileVerbs, lexical path shape, remote endpoints, providers, field splitting, globs, dynamic identity, substitutions, and incomplete flow out of the strong fact
- add Bash and PowerShell corpus coverage, D14 evidence, API snapshots, and input/output consumer guidance
- include the already-merged OpenSSL -subj correction from #162 in the 0.3.3 release notes

## Why

Netclaw needs a parser-owned local-filesystem fact for bounded authored loop operands without inventing executable grammar or treating broad compatibility path hints as authority. ShellSyntaxTree supplies the syntax fact; consumers still decide trust zones and authorization.

## Compatibility

Both net8.0 and netstandard2.0 API comparisons against public 0.3.2 report exactly one additive member. Existing signatures and compatibility leaves are unchanged.

## Validation

- Release build: 0 warnings, 0 errors
- full unit and corpus suite: 2,996 passed
- strict OpenSpec: passed
- copyright headers: passed
- corpus PII audit: passed
- Slopwatch changed-file scan: 0 findings
- 0.3.3 package build: passed for net8.0 and netstandard2.0
- adversarial review: PASS after a blocker drove the binder catalog refactor

Native Windows CI remains the merge gate. Public-package Netclaw D14 validation remains explicitly pending until 0.3.3 is published.