### PR TITLE
Add working-directory effect facts

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -10,7 +10,7 @@ priorities.
 
 ---
 
-## NOW (0.3.3 authored filesystem facts and downstream acceptance)
+## NOW (0.3.4 working-directory effects and downstream acceptance)
 
 - [x] **Create the v0.3.1 approval-fact OpenSpec.** Harvest and sanitize the
       Netclaw v0.26.0-beta.3 approval window. Classify all 18 distinct prompts
@@ -67,7 +67,7 @@ priorities.
       `Unknown` fallback. Compatibility `IsPath`, lexical path shape, broad
       file-verb tables, and bounded pre-splitting words cannot supply the fact
       by themselves.
-- [ ] **Implement, validate, and publish v0.3.3.** Add the single additive
+- [x] **Implement, validate, and publish v0.3.3.** Add the single additive
       `AnalyzedArgument.AuthoredFileSystemValue` property, the smallest audited
       Bash and PowerShell binders, exact transform and resolver boundaries,
       corpus and consumer-guide examples, public 0.3.2 API comparison, native
@@ -76,14 +76,24 @@ priorities.
       Release build, all 2,996 unit and corpus tests, the corpus PII audit,
       header verification, strict OpenSpec validation, Slopwatch, and a 0.3.3
       package build. Both target-framework API comparisons report exactly the
-      one approved additive property. Adversarial review, native Windows CI,
-      public package publication, and downstream Netclaw acceptance remain
-      required before this item is complete.
+      one approved additive property. PR #164 merged as `be47be8f` after Linux
+      and native Windows CI passed. Bare tag `0.3.3` published the package and
+      symbols through the release workflow. Downstream Netclaw acceptance
+      remains part of the separate approval-policy gate.
 - [x] **Keep OpenSSL subject data out of path classification.** Treat the
       slash-prefixed `-subj` Distinguished Name as non-path data without
       assigning verb-wide arity or path roles to subcommand-specific options.
       Direct `req`, `x509`, and `ca` regressions pin the shared subject rule,
       the valueless `x509 -serial` switch, and the non-path `ca -key` operand.
+- [x] **Approve the v0.3.4 working-directory-effect contract.** Add one closed
+      relational fact to `CommandOccurrence` so consumers can distinguish
+      proved preservation, success-only transfer, and unknown effects without
+      parsing shell builtins. Strict OpenSpec and adversarial review passed.
+- [ ] **Implement and validate v0.3.4 working-directory effects.** Derive the
+      fact from Bash and native PowerShell success/failure state, correct the
+      v0.3 Bash `chdir` flow, add scope/join/corruption/corpus/guide coverage,
+      preserve v0.3.3 compatibility, and publish only after Linux and native
+      Windows CI plus downstream Netclaw causal-directory acceptance pass.
 
 ## Completed v0.3.0 host integration and release acceptance
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,8 @@ foreach (var occurrence in parsed.Commands)
     Console.WriteLine(
         $"{occurrence.ImmediateRole} {clause.Verb.Joined} " +
         $"complete={occurrence.IsComplete} " +
-        $"cwd={Describe(occurrence.WorkingDirectory)}");
+        $"cwd={Describe(occurrence.WorkingDirectory)} " +
+        $"cwd-effect={Describe(occurrence.WorkingDirectoryEffect)}");
 
     foreach (var arg in clause.Args.Where(a => a.IsPath))
     {
@@ -114,6 +115,15 @@ static string Describe(ShellValueDomain value) => value switch
         $"{range.MinimumInclusive}..{range.MaximumInclusive}",
     ShellValueDomain.Concatenation => "bounded concatenation",
     ShellValueDomain.Unknown => "unknown",
+    _ => "unknown",
+};
+
+static string Describe(ShellWorkingDirectoryEffect effect) => effect switch
+{
+    ShellWorkingDirectoryEffect.Unchanged => "unchanged",
+    ShellWorkingDirectoryEffect.ChangesOnSuccess changed =>
+        $"changes on success to {Describe(changed.Target)}",
+    ShellWorkingDirectoryEffect.Unknown => "unknown",
     _ => "unknown",
 };
 
@@ -159,9 +169,10 @@ public enum PwshDialect { Unknown, PowerShell7, WindowsPowerShell51 }
 
 public sealed record ParsedCommand { /* Source, Syntax, Commands, Clauses, IsUnparseable, … */ }
 public abstract record ShellSyntaxNode;
-public sealed record CommandOccurrence { /* Clause, role, ancestry, analyzed arguments, cwd, redirects, completeness */ }
+public sealed record CommandOccurrence { /* Clause, role, ancestry, analyzed arguments, cwd, cwd effect, redirects, completeness */ }
 public sealed record AnalyzedArgument  { /* direct Arg + ClauseElement + ShellValueDomain join */ }
 public abstract record ShellValueDomain; // nested Unknown, Exact, FiniteSet, PathPattern
+public abstract record ShellWorkingDirectoryEffect; // nested Unknown, Unchanged, ChangesOnSuccess
 public abstract record RedirectSource;   // nested Unknown, Default, Descriptor, PowerShellAllStreams
 public abstract record RedirectAnalysis; // file, descriptor, heredoc, here-string, or unresolved alternative
 public sealed record Clause        { /* Operator, Verb, Args, Redirects, Elements, IsSubshell, IsCommandStringWrapped */ }

--- a/SPEC.POWERSHELL.md
+++ b/SPEC.POWERSHELL.md
@@ -1395,6 +1395,30 @@ v0.3 occurrence analysis is the failure-aware security fact and sanitizes stale
 exact compatibility attribution. This differs from Bash command substitution,
 whose state is isolated from the containing shell.
 
+Each v0.3 command occurrence also publishes the shared
+`ShellWorkingDirectoryEffect` from `SPEC.md`. A complete command with no
+parser-known current-runspace location mutation is `Unchanged`.
+`Set-Location` and selected-dialect aliases `cd`, `chdir`, and `sl` are
+`ChangesOnSuccess` when a success exit is reachable. Their exact or finite
+filesystem target is normalized with the PowerShell resolver; an unproved or
+non-filesystem provider target uses `ChangesOnSuccess(Unknown)`. A statically
+invalid parameter or operand shape whose only exit is unchanged failure is
+`Unchanged`. Flow and effect share one selected-dialect parameter binding;
+common parameters, aliases such as `PSPath`, and their unambiguous prefixes do
+not use a second effect-only scan.
+
+`Push-Location`, `Pop-Location`, scripts, provider ambiguity, invalidated
+identity, and unmodeled current-runspace effects are `Unknown`. A fully decoded
+current-runspace region keeps precise effects on its nested occurrences, but
+its host is `Unknown` if a nested location mutation can persist even when the
+host fails. A proved receiver whose reachable nested occurrences are all
+`Unchanged` may itself remain `Unchanged`.
+
+PowerShell pipeline location transfer retains the locked atomic-failure
+boundary until pipeline state is modeled. Parenthesized groups and `$()` are
+current-runspace scopes, not Bash subshells. Decoded child hosts isolate their
+exit state. Bash never imports PowerShell aliases or location semantics.
+
 `OpaqueRegionScanner` is grammar-agnostic but escapes on backslash; the
 PowerShell script-block, array, and hash paths give it a backtick-escape mode
 so `` { `} } `` scans correctly. The specialized `$()` scanner applies the

--- a/SPEC.md
+++ b/SPEC.md
@@ -591,8 +591,23 @@ public sealed record CommandOccurrence
     public IReadOnlyList<CommandAncestryFrame> Ancestry { get; internal init; } = [];
     public IReadOnlyList<AnalyzedArgument> Arguments { get; internal init; } = [];
     public ShellValueDomain WorkingDirectory { get; internal init; } = null!;
+    public ShellWorkingDirectoryEffect WorkingDirectoryEffect
+        { get; internal init; } = new ShellWorkingDirectoryEffect.Unknown();
     public IReadOnlyList<RedirectAnalysis> Redirects { get; internal init; } = [];
     public bool IsComplete { get; internal init; }
+}
+
+public abstract record ShellWorkingDirectoryEffect
+{
+    private protected ShellWorkingDirectoryEffect() { }
+    private protected abstract object LibraryOwnership { get; }
+
+    public sealed record Unknown : ShellWorkingDirectoryEffect { ... }
+    public sealed record Unchanged : ShellWorkingDirectoryEffect { ... }
+    public sealed record ChangesOnSuccess : ShellWorkingDirectoryEffect
+    {
+        public ShellValueDomain Target { get; }
+    }
 }
 
 public enum CommandOccurrenceRole
@@ -688,6 +703,54 @@ later identities or values remain incomplete.
 not one per predicted runtime iteration. `Ancestry` is ordered outermost to
 innermost, excludes the simple-command leaf, and retains every enclosing
 execution relation. `ImmediateRole` describes the nearest relation.
+
+`WorkingDirectory` is the occurrence's incoming shell-scope directory.
+`WorkingDirectoryEffect` is a separate relational outcome fact:
+
+- `Unchanged` proves that every modeled normal success and failure exit keeps
+  the incoming directory;
+- `ChangesOnSuccess(Target)` proves that failure keeps the incoming directory
+  and success takes `Target`; and
+- `Unknown` means neither relation is completely proved.
+
+The relation is recorded during abstract-state transfer. Equal incoming and
+outgoing domains do not create `Unchanged`, especially when both are unknown.
+The effect is local to the execution scope expressed by `Ancestry`; a mutation
+inside a Bash subshell or decoded child remains precise inside that scope but
+does not claim to change the parent.
+
+`ChangesOnSuccess.Target` is `Unknown`, `Exact`, or `FiniteSet`. Exact and
+finite targets are normalized absolute local directories under the selected
+shell path style. Unknown proves a success-only mutation without a bounded
+destination. Any other domain, malformed set, over-limit join, or missing fact
+makes the whole public effect `Unknown`. A target does not prove existence,
+accessibility, authorization, or runtime success.
+
+Effects join per authored occurrence. Two `Unchanged` visits remain
+`Unchanged`; two success-only changes join their bounded targets. Unknown,
+mixed unchanged/change visits, missing visits, or lost correlation join to
+`Unknown`. Unvisited bodies and default structural facts are `Unknown`, not
+`Unchanged`.
+
+For Bash, complete ordinary commands with no parser-known current-scope cwd
+mutation are `Unchanged`. A modeled `cd`, `command cd`, or `builtin cd` is
+`ChangesOnSuccess`; a statically invalid shape that can only fail without a
+transfer is `Unchanged`. `pushd` and `popd` are `Unknown` until a directory
+stack is modeled. Execution-bearing builtins such as `source`, `.`, and `eval`
+retain atomic parse failure and publish no occurrence.
+
+Bash has no `chdir` builtin. The v0.3 occurrence flow treats `chdir` as an
+ordinary external command and does not change the cwd. The v0.2 compatibility
+`Clauses` leaf retains its locked historical `chdir` attribution only for
+compatibility; v0.3 security consumers use `Commands`.
+
+The effect describes authored shell syntax under the selected grammar, parse
+options, and modeled source state. Ambient aliases, functions, modules,
+profiles, `PATH`, executable behavior, and inherited external state remain
+outside this fact, matching the `IsComplete` boundary. Consumers fail closed
+on unknown or future alternatives and combine the fact with ancestry,
+redirects, substitutions, path policy, all intervening occurrences, and every
+reachable fallback scope. They do not recreate a shell builtin list.
 
 `SimpleCommandSyntax.Substitutions` owns each completely delimited executable
 command substitution evaluated for that command's authored words and redirects,
@@ -900,7 +963,9 @@ final body's exit status; a zero-or-more loop joins its zero path with every
 reachable normal exit. Bounded fixed-point analysis widens differing cwd or
 variable values to `Unknown` rather than selecting one path.
 
-`cd` and `chdir` use the effective argument vector for the current visit.
+`cd` uses the effective argument vector for the current visit. Bash `chdir`
+remains a v0.2 compatibility alias only; v0.3 flow treats it as an ordinary
+external command.
 `pushd` and `popd` may be recognized only with unknown success cwd until the
 directory stack is modeled. Unmodeled execution-bearing or
 attribute-mutating builtins fail the complete parse closed globally, not only
@@ -966,7 +1031,9 @@ no partial command or compatibility projection.
 
 `Set-Location` is modeled from the complete effective argument vector. Its
 success exit takes the proved filesystem target cwd and its failure exit retains
-the incoming cwd. A successful non-filesystem or unproved target also
+the incoming cwd. One selected-dialect parameter-binding pass produces both
+that flow and `WorkingDirectoryEffect`; aliases, common parameters, and
+unambiguous prefixes cannot diverge between them. A successful non-filesystem or unproved target also
 invalidates binding and command-resolution proofs because relative provider
 operations may mutate that state. `&&` consumes only success, `||` only failure, and statement
 sequence consumes their join. The analyzer publishes no finite cwd set, so any

--- a/docs/CONSUMER_GUIDE.md
+++ b/docs/CONSUMER_GUIDE.md
@@ -830,16 +830,112 @@ aliases.
 
 With an incoming cwd of `/work`, the relevant output is:
 
-| Occurrence | `WorkingDirectory` | Authored path | `Arg.Resolved` |
-|---|---|---|---|
-| `cd /repo` | `Exact("/work")` | `/repo` | `/repo` |
-| `cat file.txt` | `Exact("/repo")` | `file.txt` | `/repo/file.txt` |
+| Occurrence | `WorkingDirectory` | `WorkingDirectoryEffect` | Authored path | `Arg.Resolved` |
+|---|---|---|---|---|
+| `cd /repo` | `Exact("/work")` | `ChangesOnSuccess(Exact("/repo"))` | `/repo` | `/repo` |
+| `cat file.txt` | `Exact("/repo")` | `Unchanged` | `file.txt` | `/repo/file.txt` |
 
 The `cd` row reports the directory in which `cd` itself runs; the `cat` row
 reports the successful `AndIf` continuation state. This is why consumers
 should use the occurrence's `WorkingDirectory` for execution context and the
 argument's `Resolved` value for path-zone policy rather than trying to infer
 either from clause order.
+
+`WorkingDirectoryEffect` is relational. It describes the authored command's
+modeled normal exits relative to its incoming shell scope:
+
+- `Unchanged` means every modeled success and failure preserves the incoming
+  directory;
+- `ChangesOnSuccess(Target)` means modeled failures preserve the incoming
+  directory and modeled successes take `Target`;
+- `Unknown` means the parser cannot publish a complete relation.
+
+The distinction matters when a later statement is reachable through more than
+one exit. Parse this with an incoming cwd of `/work`:
+
+```bash
+cd /tmp && inspect; head result.log
+```
+
+The relevant output is:
+
+| Occurrence | Incoming `WorkingDirectory` | Effect |
+|---|---|---|
+| `cd /tmp` | `Exact("/work")` | `ChangesOnSuccess(Exact("/tmp"))` |
+| `inspect` | `Exact("/tmp")` | `Unchanged` |
+| `head result.log` | `Unknown` | `Unchanged` |
+
+`head` may run after the successful `/tmp` path or after a failed transition.
+The parser therefore does not replace its unknown incoming directory with the
+earlier successful target. The fact that `head` itself is `Unchanged` does not
+make its unknown input safe.
+
+PowerShell uses the same public alternatives. Native PowerShell parses
+`Set-Location C:\repo` as
+`ChangesOnSuccess(Exact("C:/repo"))`. Selected-dialect aliases such as `cd`,
+`chdir`, and `sl` have the same effect. Bash `chdir` remains an ordinary
+command and is `Unchanged`; aliases never cross the language boundary.
+
+### Consuming a directory effect safely
+
+A policy can use the relation to explain or constrain causal intent, but the
+relation grants no authority. A default-deny consumer should apply a shape
+like this:
+
+```csharp
+static CausalDirectoryDecision EvaluateDirectoryEffect(
+    CommandOccurrence transition,
+    IReadOnlyList<CommandOccurrence> prerequisites,
+    string realFallbackDirectory,
+    IPathPolicy paths)
+{
+    if (!transition.IsComplete ||
+        transition.Clause.Verb.IsDynamic ||
+        transition.Redirects.Any(r => !r.IsComplete) ||
+        prerequisites.Any(p => !p.IsComplete))
+    {
+        return CausalDirectoryDecision.Prompt;
+    }
+
+    return transition.WorkingDirectoryEffect switch
+    {
+        ShellWorkingDirectoryEffect.Unchanged =>
+            CausalDirectoryDecision.NoTransition,
+
+        ShellWorkingDirectoryEffect.ChangesOnSuccess changed
+            when HasSupportedCurrentShellScope(transition.Ancestry) &&
+                 AllTargetsPass(changed.Target, paths) &&
+                 paths.Allows(realFallbackDirectory) &&
+                 prerequisites.All(HasIndependentAuthority) =>
+            CausalDirectoryDecision.Bounded,
+
+        ShellWorkingDirectoryEffect.ChangesOnSuccess =>
+            CausalDirectoryDecision.Prompt,
+
+        ShellWorkingDirectoryEffect.Unknown =>
+            CausalDirectoryDecision.Prompt,
+
+        _ => CausalDirectoryDecision.Deny,
+    };
+}
+```
+
+`AllTargetsPass` should accept only the domain alternatives the consumer has
+explicitly implemented. For example, it may enumerate `Exact` and bounded
+`FiniteSet` targets after normalization and symlink checks. It should reject
+`Unknown` and every future domain alternative by default.
+
+The consumer also checks every prerequisite occurrence, authored path,
+redirect, and reachable fallback directory. An effect does not prove that the
+command succeeded, that a later command is reachable only on success, or that
+the target is inside an authorized zone. Ancestry is part of the decision:
+Bash pipeline stages and subshells do not automatically transfer their effect
+to the parent shell, while a PowerShell current-runspace subexpression may.
+
+The fact is limited to authored shell semantics. It does not inspect ambient
+aliases, functions, profiles, provider state, directory stacks, or an external
+executable's private behavior. Those boundaries produce `Unknown`, remain
+outside the parser contract, or require independent executor policy.
 
 The attributed argument is derived context:
 

--- a/openspec/changes/publish-working-directory-effects/.openspec.yaml
+++ b/openspec/changes/publish-working-directory-effects/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-13

--- a/openspec/changes/publish-working-directory-effects/design.md
+++ b/openspec/changes/publish-working-directory-effects/design.md
@@ -1,0 +1,283 @@
+## Context
+
+`CommandOccurrence.WorkingDirectory` is an incoming-state fact. It can say that
+`head file` starts in `/tmp`, but it cannot say whether an earlier occurrence
+preserves or changes that directory. A consumer that wants to reason about
+`cd /tmp && inspect; head file` currently has two bad choices: keep the whole
+call strict, or maintain its own list of shell builtins.
+
+The latter fails for `pushd`, `popd`, `command cd`, `builtin cd`, PowerShell
+location cmdlets, current-scope executable regions, and future grammar. It also
+crosses the repository boundary: ShellSyntaxTree owns syntax and abstract shell
+state; Netclaw owns authorization.
+
+Both abstract-state analyzers already retain incoming state and separate normal
+success and failure flows. They do not preserve the relational reason why two
+unknown output states are equal. A public output-domain pair would therefore
+conflate “proved unchanged” with “may have changed to an unknown directory.”
+
+The v0.3.3 public API is stable. This slice must be extend-only and fail closed.
+It must also correct one v0.3 occurrence-analysis error: Bash has no `chdir`
+builtin. The v0.2 compatibility leaf may retain its legacy attribution, but
+the v0.3 occurrence flow must not claim that Bash `chdir` changes its parent
+shell directory.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Publish a relational, parser-owned cwd effect for every command occurrence.
+- Distinguish proved preservation from a proved success-only transfer and an
+  unknown effect.
+- Preserve bounded targets through loop visits and shell-specific resolution.
+- Cover Bash and native PowerShell with one public vocabulary.
+- Let security consumers reject unmodeled mutations without command-name
+  parsing.
+- Preserve all v0.3.3 public signatures and compatibility leaf shapes.
+
+**Non-Goals:**
+
+- Authorize commands, directories, redirects, or trust zones.
+- Predict ambient aliases, functions, modules, profiles, `PATH`, or executable
+  implementation behavior.
+- Model the Bash or PowerShell directory stack in this slice.
+- Prove that a transfer succeeds at runtime or that its target exists.
+- Replace `CommandOccurrence.WorkingDirectory` or legacy cwd attribution.
+- Infer effects for incomplete commands, hidden executable regions, or
+  unsupported control flow.
+
+## Decisions
+
+### 1. Add a closed relational effect family
+
+The public API gains one property and one library-owned record family:
+
+```csharp
+public sealed record CommandOccurrence
+{
+    // Existing members remain unchanged.
+    public ShellWorkingDirectoryEffect WorkingDirectoryEffect
+        { get; internal init; } = new ShellWorkingDirectoryEffect.Unknown();
+}
+
+public abstract record ShellWorkingDirectoryEffect
+{
+    private protected ShellWorkingDirectoryEffect() { }
+    private protected abstract object LibraryOwnership { get; }
+
+    public sealed record Unknown : ShellWorkingDirectoryEffect
+    {
+        internal Unknown() { }
+        private protected override object LibraryOwnership => this;
+    }
+
+    public sealed record Unchanged : ShellWorkingDirectoryEffect
+    {
+        internal Unchanged() { }
+        private protected override object LibraryOwnership => this;
+    }
+
+    public sealed record ChangesOnSuccess : ShellWorkingDirectoryEffect
+    {
+        internal ChangesOnSuccess(ShellValueDomain target) { ... }
+        private protected override object LibraryOwnership => this;
+        public ShellValueDomain Target { get; }
+    }
+}
+```
+
+`Unchanged` means every parser-modeled normal success and failure exit retains
+the occurrence's incoming shell-scope directory. `ChangesOnSuccess` means every
+modeled failure exit retains the incoming directory and every modeled success
+exit takes `Target`. `Unknown` means the parser cannot prove either relation.
+
+This is more truthful than exposing only `OnSuccess` and `OnFailure` domains.
+When the incoming cwd is unknown, two output `Unknown` domains do not prove
+preservation. An enum plus a nullable target was rejected because invalid
+state combinations would be publicly representable. A closed record family
+also gives consumers a default fail-closed arm for later alternatives.
+
+### 2. Keep the effect authored and scope-relative
+
+The fact describes the effect of authored shell syntax under the selected
+grammar, dialect, parse options, and modeled source-level state. It does not
+claim which ambient function, alias, module, profile, or executable the runtime
+selects. This matches `CommandOccurrence.IsComplete` and the existing v0.3
+threat-model boundary.
+
+The relation is local to the occurrence's execution scope. A Bash `cd` inside
+a subshell can be `ChangesOnSuccess` for that subshell while ancestry proves
+that the subshell does not mutate the parent. A PowerShell in-process execution
+region can affect its containing runspace. Consumers must evaluate ancestry,
+region timing, and completeness together with the effect.
+
+`AuthoredWorkingDirectoryEffect` was considered as the type name. The shorter
+name is preferred because all `CommandOccurrence` facts already share the
+authored-syntax boundary. XML documentation and the consumer guide state the
+boundary explicitly.
+
+### 3. Reuse `ShellValueDomain` for successful targets
+
+`ChangesOnSuccess.Target` uses the existing value family. This release permits
+only `Unknown`, `Exact`, and `FiniteSet` targets:
+
+- `Exact` is one normalized absolute directory.
+- `FiniteSet` is a bounded set of normalized absolute directories across
+  abstract visits.
+- `Unknown` proves a success-only directory mutation but not its destination.
+
+`IntegerRange`, `Concatenation`, `PathPattern`, null, or an unrecognized domain
+make the entire effect `Unknown`. A target remains a syntax fact; it does not
+prove existence, accessibility, or runtime success.
+
+### 4. Derive effects from per-occurrence transfer facts
+
+Each language analyzer records an internal effect while it computes a simple
+command's success and failure flow. It must not reconstruct the relation later
+by comparing output cwd strings. The internal join is:
+
+```text
+Unchanged + Unchanged                         -> Unchanged
+ChangesOnSuccess(A) + ChangesOnSuccess(B)     -> ChangesOnSuccess(join(A, B))
+Unknown + anything                            -> Unknown
+Unchanged + ChangesOnSuccess(...)             -> Unknown
+invalid or over-limit target join             -> Unknown
+```
+
+The analyzer copies the joined internal fact into `CommandOccurrenceFacts`.
+The public projector validates it and returns `Unknown` for any invalid or
+missing combination. Default structural facts are `Unknown`, never
+`Unchanged`.
+
+This preserves correlation across loop visits. It also avoids a false
+`Unchanged` result when both the incoming and outgoing domains happen to be
+unknown.
+
+### 5. Define the Bash boundary from Bash grammar
+
+The Bash analyzer publishes:
+
+- `Unchanged` for complete ordinary simple commands that contain no
+  parser-known current-scope cwd mutation;
+- `ChangesOnSuccess(Exact|FiniteSet)` for a modeled `cd` target;
+- `ChangesOnSuccess(Unknown)` for a modeled `cd` whose successful destination
+  is not bounded;
+- `Unknown` for `pushd`, `popd`, current-scope hidden execution, or another
+  accepted effect the grammar cannot bound.
+
+`source`, `.`, `eval`, and the existing execution-bearing builtin family keep
+their locked atomic parse failure. They produce no command occurrence and do
+not gain a working-directory effect.
+
+Exact `command cd` and `builtin cd` use the same cwd-transfer grammar as `cd`.
+Invalid static `cd` argument shapes that cannot have a successful transfer and
+retain cwd on failure are `Unchanged`.
+
+Bash `chdir` is an ordinary command name, not a builtin. The v0.3 occurrence
+flow and new effect treat it as `Unchanged`. The compatibility `Clauses`
+projection may retain its historical synthetic attribution for v0.2 consumers;
+the guide labels that leaf unsuitable for v0.3 authorization.
+
+### 6. Define the PowerShell boundary from selected-dialect grammar
+
+The native PowerShell analyzer publishes:
+
+- `Unchanged` for a complete command with no parser-known current-runspace
+  location mutation;
+- `ChangesOnSuccess(Exact|FiniteSet)` for a bounded `Set-Location` target;
+- `ChangesOnSuccess(Unknown)` for a modeled `Set-Location` with an unbounded
+  successful target;
+- `Unchanged` for a statically invalid `Set-Location` parameter or operand
+  shape whose only modeled exit is an unchanged failure;
+- `Unknown` for `Push-Location`, `Pop-Location`, an unmodeled script or
+  execution-region effect, provider ambiguity, or invalidated command state.
+
+Nested occurrences inside a fully decoded current-runspace execution region
+retain their own effects. The host occurrence is `Unknown` when any reachable
+nested effect can change location. The host cannot copy a nested
+`ChangesOnSuccess` relation because nested code can change location and then
+make the host fail. A host whose receiver and all reachable nested effects are
+proved `Unchanged` may remain `Unchanged`.
+
+Aliases canonicalized by the selected dialect (`cd`, `chdir`, and `sl`) share
+the `Set-Location` fact. One parameter-binding pass produces both flow and the
+relation. It recognizes selected-dialect common parameters, aliases, and their
+unambiguous prefixes. Bash does not inherit these PowerShell aliases.
+
+### 7. Keep authorization and causal fallback in Netclaw
+
+The parser does not decide that a transition or later action is safe. A
+Netclaw-style consumer may use the fact only after it:
+
+1. requires a complete parse and complete occurrences;
+2. checks the effect and target with a default-deny switch;
+3. evaluates every prerequisite occurrence and redirect;
+4. evaluates the intended target and every real fallback directory through
+   path policy;
+5. requires ancestry that preserves the relevant shell scope; and
+6. applies one-time, session, stored, or reviewed-safe authority independently.
+
+For example, `cd /tmp && inspect; head private.log` has a possible original-cwd
+fallback when `inspect` or `cd` does not establish the intended causal path.
+ShellSyntaxTree supplies effects and occurrence flow. Netclaw remains
+responsible for checking all reachable scopes before authorization.
+
+### 8. Preserve bounded loop effects only under a proved initial state
+
+An isolated non-interactive Bash analysis may join exact `cd` targets across
+finite loop visits. Authored-only analysis under an unknown initial state keeps
+a tracked loop-derived cwd target unbounded. This slice does not add a second
+authored transfer projection or repeat field-splitting, globbing, variable-
+attribute, and environment proofs already owned by authored filesystem facts.
+
+Thus a finite `cd "$d"` loop is positive under
+`BashInitialStateMode.IsolatedNonInteractive`. The same loop under default
+unknown initial state with only `PublishAuthoredSourceFacts=true` publishes a
+top-level unknown effect.
+
+### 9. Ship as an additive v0.x release
+
+No existing public member changes. The new property participates in record
+equality, hashing, `ToString()`, reflection, and default serializer output.
+Parser results are still an in-memory typed API, not a stable wire format.
+
+The API snapshot, package diff, `SPEC.md`, `SPEC.POWERSHELL.md`, consumer guide,
+and corpus all change together. Netclaw upgrades only after the public package
+passes its causal-directory regressions.
+
+## Risks / Trade-offs
+
+- **Risk: equality changes surprise consumers.** → Document the additive
+  record member and compare public APIs against 0.3.3.
+- **Risk: an unknown incoming cwd looks unchanged.** → Track the relational
+  fact directly; never infer it from domain equality.
+- **Risk: ambient functions can mutate cwd.** → Keep ambient runtime resolution
+  outside the authored-syntax contract and require consumers to accept that
+  existing boundary explicitly.
+- **Risk: a hidden region mutates cwd.** → Publish `Unknown` unless its current-
+  scope transfer is fully modeled.
+- **Risk: Bash and PowerShell aliases leak across languages.** → Derive through
+  the selected grammar and dialect, with cross-language negative tests.
+- **Trade-off: directory-stack commands remain unknown.** → This is safe and
+  general. A later stack model may refine them without consumer changes.
+- **Trade-off: legacy Bash `chdir` attribution remains in `Clauses`.** → Preserve
+  v0.2 compatibility while correcting the v0.3 security projection and guide.
+
+## Migration Plan
+
+1. Lock the additive API and semantic tables in the shared and PowerShell
+   specifications.
+2. Add internal effect facts and fail-closed public projection.
+3. Extend Bash and PowerShell transfer analysis and joins.
+4. Add unit, corpus, public API, consumer, and adversarial regressions.
+5. Run Release build, full tests, headers, package, API diff, and native CI.
+6. Publish the next additive v0.x package.
+7. Replace Netclaw's paused command-name logic with the parser-owned fact.
+
+Rollback requires no data migration. Consumers can ignore the property or pin
+0.3.3. Netclaw must retain strict causal behavior until it upgrades.
+
+## Open Questions
+
+None. Directory-stack refinement and richer outcome relations are later,
+separately specified capabilities.

--- a/openspec/changes/publish-working-directory-effects/proposal.md
+++ b/openspec/changes/publish-working-directory-effects/proposal.md
@@ -1,0 +1,46 @@
+## Why
+
+`CommandOccurrence.WorkingDirectory` describes where a command starts, but it
+does not describe whether that command can change the current shell scope.
+Security consumers therefore cannot distinguish an ordinary command from
+`cd`, `pushd`, `popd`, or another parser-known location mutation without
+reimplementing shell grammar.
+
+## What Changes
+
+- Add a parser-owned, closed working-directory-effect family to each command
+  occurrence.
+- Distinguish a proved unchanged directory, a change on successful completion,
+  and an unknown effect.
+- Publish the successful target as a bounded `ShellValueDomain` when the shell
+  grammar proves one.
+- Derive the fact from the existing success/failure abstract-state transfer for
+  Bash and native PowerShell.
+- Keep ambient functions, aliases, profiles, modules, executable behavior, and
+  other runtime resolution outside the authored-syntax fact.
+- Update the shared and PowerShell contracts, consumer guide, public API
+  snapshots, and sanitized regression corpus.
+
+## Capabilities
+
+### New Capabilities
+
+- `working-directory-effects`: Defines the additive public fact, its
+  success/failure semantics, shell-specific derivation, and fail-closed
+  consumer boundary.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Adds one property to `CommandOccurrence` and one closed public record family.
+- Extends Bash and PowerShell abstract-state projection without changing the
+  accepted grammar or compatibility `Clauses` projection.
+- Changes record equality, hashing, and diagnostic rendering for
+  `CommandOccurrence`; the new library-owned default is `Unknown`.
+- Enables Netclaw to consume a general parser fact instead of maintaining a
+  command-name list for causal working-directory approval.
+- Requires the next additive v0.x package release; no existing public member is
+  removed or changed.

--- a/openspec/changes/publish-working-directory-effects/specs/working-directory-effects/spec.md
+++ b/openspec/changes/publish-working-directory-effects/specs/working-directory-effects/spec.md
@@ -1,0 +1,456 @@
+## ADDED Requirements
+
+### Requirement: Working-directory effect is additive and fail-closed
+
+`CommandOccurrence` SHALL expose an additive `WorkingDirectoryEffect` property
+of type `ShellWorkingDirectoryEffect` with an assembly-owned setter. Every
+parser-produced occurrence SHALL set the property to a non-null member of the
+closed family. Missing, invalid, incomplete, or unrecognized internal facts
+SHALL project as `ShellWorkingDirectoryEffect.Unknown`.
+
+The family SHALL contain `Unknown`, `Unchanged`, and `ChangesOnSuccess`.
+`ChangesOnSuccess` SHALL expose a non-null `Target` of type `ShellValueDomain`.
+Every family constructor SHALL be non-public, and every alternative SHALL
+implement the same library-ownership boundary as `ShellValueDomain`.
+The property and family SHALL participate in record equality, hashing,
+`ToString()`, reflection, and default serializer shape. No v0.3.3 public member
+or signature SHALL change.
+
+#### Scenario: Strict default is unknown
+
+- **WHEN** projection receives no valid internal cwd-effect fact
+- **THEN** `WorkingDirectoryEffect` is `Unknown`
+
+#### Scenario: Public API extends v0.3.3
+
+- **WHEN** both target-framework API surfaces are compared with public v0.3.3
+- **THEN** this capability adds only `CommandOccurrence.WorkingDirectoryEffect`
+  and the closed `ShellWorkingDirectoryEffect` family
+- **AND** no existing public member or signature changes
+
+#### Scenario: New fact participates in record semantics
+
+- **WHEN** two otherwise equal command occurrences have different
+  `WorkingDirectoryEffect` values
+- **THEN** generated equality, hashing, and diagnostic rendering observe the
+  difference
+
+#### Scenario: Consumers cannot construct effect alternatives
+
+- **WHEN** reflection inspects every `ShellWorkingDirectoryEffect` alternative
+- **THEN** no public or protected constructor is available to consumers
+
+### Requirement: Effect semantics preserve the incoming-state relation
+
+`Unchanged` SHALL mean that every parser-modeled normal success and failure
+exit retains the occurrence's incoming shell-scope directory.
+`ChangesOnSuccess` SHALL mean that every modeled failure exit retains the
+incoming directory and every modeled success exit takes `Target`. `Unknown`
+SHALL mean that neither relation is completely proved.
+
+The analyzer SHALL record this relation directly while it computes command
+flow. It SHALL NOT infer `Unchanged` merely because incoming and outgoing
+domains compare equal or are both unknown. The effect SHALL be relative to the
+execution scope described by the occurrence's ancestry.
+
+#### Scenario: Unknown domain equality does not prove preservation
+
+- **GIVEN** an occurrence has an unknown incoming cwd
+- **AND** a parser-known mutation produces an unknown outgoing cwd
+- **WHEN** the effect is projected
+- **THEN** it is not `Unchanged`
+
+#### Scenario: Subshell-local mutation stays scope-relative
+
+- **WHEN** Bash parses `(cd /tmp)`
+- **THEN** the inner `cd` effect describes its subshell scope
+- **AND** command ancestry preserves the subshell boundary
+- **AND** the fact does not claim that the parent shell changes directory
+
+#### Scenario: PowerShell in-process scope remains visible
+
+- **WHEN** a modeled PowerShell execution region runs in the containing
+  runspace
+- **THEN** its nested occurrence effects use that runspace scope
+- **AND** an unmodeled host-level location effect remains `Unknown`
+
+### Requirement: Successful targets use a bounded value domain
+
+`ChangesOnSuccess.Target` SHALL be `Unknown`, `Exact`, or `FiniteSet`.
+`Exact` and every member of `FiniteSet` SHALL be a normalized absolute local
+directory under the selected shell path style. `Unknown` SHALL mean a
+success-only mutation is proved but its destination is not bounded.
+
+`IntegerRange`, `Concatenation`, `PathPattern`, null, an empty finite set, an
+over-limit union, mixed path styles, or an unrecognized domain SHALL make the
+entire public effect `Unknown`. A positive target SHALL NOT prove existence,
+accessibility, authorization, or runtime success.
+
+#### Scenario: Exact transfer target
+
+- **GIVEN** the incoming Bash cwd is `/work`
+- **WHEN** Bash parses `cd ../tmp`
+- **THEN** the effect is `ChangesOnSuccess(Exact("/tmp"))`
+
+#### Scenario: Finite loop target under proved initial state
+
+- **GIVEN** Bash uses `BashInitialStateMode.IsolatedNonInteractive`
+- **AND** the initial cwd is exact
+- **WHEN** Bash parses
+  `for d in /work/a /work/b; do cd "$d"; done`
+- **THEN** the loop-body occurrence effect is
+  `ChangesOnSuccess(FiniteSet(["/work/a", "/work/b"]))`
+
+#### Scenario: Authored-only loop target remains strict
+
+- **GIVEN** Bash uses unknown initial state with
+  `PublishAuthoredSourceFacts=true`
+- **WHEN** Bash parses
+  `for d in /work/a /work/b; do cd "$d"; done`
+- **THEN** the loop-body occurrence effect is `Unknown`
+
+#### Scenario: Unbounded successful target
+
+- **WHEN** a complete modeled cwd transfer has no bounded destination
+- **THEN** the effect is `ChangesOnSuccess(Unknown)`
+
+#### Scenario: Invalid target domain fails closed
+
+- **WHEN** an internal effect carries an unsupported or malformed target
+- **THEN** the public effect is `Unknown`
+
+### Requirement: Effect joins are correlation-preserving
+
+The analyzer SHALL join effect facts for repeated visits to the same authored
+occurrence. Two `Unchanged` facts SHALL join to `Unchanged`. Two
+`ChangesOnSuccess` facts SHALL join by the existing bounded-domain union.
+Any join that contains `Unknown`, mixes `Unchanged` with
+`ChangesOnSuccess`, exceeds limits, or cannot preserve visit correlation SHALL
+be `Unknown`.
+
+Default structural facts, unvisited branches, incomplete visits, and missing
+provenance SHALL be `Unknown`; they SHALL NOT default to `Unchanged`.
+
+#### Scenario: Equal successful transfers remain exact
+
+- **WHEN** every reachable visit transfers successfully to `/work`
+- **THEN** the joined effect is `ChangesOnSuccess(Exact("/work"))`
+
+#### Scenario: Distinct bounded transfers form a finite set
+
+- **WHEN** reachable visits transfer successfully to `/work/a` and `/work/b`
+- **THEN** the joined target is the deduplicated finite set of both paths
+
+#### Scenario: Mixed preservation and mutation remains unknown
+
+- **WHEN** one reachable visit is `Unchanged`
+- **AND** another reachable visit is `ChangesOnSuccess`
+- **THEN** the joined effect is `Unknown`
+
+#### Scenario: Missing visit evidence remains strict
+
+- **WHEN** one reachable visit lacks a complete effect fact
+- **THEN** the joined effect is `Unknown`
+
+### Requirement: Bash effects come from Bash syntax and modeled state
+
+For a complete Bash simple command, the analyzer SHALL publish `Unchanged`
+only when authored Bash syntax has no parser-known current-scope cwd mutation.
+A modeled `cd`, `command cd`, or `builtin cd` SHALL publish
+`ChangesOnSuccess` with its bounded target or `Unknown` target. A statically
+invalid `cd` shape with no successful transfer and an unchanged failure exit
+SHALL publish `Unchanged`.
+
+`pushd`, `popd`, a hidden current-scope executable region, or another accepted
+unbounded source-level mutation SHALL publish `Unknown`. Computed identity or
+incomplete executable syntax SHALL not receive a reusable effect. `source`,
+`.`, `eval`, and the locked execution-bearing builtin family SHALL keep atomic
+parse failure and SHALL publish no `CommandOccurrence`.
+
+Bash `chdir` SHALL be treated as an ordinary external command name and SHALL
+publish `Unchanged` when otherwise complete. It SHALL NOT update the v0.3
+occurrence flow. The legacy compatibility `Clauses` projection MAY retain its
+historical `chdir` cwd attribution, but consumers SHALL NOT use that leaf for
+v0.3 authorization.
+
+#### Scenario: Ordinary Bash command preserves cwd
+
+- **WHEN** Bash parses `inspect artifact`
+- **THEN** the occurrence effect is `Unchanged`
+
+#### Scenario: Bash cd transfers on success
+
+- **GIVEN** an exact cwd of `/work`
+- **WHEN** Bash parses `cd /tmp`
+- **THEN** the effect is `ChangesOnSuccess(Exact("/tmp"))`
+- **AND** failure retains `/work`
+
+#### Scenario: Exact dispatch wrappers preserve cd semantics
+
+- **WHEN** Bash parses `command cd /tmp` or `builtin cd /tmp`
+- **THEN** each effect is `ChangesOnSuccess(Exact("/tmp"))`
+
+#### Scenario: Invalid extra operand cannot transfer
+
+- **WHEN** Bash parses `cd /tmp extra`
+- **THEN** the effect is `Unchanged`
+- **AND** a later semicolon command keeps its original incoming cwd
+
+#### Scenario: Invalid option cannot transfer
+
+- **WHEN** Bash parses `cd -z /tmp`
+- **THEN** the effect is `Unchanged`
+
+#### Scenario: Directory stack remains unmodeled
+
+- **WHEN** Bash parses `pushd /tmp` or `popd`
+- **THEN** the effect is `Unknown`
+
+#### Scenario: Execution-bearing builtins still fail atomically
+
+- **WHEN** Bash parses `source setup.sh`, `. setup.sh`, or `eval "$code"`
+- **THEN** the whole parse is unparseable
+- **AND** no clauses or command occurrences are published
+
+#### Scenario: Bash chdir does not impersonate PowerShell
+
+- **GIVEN** an exact Bash cwd of `/work`
+- **WHEN** Bash parses `chdir /tmp; head file`
+- **THEN** the `chdir` effect is `Unchanged`
+- **AND** the `head` occurrence cwd remains `/work`
+
+#### Scenario: Later stack mutation invalidates causal intent
+
+- **WHEN** Bash parses `cd /tmp && pushd /other; head file`
+- **THEN** the `cd` effect is a bounded success transfer
+- **AND** the `pushd` effect is `Unknown`
+- **AND** a consumer cannot prove that `head` runs under `/tmp`
+
+#### Scenario: Pipeline stage effect does not prove parent leakage
+
+- **WHEN** Bash parses `printf x | cd /tmp; pwd` without proved `lastpipe`
+- **THEN** the `cd` pipeline-stage occurrence has
+  `ChangesOnSuccess(Exact("/tmp"))` for its stage scope
+- **AND** the following `pwd` occurrence has an unknown incoming cwd
+- **AND** no effect fact claims that the parent shell reached `/tmp`
+
+#### Scenario: First pipeline stage remains isolated
+
+- **GIVEN** an exact outer cwd of `/work`
+- **WHEN** Bash parses `cd /tmp | pwd; pwd`
+- **THEN** the first-stage `cd` has
+  `ChangesOnSuccess(Exact("/tmp"))` for its stage scope
+- **AND** the final outer `pwd` starts in `/work`
+
+#### Scenario: Command substitution discards inner cwd mutation
+
+- **GIVEN** an exact outer cwd of `/work`
+- **WHEN** Bash parses `echo "$(cd /tmp && pwd)"; pwd`
+- **THEN** the inner `cd` is `ChangesOnSuccess(Exact("/tmp"))`
+- **AND** its ancestry identifies substitution scope
+- **AND** the final outer `pwd` starts in `/work`
+
+#### Scenario: Decoded child shell isolates its exit state
+
+- **GIVEN** an exact outer cwd of `/work`
+- **WHEN** Bash parses `bash -c 'cd /tmp && pwd'; pwd`
+- **THEN** the decoded child `cd` is
+  `ChangesOnSuccess(Exact("/tmp"))`
+- **AND** the final outer `pwd` starts in `/work`
+
+#### Scenario: Unreachable loop body has no reusable effect
+
+- **WHEN** a proved zero-iteration Bash loop contains `cd /tmp`
+- **THEN** its projected body occurrence effect is `Unknown`
+
+### Requirement: PowerShell effects use the selected native dialect
+
+For a complete native PowerShell command, the analyzer SHALL publish
+`Unchanged` only when authored PowerShell syntax has no parser-known
+current-runspace location mutation. A modeled `Set-Location` SHALL publish
+`ChangesOnSuccess` with a bounded or unknown target when a success exit is
+reachable. A statically invalid parameter or operand shape whose only modeled
+exit is an unchanged failure SHALL publish `Unchanged`. Aliases canonicalized
+by the selected dialect (`cd`, `chdir`, and `sl`) SHALL share those rules.
+
+`Push-Location`, `Pop-Location`, provider ambiguity, script invocation,
+unmodeled current-runspace code, an invalidated command identity, or another
+unbounded location mutation SHALL publish `Unknown`. PowerShell aliases SHALL
+NOT affect Bash analysis.
+
+#### Scenario: Ordinary PowerShell command preserves location
+
+- **WHEN** native PowerShell parses `Get-Content file.txt`
+- **THEN** the occurrence effect is `Unchanged`
+
+#### Scenario: Set-Location transfers on success
+
+- **GIVEN** an exact Windows cwd of `C:/work`
+- **WHEN** native PowerShell parses `Set-Location C:\temp`
+- **THEN** the effect is `ChangesOnSuccess(Exact("C:/temp"))`
+
+#### Scenario: Native aliases share selected-dialect semantics
+
+- **WHEN** PowerShell parses `cd C:\temp`, `chdir C:\temp`, or `sl C:\temp`
+- **THEN** each effect matches canonical `Set-Location`
+
+#### Scenario: Parameter alias prefixes share flow and effect binding
+
+- **GIVEN** an exact Windows cwd of `C:/work`
+- **WHEN** PowerShell parses
+  `Set-Location -psp C:\temp && Get-Location`
+- **THEN** `-psp` resolves as an unambiguous `PSPath` prefix
+- **AND** the effect is `ChangesOnSuccess(Exact("C:/temp"))`
+- **AND** the success-gated `Get-Location` starts in `C:/temp`
+
+#### Scenario: Invalid switch value is failure-only
+
+- **WHEN** PowerShell parses `Set-Location -Verbose:no C:\temp`
+- **THEN** the effect is `Unchanged`
+- **AND** a later statement retains the incoming location
+
+#### Scenario: PowerShell location stack remains unmodeled
+
+- **WHEN** PowerShell parses `Push-Location C:\temp` or `Pop-Location`
+- **THEN** the effect is `Unknown`
+
+#### Scenario: Extra Set-Location operand cannot transfer
+
+- **GIVEN** an exact incoming location of `C:/work`
+- **WHEN** PowerShell parses `Set-Location C:\temp C:\other`
+- **THEN** the effect is `Unchanged`
+- **AND** a later statement keeps its original incoming location
+
+#### Scenario: Missing Set-Location parameter value cannot transfer
+
+- **WHEN** PowerShell parses `Set-Location -Path`
+- **THEN** the effect is `Unchanged`
+
+#### Scenario: Invalid static Set-Location parameter cannot transfer
+
+- **WHEN** PowerShell parses `Set-Location -Unsupported C:\temp`
+- **THEN** the effect is `Unchanged`
+
+#### Scenario: Non-filesystem provider transfer remains unbounded
+
+- **WHEN** PowerShell parses `Set-Location Env:`
+- **THEN** no exact local-filesystem target is published
+- **AND** the effect is `ChangesOnSuccess(Unknown)`
+
+#### Scenario: Bash keeps language separation
+
+- **WHEN** Bash parses `chdir /tmp` or `sl /tmp`
+- **THEN** neither command is treated as PowerShell `Set-Location`
+
+#### Scenario: PowerShell subexpression remains current-runspace scoped
+
+- **GIVEN** an exact incoming location of `C:/work`
+- **WHEN** PowerShell parses `$(Set-Location C:\temp); Get-Location`
+- **THEN** the nested `Set-Location` is
+  `ChangesOnSuccess(Exact("C:/temp"))`
+- **AND** ancestry identifies the subexpression relation
+- **AND** the later occurrence uses the failure-aware joined runspace location
+
+#### Scenario: PowerShell parenthesized group is not isolated
+
+- **WHEN** PowerShell parses `(Set-Location C:\temp); Get-Location`
+- **THEN** the nested location effect applies to the containing runspace
+- **AND** the later occurrence does not assume Bash subshell isolation
+
+#### Scenario: PowerShell location transfer in a pipeline stays atomic
+
+- **WHEN** PowerShell parses `Set-Location C:\temp | Get-Location`
+- **THEN** the whole parse is unparseable until pipeline location state is
+  modeled
+- **AND** no clauses or command occurrences are published
+
+#### Scenario: Modeled current-runspace mutation keeps host strict
+
+- **WHEN** PowerShell completely decodes an accepted current-runspace host
+  whose nested occurrence changes location and can later fail
+- **THEN** the nested occurrence retains its precise effect
+- **AND** the host occurrence effect is `Unknown`
+- **AND** the host does not copy the nested success-only relation
+
+#### Scenario: Unmodeled attached execution region keeps host strict
+
+- **WHEN** an accepted PowerShell host contains a current-runspace execution
+  region whose location effect is not completely modeled
+- **THEN** the host occurrence effect is `Unknown`
+
+#### Scenario: Current-runspace host with preserving body may be unchanged
+
+- **WHEN** a proved receiver and every reachable nested occurrence have
+  `Unchanged` effects
+- **AND** the receiver has no separate location mutation
+- **THEN** the host occurrence effect is `Unchanged`
+
+#### Scenario: Unreachable PowerShell loop body has no reusable effect
+
+- **WHEN** a proved empty PowerShell loop contains `Set-Location C:\temp`
+- **THEN** its projected body occurrence effect is `Unknown`
+
+### Requirement: Consumers combine effects with complete control-flow policy
+
+A positive working-directory effect SHALL NOT authorize a command or path.
+A security consumer SHALL require complete occurrences, use a default-deny
+switch for unknown or future effect alternatives, validate every exact or
+finite target through its own path policy, and evaluate all prerequisite and
+consumer occurrences independently.
+
+The consumer SHALL also evaluate occurrence ancestry, redirects, substitutions,
+real fallback scopes, and the effect of every intervening current-scope
+command. It SHALL NOT replace these checks with command-name parsing. Ambient
+runtime resolution remains the same explicit externality as other v0.3 command
+facts.
+
+#### Scenario: Bounded causal chain can be evaluated without verb parsing
+
+- **GIVEN** complete Bash occurrences for
+  `cd /tmp && inspect; head result.log`
+- **AND** `cd` has `ChangesOnSuccess(Exact("/tmp"))`
+- **AND** `inspect` and `head` have `Unchanged`
+- **WHEN** a consumer evaluates causal intent
+- **THEN** it can use the parser-owned effects without a builtin-name list
+- **AND** it still checks `/tmp`, the original cwd fallback, all redirects,
+  and all command authority
+
+#### Scenario: Unknown intervening effect keeps the chain strict
+
+- **WHEN** an intervening occurrence has `Unknown` effect
+- **THEN** the consumer does not infer a later cwd from the earlier transfer
+
+#### Scenario: Target outside policy remains denied
+
+- **WHEN** `ChangesOnSuccess.Target` lies outside the consumer's allowed roots
+- **THEN** the parser fact does not override the consumer's path decision
+
+#### Scenario: Future effect alternative fails closed
+
+- **WHEN** a consumer receives an unrecognized effect subtype
+- **THEN** it treats the occurrence as policy-sensitive and unresolved
+
+### Requirement: Shared specifications and guidance remain coherent
+
+`SPEC.md` SHALL define the shared API, relational semantics, Bash derivation,
+and consumer contract. `SPEC.POWERSHELL.md` SHALL define native PowerShell
+derivation and dialect behavior. `docs/CONSUMER_GUIDE.md` SHALL show input,
+parser output, and bounded consumer evaluation for direct transfer, directory
+stack, invalid transfer, language-separation, ancestry, and causal fallback
+cases.
+
+The sanitized corpus SHALL pin both positive and negative Bash behavior. Unit
+tests SHALL pin native PowerShell behavior without requiring a host-installed
+PowerShell parser at runtime. No corpus or guide example SHALL contain private
+repository names, user names, tokens, or machine-specific paths.
+
+#### Scenario: Guide distinguishes incoming cwd from effect
+
+- **WHEN** a consumer reads the working-directory section
+- **THEN** it sees that `WorkingDirectory` is the incoming value
+- **AND** `WorkingDirectoryEffect` is the relational outcome fact
+
+#### Scenario: Corpus is sanitized
+
+- **WHEN** the corpus PII audit scans new working-directory examples
+- **THEN** it finds zero forbidden patterns

--- a/openspec/changes/publish-working-directory-effects/tasks.md
+++ b/openspec/changes/publish-working-directory-effects/tasks.md
@@ -1,0 +1,110 @@
+## 1. Contract and Design Review
+
+- [x] 1.1 Synchronize the accepted API, relational semantics, Bash rules, and
+  consumer boundary into `SPEC.md`.
+- [x] 1.2 Synchronize selected-dialect location effects and language separation
+  into `SPEC.POWERSHELL.md`.
+- [x] 1.3 Correct the v0.3 Bash `chdir` occurrence contract while preserving the
+  explicitly documented v0.2 compatibility leaf.
+- [x] 1.4 Update `IMPLEMENTATION_PLAN.md` for the completed v0.3.3 release and
+  the new v0.3.4 working-directory-effect slice.
+- [x] 1.5 Run strict OpenSpec validation and obtain an adversarial review of the
+  public API, semantics, threat-model boundary, and acceptance matrix before
+  production implementation.
+
+## 2. Public Projection and Internal Facts
+
+- [x] 2.1 Add the closed `ShellWorkingDirectoryEffect` public family with
+  library-owned construction and immutable `ChangesOnSuccess.Target`.
+- [x] 2.2 Add `CommandOccurrence.WorkingDirectoryEffect` with a non-null
+  `Unknown` default and no change to existing signatures.
+- [x] 2.3 Add internal relational effect facts and validation that permits only
+  `Unknown`, `Unchanged`, and success-only `Unknown`/`Exact`/`FiniteSet`
+  targets.
+- [x] 2.4 Add correlation-preserving joins for repeated abstract visits and
+  fail closed on missing, mixed, invalid, or over-limit facts.
+- [x] 2.5 Extend public API snapshots, equality/hash/rendering tests, defensive
+  ownership tests, and both target-framework API comparisons against public
+  v0.3.3.
+
+## 3. Bash Analysis
+
+- [x] 3.1 Record `Unchanged` for complete ordinary Bash commands only after all
+  parser-known current-scope mutation boundaries pass.
+- [x] 3.2 Record bounded or unknown `ChangesOnSuccess` for `cd`, `command cd`,
+  and `builtin cd` from the existing effective-argument transfer.
+- [x] 3.3 Record `Unchanged` for statically invalid `cd` shapes whose only
+  reachable normal exit preserves cwd.
+- [x] 3.4 Record `Unknown` for pushd/popd and accepted hidden current-scope
+  effects; preserve atomic failure for source/dot/eval, unsupported dispatch,
+  computed identity, and incomplete execution-bearing syntax.
+- [x] 3.5 Stop treating Bash `chdir` as a v0.3 cwd transfer while preserving its
+  documented v0.2 compatibility attribution.
+- [x] 3.6 Preserve scope-relative effects and ancestry across first/last
+  pipeline stages, substitutions, decoded child shells, subshells, and loops;
+  pin unproved lastpipe, unreachable body, and zero-iteration boundaries.
+
+## 4. PowerShell Analysis
+
+- [x] 4.1 Record `Unchanged` for complete native PowerShell commands with no
+  parser-known current-runspace location mutation.
+- [x] 4.2 Record bounded or unknown `ChangesOnSuccess` for `Set-Location` and
+  its selected-dialect aliases; record failure-only invalid static shapes as
+  `Unchanged`.
+- [x] 4.3 Record `Unknown` for Push-Location/Pop-Location, provider ambiguity,
+  scripts, unmodeled current-runspace code, and invalidated identity.
+- [x] 4.4 Join repeated PowerShell visits without cross-dialect or
+  cross-language alias widening.
+- [ ] 4.5 Verify PowerShell 7 and Windows PowerShell 5.1 behavior on native
+  Windows, including path normalization and aliases.
+- [x] 4.6 Pin `$()` and parenthesized current-runspace propagation, PowerShell
+  pipeline semantics, modeled and unmodeled attached-region host effects,
+  shared Set-Location parameter binding, failure-only shapes, and empty-loop
+  bodies.
+
+## 5. Acceptance Corpus and Unit Coverage
+
+- [x] 5.1 Add Bash positives for ordinary unchanged commands, exact and finite
+  cd targets, command/builtin wrappers, and subshell-local effects.
+- [x] 5.2 Add Bash negatives for pushd/popd, atomic source/dot/eval failure,
+  dynamic targets, invalid options, extra operands, incomplete regions, and
+  mixed joins.
+- [x] 5.3 Pin `chdir` language separation and the
+  `cd /tmp && pushd /other; head file` counterexample.
+- [x] 5.4 Add PowerShell positives for Set-Location and aliases plus negatives
+  for alias prefixes, invalid switch values, location stack, provider, script,
+  and execution-region ambiguity.
+- [x] 5.5 Extend the corpus DTO and sanitized Bash entries with exact effect
+  expectations; run the corpus PII audit.
+- [x] 5.6 Add projection corruption tests for null, unsupported target domains,
+  malformed finite sets, relative/non-normalized/mixed-style paths, unknown
+  subtypes, and missing internal facts.
+
+## 6. Consumer Guidance and Downstream Acceptance
+
+- [x] 6.1 Update `docs/CONSUMER_GUIDE.md` with input/output examples that
+  distinguish incoming `WorkingDirectory` from relational effect.
+- [x] 6.2 Show a default-deny consumer switch over all effect alternatives,
+  target path checks, ancestry, redirects, prerequisites, and fallback cwd.
+- [x] 6.3 Explain authored-syntax versus ambient-runtime scope and why the fact
+  grants no authority.
+- [ ] 6.4 Upgrade the paused Netclaw causal-directory slice to the public
+  package and remove its command-name mutation logic.
+- [ ] 6.5 Add Netclaw regressions for cd success/failure, original-cwd fallback,
+  pushd/popd, command/builtin cd, Bash chdir, PowerShell separation, protected
+  paths, parent/subagent, interactive/headless, and recovery.
+
+## 7. Validation and Delivery
+
+- [x] 7.1 Run `openspec validate publish-working-directory-effects --strict`
+  after every contract or task-state revision.
+- [x] 7.2 Run Release build, full unit and corpus suite, header verification,
+  format checks, Slopwatch, package build, API diff, and PII audit.
+- [x] 7.3 Obtain adversarial reviews of the implementation, Bash/PowerShell
+  semantics, public API, consumer guide, corpus, and final frozen diff.
+- [ ] 7.4 Open the bounded ShellSyntaxTree pull request and merge only after
+  Linux and native Windows checks pass.
+- [ ] 7.5 Publish the next additive v0.x package through the release workflow
+  only after the implementation PR is merged and release gates pass.
+- [ ] 7.6 Run Netclaw local, native Windows, strict OpenSpec, approval-matrix,
+  and relevant headless eval gates before its causal-policy PR merges.

--- a/src/ShellSyntaxTree/CommandOccurrence.cs
+++ b/src/ShellSyntaxTree/CommandOccurrence.cs
@@ -68,6 +68,13 @@ public sealed record CommandOccurrence
     public ShellValueDomain WorkingDirectory { get; internal init; } =
         new ShellValueDomain.Unknown();
 
+    /// <summary>
+    /// Gets the authored command's relational effect on its shell-scope
+    /// working directory. This parser fact does not grant authority.
+    /// </summary>
+    public ShellWorkingDirectoryEffect WorkingDirectoryEffect { get; internal init; } =
+        new ShellWorkingDirectoryEffect.Unknown();
+
     /// <summary>Gets explicit redirect analysis in compatibility redirect order.</summary>
     public IReadOnlyList<RedirectAnalysis> Redirects
     {
@@ -89,6 +96,53 @@ public sealed record CommandOccurrence
         }
 
         return -1;
+    }
+}
+
+/// <summary>
+/// Describes an authored command's modeled effect on its shell-scope working
+/// directory.
+/// </summary>
+public abstract record ShellWorkingDirectoryEffect
+{
+    private protected ShellWorkingDirectoryEffect()
+    {
+    }
+
+    private protected abstract object LibraryOwnership { get; }
+
+    /// <summary>No complete working-directory relation is proved.</summary>
+    public sealed record Unknown : ShellWorkingDirectoryEffect
+    {
+        internal Unknown()
+        {
+        }
+
+        private protected override object LibraryOwnership => this;
+    }
+
+    /// <summary>Every modeled normal exit preserves the incoming directory.</summary>
+    public sealed record Unchanged : ShellWorkingDirectoryEffect
+    {
+        internal Unchanged()
+        {
+        }
+
+        private protected override object LibraryOwnership => this;
+    }
+
+    /// <summary>
+    /// Every modeled failure preserves the incoming directory and every
+    /// modeled success takes <see cref="Target"/>.
+    /// </summary>
+    public sealed record ChangesOnSuccess : ShellWorkingDirectoryEffect
+    {
+        internal ChangesOnSuccess(ShellValueDomain target) => Target = target;
+
+        private protected override object LibraryOwnership => this;
+
+        /// <summary>Gets the modeled directory after successful completion.</summary>
+        public ShellValueDomain Target { get; }
     }
 }
 

--- a/src/ShellSyntaxTree/Internal/Bash/Parsing/BashAbstractStateAnalyzer.cs
+++ b/src/ShellSyntaxTree/Internal/Bash/Parsing/BashAbstractStateAnalyzer.cs
@@ -31,6 +31,8 @@ internal sealed class BashAbstractStateAnalyzer
         _authoredArguments = new(ClauseReferenceComparer.Instance);
     private readonly Dictionary<Clause, HashSet<int>> _cwdResolutionSanitization =
         new(ClauseReferenceComparer.Instance);
+    private readonly Dictionary<Clause, ShellWorkingDirectoryEffectFacts>
+        _workingDirectoryEffects = new(ClauseReferenceComparer.Instance);
     private readonly List<BashForInAnalysisPlanReference> _rewrittenForInPlans = new();
     private bool _isComplete = true;
     private int _remainingLoopAnalysisTransitions = MaxLoopAnalysisTransitions;
@@ -155,9 +157,15 @@ internal sealed class BashAbstractStateAnalyzer
 
         if (!TryGetLegacyCwdTransfer(simple.Clause, input, out var success))
         {
+            RecordWorkingDirectoryEffect(
+                simple.Clause,
+                ShellWorkingDirectoryEffectFacts.Unchanged);
             return BashFlowResult.Both(input);
         }
 
+        RecordWorkingDirectoryEffect(
+            simple.Clause,
+            ShellWorkingDirectoryEffectFacts.Unknown);
         return new BashFlowResult(success, input);
     }
 
@@ -879,6 +887,9 @@ internal sealed class BashAbstractStateAnalyzer
             out var argumentElementIndices);
         if (dispatchKind == BashDispatchKind.Query)
         {
+            RecordWorkingDirectoryEffect(
+                simple.Clause,
+                ShellWorkingDirectoryEffectFacts.Unchanged);
             return BashFlowResult.Both(input);
         }
 
@@ -906,6 +917,9 @@ internal sealed class BashAbstractStateAnalyzer
                 }
 
                 RecordCwdResolutionSanitization(simple.Clause, argumentElementIndices);
+                RecordWorkingDirectoryEffect(
+                    simple.Clause,
+                    ShellWorkingDirectoryEffectFacts.Unknown);
                 return BashFlowResult.Both(input.WithUnknownCwd());
             }
         }
@@ -934,11 +948,16 @@ internal sealed class BashAbstractStateAnalyzer
         if (alternativeResult == BashBindingAlternativeResult.Unknown)
         {
             RecordCwdResolutionSanitization(simple.Clause, argumentElementIndices);
+            RecordWorkingDirectoryEffect(
+                simple.Clause,
+                ShellWorkingDirectoryEffectFacts.ChangesOnSuccess(
+                    ShellValueDomainFacts.Unknown));
             return new BashFlowResult(input.WithUnknownCwd(), input);
         }
 
         BashAbstractState? success = null;
         BashAbstractState? failure = null;
+        ShellWorkingDirectoryEffectFacts? effect = null;
         foreach (var bindings in bindingAlternatives)
         {
             BuildEffectiveCwdArguments(
@@ -963,10 +982,44 @@ internal sealed class BashAbstractStateAnalyzer
 
             success = BashAbstractState.JoinNullable(success, visit.OnSuccess);
             failure = BashAbstractState.JoinNullable(failure, visit.OnFailure);
+            var visitEffect = CreateCwdTransferEffect(visit);
+            effect = effect is null
+                ? visitEffect
+                : ShellWorkingDirectoryEffectFacts.Join(effect, visitEffect);
         }
 
+        RecordWorkingDirectoryEffect(
+            simple.Clause,
+            effect ?? ShellWorkingDirectoryEffectFacts.Unknown);
         return new BashFlowResult(success, failure);
     }
+
+    private static ShellWorkingDirectoryEffectFacts CreateCwdTransferEffect(
+        BashFlowResult flow)
+    {
+        if (flow.OnSuccess is not BashAbstractState success)
+        {
+            return ShellWorkingDirectoryEffectFacts.Unchanged;
+        }
+
+        return ShellWorkingDirectoryEffectFacts.ChangesOnSuccess(success.ToDomain());
+    }
+
+    private void RecordWorkingDirectoryEffect(
+        Clause clause,
+        ShellWorkingDirectoryEffectFacts effect)
+    {
+        _workingDirectoryEffects[clause] = _workingDirectoryEffects.TryGetValue(
+            clause,
+            out var prior)
+            ? ShellWorkingDirectoryEffectFacts.Join(prior, effect)
+            : effect;
+    }
+
+    private ShellWorkingDirectoryEffectFacts GetWorkingDirectoryEffect(Clause clause) =>
+        _workingDirectoryEffects.TryGetValue(clause, out var effect)
+            ? effect
+            : ShellWorkingDirectoryEffectFacts.Unknown;
 
     private bool TryGetCwdArgumentValues(
         SimpleCommandSyntax simple,
@@ -1233,7 +1286,7 @@ internal sealed class BashAbstractStateAnalyzer
         if (verb is "command" or "builtin")
         {
             var dispatched = DispatchedVerb(clause);
-            if (dispatched is "cd" or "chdir" or "pushd" or "popd" or
+            if (dispatched is "cd" or "pushd" or "popd" or
                 "eval" or "." or "source" or "trap")
             {
                 success = input.WithUnknownCwd();
@@ -1249,7 +1302,7 @@ internal sealed class BashAbstractStateAnalyzer
             return true;
         }
 
-        if (verb is not ("cd" or "chdir"))
+        if (verb != "cd")
         {
             return false;
         }
@@ -1505,6 +1558,7 @@ internal sealed class BashAbstractStateAnalyzer
             AuthoredArguments = CreateAuthoredArguments(simple.Clause),
             PublishAuthoredPathShape = true,
             WorkingDirectory = input.ToDomain(),
+            WorkingDirectoryEffect = GetWorkingDirectoryEffect(simple.Clause),
             Redirects = redirects,
             RedirectTargetProvenance = sourceFacts.RedirectTargetProvenance,
             CwdPathDependencies = sourceFacts.CwdPathDependencies,

--- a/src/ShellSyntaxTree/Internal/Bash/Parsing/BashCwdInvocationGrammar.cs
+++ b/src/ShellSyntaxTree/Internal/Bash/Parsing/BashCwdInvocationGrammar.cs
@@ -66,7 +66,7 @@ internal static class BashCwdInvocationGrammar
 
         var targetWordIndex = dispatch.TargetWordIndex.Value;
         var target = clause.Elements[words[targetWordIndex]];
-        if (target.Value is not ("cd" or "chdir"))
+        if (target.Value != "cd")
         {
             return BashDispatchKind.None;
         }

--- a/src/ShellSyntaxTree/Internal/Bash/Parsing/BashStructuralCoordinator.cs
+++ b/src/ShellSyntaxTree/Internal/Bash/Parsing/BashStructuralCoordinator.cs
@@ -1675,7 +1675,7 @@ internal static partial class BashCommandParser
             if (verb is "unset" or "read" or "readarray" or "mapfile" or
                 "declare" or "typeset" or "local" or "export" or "readonly" or
                 "let" or "eval" or "." or "source" or "getopts" or "set" or
-                "cd" or "chdir" or "pushd" or "popd" or "trap" or
+                "cd" or "pushd" or "popd" or "trap" or
                 "break" or "continue" or "return" or "exit" or "exec")
             {
                 return true;

--- a/src/ShellSyntaxTree/Internal/Pwsh/Parsing/PwshForEachValueAnalysis.cs
+++ b/src/ShellSyntaxTree/Internal/Pwsh/Parsing/PwshForEachValueAnalysis.cs
@@ -1932,12 +1932,17 @@ internal sealed class PwshForEachValueAnalyzer
         new(ClauseReferenceComparer.Instance);
     private readonly Dictionary<Clause, IReadOnlyList<ExecutionRegionSyntax>>
         _executionRegions = new(ClauseReferenceComparer.Instance);
+    private readonly Dictionary<Clause, ShellWorkingDirectoryEffectFacts>
+        _workingDirectoryEffects = new(ClauseReferenceComparer.Instance);
+    private readonly Dictionary<Clause, ShellWorkingDirectoryEffectFacts>
+        _executionRegionHostEffects = new(ClauseReferenceComparer.Instance);
     private readonly List<AnalysisContext> _invocationRedirectContexts = new();
     private bool _isComplete = true;
     private int _remainingLoopAnalysisTransitions = MaxLoopAnalysisTransitions;
     private long _executionRegionEffectCount;
     private long _nonRegionStateMutationCount;
     private long _locationStateMutationCount;
+    private long _nonPreservingWorkingDirectoryEffectCount;
     private long _childScopeEscapeRiskCount;
     private long _childRunspaceProcessEscapeRiskCount;
     private bool _pipelineStageMayReceiveInput;
@@ -2041,6 +2046,19 @@ internal sealed class PwshForEachValueAnalyzer
 
     private PwshFlowResult AnalyzeSimple(SimpleCommandSyntax simple, AnalysisContext input)
     {
+        var flow = AnalyzeSimpleCore(simple, input, out var directEffect);
+        RecordWorkingDirectoryEffect(
+            simple.Clause,
+            directEffect ?? ClassifyWorkingDirectoryEffect(simple));
+        return flow;
+    }
+
+    private PwshFlowResult AnalyzeSimpleCore(
+        SimpleCommandSyntax simple,
+        AnalysisContext input,
+        out ShellWorkingDirectoryEffectFacts? directEffect)
+    {
+        directEffect = null;
         var current = input;
         foreach (var substitution in simple.Substitutions)
         {
@@ -2116,6 +2134,7 @@ internal sealed class PwshForEachValueAnalyzer
         var location = AnalyzeSetLocation(simple, current);
         if (location is not null)
         {
+            directEffect = location.Value.Effect;
             _nonRegionStateMutationCount++;
             _locationStateMutationCount++;
             if (PwshPersistentStateMutation.TryGetEffect(
@@ -2123,7 +2142,7 @@ internal sealed class PwshForEachValueAnalyzer
                     _options.Dialect,
                     effective,
                     providerLocationUnknown: current.WorkingDirectory is null,
-                    out var locationEffectUnknownCwd))
+                    out _))
             {
                 var mayEscapeChildRunspaceProcess =
                     PwshPersistentStateMutation.MayEscapeChildRunspaceProcess(
@@ -2144,12 +2163,12 @@ internal sealed class PwshForEachValueAnalyzer
                     _childRunspaceProcessEscapeRiskCount++;
                 }
 
-                var flow = location.Value;
+                var flow = location.Value.Flow;
                 return ApplyExecutionRegionEffect(simple, current, new PwshFlowResult(
                     flow.OnSuccess is AnalysisContext success
                         ? ApplyPersistentStateInvalidation(
                             success,
-                            locationEffectUnknownCwd,
+                            unknownCwd: false,
                             hasCommandResolutionMutation,
                             invalidatesAllCommandNames,
                             mutatedCommandNames,
@@ -2160,7 +2179,7 @@ internal sealed class PwshForEachValueAnalyzer
                     flow.OnFailure is AnalysisContext failure
                         ? ApplyPersistentStateInvalidation(
                             failure,
-                            locationEffectUnknownCwd,
+                            unknownCwd: false,
                             hasCommandResolutionMutation,
                             invalidatesAllCommandNames,
                             mutatedCommandNames,
@@ -2170,7 +2189,7 @@ internal sealed class PwshForEachValueAnalyzer
                         : null));
             }
 
-            return ApplyExecutionRegionEffect(simple, current, location.Value);
+            return ApplyExecutionRegionEffect(simple, current, location.Value.Flow);
         }
 
         if (PwshPersistentStateMutation.TryGetEffect(
@@ -2223,6 +2242,60 @@ internal sealed class PwshForEachValueAnalyzer
                     : current));
     }
 
+    private ShellWorkingDirectoryEffectFacts ClassifyWorkingDirectoryEffect(
+        SimpleCommandSyntax simple)
+    {
+        if (!_facts.TryGetValue(simple.Clause, out var facts) ||
+            !facts.IsComplete)
+        {
+            return ShellWorkingDirectoryEffectFacts.Unknown;
+        }
+
+        if (simple.ExecutionRegions.Count > 0)
+        {
+            return _executionRegionHostEffects.TryGetValue(
+                simple.Clause,
+                out var hostEffect)
+                ? hostEffect
+                : ShellWorkingDirectoryEffectFacts.Unknown;
+        }
+
+        if (PwshPersistentStateMutation.TryGetEffect(
+                simple.Clause,
+                _options.Dialect,
+                facts.EffectiveArguments,
+                providerLocationUnknown:
+                    facts.WorkingDirectory.Kind == ShellValueDomainKind.Unknown,
+                out var unknownCwd) &&
+            unknownCwd)
+        {
+            return ShellWorkingDirectoryEffectFacts.Unknown;
+        }
+
+        return ShellWorkingDirectoryEffectFacts.Unchanged;
+    }
+
+    private void RecordWorkingDirectoryEffect(
+        Clause clause,
+        ShellWorkingDirectoryEffectFacts effect)
+    {
+        if (effect.Kind != ShellWorkingDirectoryEffectKind.Unchanged)
+        {
+            _nonPreservingWorkingDirectoryEffectCount++;
+        }
+
+        _workingDirectoryEffects[clause] = _workingDirectoryEffects.TryGetValue(
+            clause,
+            out var prior)
+            ? ShellWorkingDirectoryEffectFacts.Join(prior, effect)
+            : effect;
+    }
+
+    private ShellWorkingDirectoryEffectFacts GetWorkingDirectoryEffect(Clause clause) =>
+        _workingDirectoryEffects.TryGetValue(clause, out var effect)
+            ? effect
+            : ShellWorkingDirectoryEffectFacts.Unknown;
+
     private static AnalysisContext ApplyPersistentStateInvalidation(
         AnalysisContext input,
         bool unknownCwd,
@@ -2263,6 +2336,45 @@ internal sealed class PwshForEachValueAnalyzer
         {
             return flow;
         }
+
+        var receiverIdentityProven = IsExecutionRegionReceiverIdentityProven(
+            simple.Clause,
+            receiverInput);
+        var binding = PwshExecutionRegionBindingCatalog.Bind(
+            simple.Clause,
+            receiverIdentityProven,
+            _options.Dialect);
+        var before = _nonPreservingWorkingDirectoryEffectCount;
+        var result = ApplyExecutionRegionEffectCore(
+            simple,
+            receiverInput,
+            flow);
+        var supported = binding.Status == PwshExecutionRegionBindingStatus.ProvedData ||
+            IsSupportedExecutionRegionReceiver(binding) &&
+            TryApplyExecutionRegionBindings(simple, binding, out _);
+        var isolated = binding.ParameterSet is
+            PwshExecutionRegionParameterSet.ForEachParallel or
+            PwshExecutionRegionParameterSet.InvokeRemote or
+            PwshExecutionRegionParameterSet.StartJobScriptBlock;
+        _executionRegionHostEffects[simple.Clause] = !supported
+            ? ShellWorkingDirectoryEffectFacts.Unknown
+            : isolated ||
+              _nonPreservingWorkingDirectoryEffectCount == before
+                ? ShellWorkingDirectoryEffectFacts.Unchanged
+                : ShellWorkingDirectoryEffectFacts.Unknown;
+        if (isolated)
+        {
+            _nonPreservingWorkingDirectoryEffectCount = before;
+        }
+
+        return result;
+    }
+
+    private PwshFlowResult ApplyExecutionRegionEffectCore(
+        SimpleCommandSyntax simple,
+        AnalysisContext receiverInput,
+        PwshFlowResult flow)
+    {
 
         var receiverIdentityProven = IsExecutionRegionReceiverIdentityProven(
             simple.Clause,
@@ -3230,10 +3342,10 @@ internal sealed class PwshForEachValueAnalyzer
             _ when values.Count > 1 &&
                 values.Count <= ShellAnalysisLimits.MaxValueCandidates =>
                 new ShellValueDomainFacts
-            {
-                Kind = ShellValueDomainKind.FiniteSet,
-                Values = values,
-            },
+                {
+                    Kind = ShellValueDomainKind.FiniteSet,
+                    Values = values,
+                },
             _ => ShellValueDomainFacts.Unknown,
         };
 
@@ -3740,7 +3852,7 @@ internal sealed class PwshForEachValueAnalyzer
         return true;
     }
 
-    private PwshFlowResult? AnalyzeSetLocation(
+    private PwshSetLocationAnalysis? AnalyzeSetLocation(
         SimpleCommandSyntax simple,
         AnalysisContext input)
     {
@@ -3757,6 +3869,7 @@ internal sealed class PwshForEachValueAnalyzer
         var hasTarget = false;
         var expectsPath = false;
         var literalPath = false;
+        var usesStackName = false;
         for (var elementIndex = 0;
              elementIndex < simple.Clause.Elements.Count;
              elementIndex++)
@@ -3767,34 +3880,101 @@ internal sealed class PwshForEachValueAnalyzer
                 continue;
             }
 
+            if (element.IsFlag && TryAnalyzeSetLocationSwitch(
+                    element,
+                    out var switchStatus))
+            {
+                if (switchStatus == SetLocationSwitchStatus.Invalid)
+                {
+                    return FailedSetLocation(input);
+                }
+
+                if (switchStatus == SetLocationSwitchStatus.MaySucceed)
+                {
+                    continue;
+                }
+
+                continue;
+            }
+
             if (!TryGetElementDomain(simple, elementIndex, input, out var domain) ||
                 domain.Kind != ShellValueDomainKind.Exact ||
                 domain.Values.Count != 1)
             {
-                return new PwshFlowResult(input.Invalidate(unknownCwd: true), input);
+                return new PwshSetLocationAnalysis(
+                    new PwshFlowResult(input.Invalidate(unknownCwd: true), input),
+                    ShellWorkingDirectoryEffectFacts.ChangesOnSuccess(
+                        ShellValueDomainFacts.Unknown));
             }
 
             var value = domain.Values[0];
             if (element.IsFlag)
             {
+                if (expectsPath)
+                {
+                    return FailedSetLocation(input);
+                }
+
                 var colon = value.IndexOf(':');
                 var parameter = colon < 0 ? value : value.Substring(0, colon);
-                if (parameter.Equals("-PassThru", StringComparison.OrdinalIgnoreCase))
+                var parameterRole = PwshSetLocationParameterCatalog.Resolve(
+                    parameter,
+                    _options.Dialect);
+                if (parameterRole == PwshSetLocationParameterRole.Invalid)
                 {
+                    return FailedSetLocation(input);
+                }
+
+                if (parameterRole == PwshSetLocationParameterRole.Switch)
+                {
+                    if (colon >= 0 && !IsValidSwitchValue(value.Substring(colon + 1)))
+                    {
+                        return FailedSetLocation(input);
+                    }
+
                     continue;
                 }
 
-                if (!IsPathParameter(parameter, out var isLiteralPath))
+                if (parameterRole is PwshSetLocationParameterRole.NonPathValue or
+                    PwshSetLocationParameterRole.StackNameValue)
                 {
-                    return new PwshFlowResult(input.Invalidate(unknownCwd: true), input);
+                    if (colon >= 0)
+                    {
+                        if (colon + 1 == value.Length)
+                        {
+                            return FailedSetLocation(input);
+                        }
+                    }
+                    else if (!TrySkipParameterValue(simple, ref elementIndex))
+                    {
+                        return FailedSetLocation(input);
+                    }
+
+                    if (parameterRole == PwshSetLocationParameterRole.StackNameValue)
+                    {
+                        if (usesStackName || hasTarget)
+                        {
+                            return FailedSetLocation(input);
+                        }
+
+                        usesStackName = true;
+                    }
+
+                    continue;
                 }
 
-                literalPath = isLiteralPath;
+                if (usesStackName)
+                {
+                    return FailedSetLocation(input);
+                }
+
+                literalPath = parameterRole ==
+                    PwshSetLocationParameterRole.LiteralPathValue;
                 if (colon >= 0)
                 {
                     if (hasTarget || colon + 1 == value.Length)
                     {
-                        return new PwshFlowResult(null, input);
+                        return FailedSetLocation(input);
                     }
 
                     target = value.Substring(colon + 1);
@@ -3810,7 +3990,7 @@ internal sealed class PwshForEachValueAnalyzer
 
             if (hasTarget)
             {
-                return new PwshFlowResult(null, input);
+                return FailedSetLocation(input);
             }
 
             target = value;
@@ -3820,7 +4000,17 @@ internal sealed class PwshForEachValueAnalyzer
 
         if (expectsPath)
         {
-            return new PwshFlowResult(null, input);
+            return FailedSetLocation(input);
+        }
+
+        if (usesStackName)
+        {
+            return hasTarget
+                ? FailedSetLocation(input)
+                : new PwshSetLocationAnalysis(
+                    new PwshFlowResult(input.Invalidate(unknownCwd: true), input),
+                    ShellWorkingDirectoryEffectFacts.ChangesOnSuccess(
+                        ShellValueDomainFacts.Unknown));
         }
 
         if (!hasTarget)
@@ -3828,12 +4018,16 @@ internal sealed class PwshForEachValueAnalyzer
             var home = string.IsNullOrEmpty(_options.HomeDirectory)
                 ? Environment.GetFolderPath(Environment.SpecialFolder.UserProfile)
                 : _options.HomeDirectory!;
-            return new PwshFlowResult(input.WithCwd(NormalizePath(home)), input);
+            var normalizedHome = NormalizePath(home);
+            return ExactSetLocation(input, normalizedHome);
         }
 
         if (target is "-" or "+")
         {
-            return new PwshFlowResult(input.Invalidate(unknownCwd: true), input);
+            return new PwshSetLocationAnalysis(
+                new PwshFlowResult(input.Invalidate(unknownCwd: true), input),
+                ShellWorkingDirectoryEffectFacts.ChangesOnSuccess(
+                    ShellValueDomainFacts.Unknown));
         }
 
         var resolverOptions = new PwshParserOptions
@@ -3852,17 +4046,89 @@ internal sealed class PwshForEachValueAnalyzer
                 ? ShellResolutionConsumer.PowerShellCmdletLiteralPath
                 : ShellResolutionConsumer.PowerShellCmdletPath);
         return resolved.IsPath && resolved.Resolved is not null
-            ? new PwshFlowResult(input.WithCwd(resolved.Resolved), input)
-            : new PwshFlowResult(input.Invalidate(unknownCwd: true), input);
+            ? ExactSetLocation(input, resolved.Resolved)
+            : new PwshSetLocationAnalysis(
+                new PwshFlowResult(input.Invalidate(unknownCwd: true), input),
+                ShellWorkingDirectoryEffectFacts.ChangesOnSuccess(
+                    ShellValueDomainFacts.Unknown));
     }
 
-    private static bool IsPathParameter(string parameter, out bool literalPath)
+    private static PwshSetLocationAnalysis ExactSetLocation(
+        AnalysisContext input,
+        string target) =>
+        new(
+            new PwshFlowResult(input.WithCwd(target), input),
+            ShellWorkingDirectoryEffectFacts.ChangesOnSuccess(
+                new ShellValueDomainFacts
+                {
+                    Kind = ShellValueDomainKind.Exact,
+                    Values = new[] { target },
+                }));
+
+    private static PwshSetLocationAnalysis FailedSetLocation(
+        AnalysisContext input) =>
+        new(
+            new PwshFlowResult(null, input),
+            ShellWorkingDirectoryEffectFacts.Unchanged);
+
+    private static bool IsValidSwitchValue(string value) =>
+        value.Equals("$true", StringComparison.OrdinalIgnoreCase) ||
+        value.Equals("$false", StringComparison.OrdinalIgnoreCase);
+
+    private bool TryAnalyzeSetLocationSwitch(
+        ClauseElement element,
+        out SetLocationSwitchStatus status)
     {
-        literalPath = parameter.Equals("-LiteralPath", StringComparison.OrdinalIgnoreCase) ||
-            parameter.Equals("-LP", StringComparison.OrdinalIgnoreCase);
-        return literalPath ||
-            parameter.Equals("-Path", StringComparison.OrdinalIgnoreCase) ||
-            parameter.Equals("-PSPath", StringComparison.OrdinalIgnoreCase);
+        status = SetLocationSwitchStatus.Invalid;
+        var authored = element.Value;
+        var colon = authored.IndexOf(':');
+        var parameter = colon < 0 ? authored : authored.Substring(0, colon);
+        if (PwshSetLocationParameterCatalog.Resolve(parameter, _options.Dialect) !=
+            PwshSetLocationParameterRole.Switch)
+        {
+            return false;
+        }
+
+        if (colon < 0 || IsValidSwitchValue(authored.Substring(colon + 1)))
+        {
+            status = SetLocationSwitchStatus.Valid;
+            return true;
+        }
+
+        var value = authored.Substring(colon + 1);
+        status = element.Kind is ArgKind.EnvVar or ArgKind.DynamicSkip ||
+                 value.Length > 0 && value[0] is >= '0' and <= '9' ||
+                 value.Length > 1 && value[0] == '.' &&
+                 value[1] is >= '0' and <= '9'
+            ? SetLocationSwitchStatus.MaySucceed
+            : SetLocationSwitchStatus.Invalid;
+        return true;
+    }
+
+    private static bool TrySkipParameterValue(
+        SimpleCommandSyntax simple,
+        ref int elementIndex)
+    {
+        for (var nextIndex = elementIndex + 1;
+             nextIndex < simple.Clause.Elements.Count;
+             nextIndex++)
+        {
+            var next = simple.Clause.Elements[nextIndex];
+            if (next.Role != ClauseElementRole.Argument)
+            {
+                continue;
+            }
+
+            if (next.IsFlag)
+            {
+                return false;
+            }
+
+            elementIndex = nextIndex;
+            return true;
+        }
+
+        return false;
     }
 
     private bool TryGetElementDomain(
@@ -4033,6 +4299,7 @@ internal sealed class PwshForEachValueAnalyzer
         {
             EffectiveArguments = source.EffectiveArguments,
             WorkingDirectory = source.WorkingDirectory,
+            WorkingDirectoryEffect = GetWorkingDirectoryEffect(simple.Clause),
             Redirects = redirects,
             RedirectTargetProvenance = source.RedirectTargetProvenance,
             CwdPathDependencies = source.CwdPathDependencies,
@@ -6107,6 +6374,17 @@ internal sealed class PwshForEachValueAnalyzer
         internal static PwshFlowResult Both(AnalysisContext state) => new(state, state);
 
         internal static PwshFlowResult Success(AnalysisContext state) => new(state, null);
+    }
+
+    private readonly record struct PwshSetLocationAnalysis(
+        PwshFlowResult Flow,
+        ShellWorkingDirectoryEffectFacts Effect);
+
+    private enum SetLocationSwitchStatus
+    {
+        Invalid,
+        Valid,
+        MaySucceed,
     }
 
     private sealed class ClauseReferenceComparer : IEqualityComparer<Clause>

--- a/src/ShellSyntaxTree/Internal/Pwsh/Verbs/PwshSetLocationParameterCatalog.cs
+++ b/src/ShellSyntaxTree/Internal/Pwsh/Verbs/PwshSetLocationParameterCatalog.cs
@@ -1,0 +1,135 @@
+// -----------------------------------------------------------------------
+// <copyright file="PwshSetLocationParameterCatalog.cs" company="Aaron Stannard">
+//      Copyright (C) 2026 - 2026 Aaron Stannard <https://github.com/Aaronontheweb>
+// </copyright>
+// -----------------------------------------------------------------------
+using System;
+using System.Collections.Generic;
+
+namespace ShellSyntaxTree.Internal.Pwsh.Verbs;
+
+internal enum PwshSetLocationParameterRole
+{
+    Invalid,
+    Switch,
+    NonPathValue,
+    PathValue,
+    LiteralPathValue,
+    StackNameValue,
+}
+
+/// <summary>
+/// Selected-dialect parameter metadata for the parser-owned Set-Location
+/// transfer. This keeps abbreviation and alias handling aligned with the
+/// cmdlet rather than the broader compatibility binding table.
+/// </summary>
+internal static class PwshSetLocationParameterCatalog
+{
+    private static readonly IReadOnlyDictionary<string, PwshSetLocationParameterRole>
+        Parameters = new Dictionary<string, PwshSetLocationParameterRole>(
+            StringComparer.OrdinalIgnoreCase)
+        {
+            ["Debug"] = PwshSetLocationParameterRole.Switch,
+            ["ErrorAction"] = PwshSetLocationParameterRole.NonPathValue,
+            ["ErrorVariable"] = PwshSetLocationParameterRole.NonPathValue,
+            ["InformationAction"] = PwshSetLocationParameterRole.NonPathValue,
+            ["InformationVariable"] = PwshSetLocationParameterRole.NonPathValue,
+            ["LiteralPath"] = PwshSetLocationParameterRole.LiteralPathValue,
+            ["OutBuffer"] = PwshSetLocationParameterRole.NonPathValue,
+            ["OutVariable"] = PwshSetLocationParameterRole.NonPathValue,
+            ["PassThru"] = PwshSetLocationParameterRole.Switch,
+            ["Path"] = PwshSetLocationParameterRole.PathValue,
+            ["PipelineVariable"] = PwshSetLocationParameterRole.NonPathValue,
+            ["ProgressAction"] = PwshSetLocationParameterRole.NonPathValue,
+            ["StackName"] = PwshSetLocationParameterRole.StackNameValue,
+            ["Verbose"] = PwshSetLocationParameterRole.Switch,
+            ["WarningAction"] = PwshSetLocationParameterRole.NonPathValue,
+            ["WarningVariable"] = PwshSetLocationParameterRole.NonPathValue,
+        };
+
+    private static readonly IReadOnlyDictionary<string, string> Aliases =
+        new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+        {
+            ["db"] = "Debug",
+            ["ea"] = "ErrorAction",
+            ["ev"] = "ErrorVariable",
+            ["infa"] = "InformationAction",
+            ["iv"] = "InformationVariable",
+            ["lp"] = "LiteralPath",
+            ["ob"] = "OutBuffer",
+            ["ov"] = "OutVariable",
+            ["proga"] = "ProgressAction",
+            ["pspath"] = "LiteralPath",
+            ["pv"] = "PipelineVariable",
+            ["vb"] = "Verbose",
+            ["wa"] = "WarningAction",
+            ["wv"] = "WarningVariable",
+        };
+
+    internal static PwshSetLocationParameterRole Resolve(
+        string parameter,
+        PwshDialect dialect)
+    {
+        if (parameter.Length < 2 || parameter[0] != '-')
+        {
+            return PwshSetLocationParameterRole.Invalid;
+        }
+
+        var name = parameter.Substring(1);
+        if (Aliases.TryGetValue(name, out var canonicalAlias))
+        {
+            return IsAvailable(canonicalAlias, dialect)
+                ? Parameters[canonicalAlias]
+                : PwshSetLocationParameterRole.Invalid;
+        }
+
+        if (Parameters.TryGetValue(name, out var exact))
+        {
+            return IsAvailable(name, dialect)
+                ? exact
+                : PwshSetLocationParameterRole.Invalid;
+        }
+
+        string? canonical = null;
+        foreach (var candidate in Parameters.Keys)
+        {
+            if (!IsAvailable(candidate, dialect) ||
+                !candidate.StartsWith(name, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (canonical is not null)
+            {
+                return PwshSetLocationParameterRole.Invalid;
+            }
+
+            canonical = candidate;
+        }
+
+        foreach (var alias in Aliases)
+        {
+            if (!IsAvailable(alias.Value, dialect) ||
+                !alias.Key.StartsWith(name, StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            if (canonical is not null &&
+                !canonical.Equals(alias.Value, StringComparison.OrdinalIgnoreCase))
+            {
+                return PwshSetLocationParameterRole.Invalid;
+            }
+
+            canonical = alias.Value;
+        }
+
+        return canonical is null
+            ? PwshSetLocationParameterRole.Invalid
+            : Parameters[canonical];
+    }
+
+    private static bool IsAvailable(string parameter, PwshDialect dialect) =>
+        !parameter.Equals("ProgressAction", StringComparison.OrdinalIgnoreCase) ||
+        dialect == PwshDialect.PowerShell7;
+}

--- a/src/ShellSyntaxTree/ShellSyntaxProjection.cs
+++ b/src/ShellSyntaxTree/ShellSyntaxProjection.cs
@@ -26,6 +26,9 @@ internal sealed class CommandOccurrenceFacts
 
     internal ShellValueDomainFacts WorkingDirectory { get; init; } = ShellValueDomainFacts.Unknown;
 
+    internal ShellWorkingDirectoryEffectFacts WorkingDirectoryEffect { get; init; } =
+        ShellWorkingDirectoryEffectFacts.Unknown;
+
     internal IReadOnlyList<RedirectAnalysisFacts> Redirects { get; init; } =
         Array.Empty<RedirectAnalysisFacts>();
 
@@ -41,6 +44,110 @@ internal sealed class CommandOccurrenceFacts
     internal bool HasCompleteValueProvenance { get; init; }
 
     internal bool IsComplete { get; init; }
+}
+
+internal enum ShellWorkingDirectoryEffectKind
+{
+    Unknown,
+    Unchanged,
+    ChangesOnSuccess,
+}
+
+internal sealed record ShellWorkingDirectoryEffectFacts
+{
+    internal static ShellWorkingDirectoryEffectFacts Unknown { get; } = new();
+
+    internal static ShellWorkingDirectoryEffectFacts Unchanged { get; } = new()
+    {
+        Kind = ShellWorkingDirectoryEffectKind.Unchanged,
+    };
+
+    internal ShellWorkingDirectoryEffectKind Kind { get; init; }
+
+    internal ShellValueDomainFacts Target { get; init; } = ShellValueDomainFacts.Unknown;
+
+    internal static ShellWorkingDirectoryEffectFacts ChangesOnSuccess(
+        ShellValueDomainFacts target) => IsSupportedTarget(target)
+        ? new ShellWorkingDirectoryEffectFacts
+        {
+            Kind = ShellWorkingDirectoryEffectKind.ChangesOnSuccess,
+            Target = target,
+        }
+        : Unknown;
+
+    internal static ShellWorkingDirectoryEffectFacts Join(
+        ShellWorkingDirectoryEffectFacts left,
+        ShellWorkingDirectoryEffectFacts right)
+    {
+        if (left.Kind == ShellWorkingDirectoryEffectKind.Unknown ||
+            right.Kind == ShellWorkingDirectoryEffectKind.Unknown ||
+            left.Kind != right.Kind)
+        {
+            return Unknown;
+        }
+
+        if (left.Kind == ShellWorkingDirectoryEffectKind.Unchanged)
+        {
+            return Unchanged;
+        }
+
+        return ChangesOnSuccess(JoinTargets(left.Target, right.Target));
+    }
+
+    private static ShellValueDomainFacts JoinTargets(
+        ShellValueDomainFacts left,
+        ShellValueDomainFacts right)
+    {
+        if (!IsSupportedTarget(left) || !IsSupportedTarget(right) ||
+            left.Kind == ShellValueDomainKind.Unknown ||
+            right.Kind == ShellValueDomainKind.Unknown)
+        {
+            return ShellValueDomainFacts.Unknown;
+        }
+
+        if (ShellValueDomainFacts.AreEqual(left, right))
+        {
+            return left;
+        }
+
+        var distinct = new HashSet<string>(StringComparer.Ordinal);
+        AddValues(left, distinct);
+        AddValues(right, distinct);
+        if (distinct.Count > ShellAnalysisLimits.MaxValueCandidates)
+        {
+            return ShellValueDomainFacts.Unknown;
+        }
+
+        var values = new List<string>(distinct);
+        values.Sort(StringComparer.Ordinal);
+        return values.Count == 1
+            ? new ShellValueDomainFacts
+            {
+                Kind = ShellValueDomainKind.Exact,
+                Values = values.ToArray(),
+            }
+            : new ShellValueDomainFacts
+            {
+                Kind = ShellValueDomainKind.FiniteSet,
+                Values = values.ToArray(),
+            };
+    }
+
+    private static void AddValues(
+        ShellValueDomainFacts domain,
+        ISet<string> destination)
+    {
+        for (var index = 0; index < domain.Values.Count; index++)
+        {
+            destination.Add(domain.Values[index]);
+        }
+    }
+
+    private static bool IsSupportedTarget(ShellValueDomainFacts target) =>
+        target is not null &&
+        target.Kind is ShellValueDomainKind.Unknown or
+            ShellValueDomainKind.Exact or
+            ShellValueDomainKind.FiniteSet;
 }
 
 internal static class ShellPathShapeClassifier
@@ -637,6 +744,7 @@ internal static class ShellSyntaxProjection
                     _language,
                     out var arguments,
                     out var workingDirectory,
+                    out var workingDirectoryEffect,
                     out var redirects))
             {
                 return false;
@@ -649,6 +757,7 @@ internal static class ShellSyntaxProjection
                 Ancestry = _ancestry.ToArray(),
                 Arguments = arguments,
                 WorkingDirectory = workingDirectory,
+                WorkingDirectoryEffect = workingDirectoryEffect,
                 Redirects = redirects,
                 IsComplete = facts.IsComplete && _structuralContextIsComplete &&
                     AreExecutionRegionFactsComplete(simple.ExecutionRegions),
@@ -907,10 +1016,12 @@ internal static class ShellSyntaxProjection
             ShellProjectionLanguage language,
             out IReadOnlyList<AnalyzedArgument> arguments,
             out ShellValueDomain workingDirectory,
+            out ShellWorkingDirectoryEffect workingDirectoryEffect,
             out IReadOnlyList<RedirectAnalysis> redirects)
         {
             arguments = Array.Empty<AnalyzedArgument>();
             workingDirectory = new ShellValueDomain.Unknown();
+            workingDirectoryEffect = new ShellWorkingDirectoryEffect.Unknown();
             redirects = Array.Empty<RedirectAnalysis>();
             if (facts is null ||
                 facts.EffectiveArguments is null ||
@@ -934,6 +1045,9 @@ internal static class ShellSyntaxProjection
             }
 
             workingDirectory = ToPublicDomain(facts.WorkingDirectory);
+            workingDirectoryEffect = ToPublicEffect(
+                facts.WorkingDirectoryEffect,
+                language);
             return TryCreateAnalyzedArguments(
                     clause,
                     facts.EffectiveArguments,
@@ -1141,48 +1255,48 @@ internal static class ShellSyntaxProjection
             analysis = source is RedirectSource.Unknown
                 ? new UnresolvedRedirectAnalysis()
                 : fact.Operation switch
-            {
-                RedirectOperation.FileInput => new FileRedirectAnalysis(FileRedirectMode.Input)
                 {
-                    Target = ToPublicDomain(fact.Target),
-                },
-                RedirectOperation.FileOutput => new FileRedirectAnalysis(FileRedirectMode.Output)
-                {
-                    Target = ToPublicDomain(fact.Target),
-                },
-                RedirectOperation.FileAppend => new FileRedirectAnalysis(FileRedirectMode.Append)
-                {
-                    Target = ToPublicDomain(fact.Target),
-                },
-                RedirectOperation.CombinedOutput =>
-                    new FileRedirectAnalysis(FileRedirectMode.CombinedOutput)
+                    RedirectOperation.FileInput => new FileRedirectAnalysis(FileRedirectMode.Input)
                     {
                         Target = ToPublicDomain(fact.Target),
                     },
-                RedirectOperation.CombinedOutputAppend =>
-                    new FileRedirectAnalysis(FileRedirectMode.CombinedOutputAppend)
+                    RedirectOperation.FileOutput => new FileRedirectAnalysis(FileRedirectMode.Output)
                     {
                         Target = ToPublicDomain(fact.Target),
                     },
-                RedirectOperation.DescriptorDuplicate when fact.TargetDescriptor.HasValue =>
-                    new DescriptorDuplicateRedirectAnalysis
+                    RedirectOperation.FileAppend => new FileRedirectAnalysis(FileRedirectMode.Append)
                     {
-                        TargetDescriptor = fact.TargetDescriptor.Value,
+                        Target = ToPublicDomain(fact.Target),
                     },
-                RedirectOperation.DescriptorMove when fact.TargetDescriptor.HasValue =>
-                    new DescriptorMoveRedirectAnalysis
+                    RedirectOperation.CombinedOutput =>
+                        new FileRedirectAnalysis(FileRedirectMode.CombinedOutput)
+                        {
+                            Target = ToPublicDomain(fact.Target),
+                        },
+                    RedirectOperation.CombinedOutputAppend =>
+                        new FileRedirectAnalysis(FileRedirectMode.CombinedOutputAppend)
+                        {
+                            Target = ToPublicDomain(fact.Target),
+                        },
+                    RedirectOperation.DescriptorDuplicate when fact.TargetDescriptor.HasValue =>
+                        new DescriptorDuplicateRedirectAnalysis
+                        {
+                            TargetDescriptor = fact.TargetDescriptor.Value,
+                        },
+                    RedirectOperation.DescriptorMove when fact.TargetDescriptor.HasValue =>
+                        new DescriptorMoveRedirectAnalysis
+                        {
+                            TargetDescriptor = fact.TargetDescriptor.Value,
+                        },
+                    RedirectOperation.DescriptorClose => new DescriptorCloseRedirectAnalysis(),
+                    RedirectOperation.HereDocument when fact.HereDocument is not null =>
+                        new HereDocumentRedirectAnalysis { Document = fact.HereDocument },
+                    RedirectOperation.HereString => new HereStringRedirectAnalysis
                     {
-                        TargetDescriptor = fact.TargetDescriptor.Value,
+                        Data = ToPublicDomain(fact.Target),
                     },
-                RedirectOperation.DescriptorClose => new DescriptorCloseRedirectAnalysis(),
-                RedirectOperation.HereDocument when fact.HereDocument is not null =>
-                    new HereDocumentRedirectAnalysis { Document = fact.HereDocument },
-                RedirectOperation.HereString => new HereStringRedirectAnalysis
-                {
-                    Data = ToPublicDomain(fact.Target),
-                },
-                _ => new UnresolvedRedirectAnalysis(),
-            };
+                    _ => new UnresolvedRedirectAnalysis(),
+                };
             analysis = analysis with
             {
                 RedirectIndex = fact.RedirectIndex,
@@ -1216,9 +1330,11 @@ internal static class ShellSyntaxProjection
                 (RedirectSource.Default, HereDocumentRedirectAnalysis) => true,
                 (RedirectSource.Default, HereStringRedirectAnalysis) => true,
                 (RedirectSource.Descriptor, FileRedirectAnalysis
-                    { Mode: FileRedirectMode.Input or
+                {
+                    Mode: FileRedirectMode.Input or
                             FileRedirectMode.Output or
-                            FileRedirectMode.Append }) => true,
+                            FileRedirectMode.Append
+                }) => true,
                 (RedirectSource.Descriptor, DescriptorDuplicateRedirectAnalysis) => true,
                 (RedirectSource.Descriptor, DescriptorMoveRedirectAnalysis) => true,
                 (RedirectSource.Descriptor, DescriptorCloseRedirectAnalysis) => true,
@@ -1248,6 +1364,26 @@ internal static class ShellSyntaxProjection
                     ToPublicDomains(domain.Parts)),
                 _ => new ShellValueDomain.Unknown(),
             };
+
+        private static ShellWorkingDirectoryEffect ToPublicEffect(
+            ShellWorkingDirectoryEffectFacts? effect,
+            ShellProjectionLanguage language)
+        {
+            if (effect is null || !IsValidWorkingDirectoryEffect(effect, language))
+            {
+                return new ShellWorkingDirectoryEffect.Unknown();
+            }
+
+            return effect.Kind switch
+            {
+                ShellWorkingDirectoryEffectKind.Unchanged =>
+                    new ShellWorkingDirectoryEffect.Unchanged(),
+                ShellWorkingDirectoryEffectKind.ChangesOnSuccess =>
+                    new ShellWorkingDirectoryEffect.ChangesOnSuccess(
+                        ToPublicDomain(effect.Target)),
+                _ => new ShellWorkingDirectoryEffect.Unknown(),
+            };
+        }
 
         private static IReadOnlyList<ShellValueDomain> ToPublicDomains(
             IReadOnlyList<ShellValueDomainFacts> domains)
@@ -1458,6 +1594,132 @@ internal static class ShellSyntaxProjection
                     AreValidConcatenationParts(domain.Parts),
                 _ => false,
             };
+        }
+
+        private static bool IsValidWorkingDirectoryEffect(
+            ShellWorkingDirectoryEffectFacts? effect,
+            ShellProjectionLanguage language)
+        {
+            if (effect is null ||
+                effect.Target is null ||
+                !IsValidValueDomain(effect.Target))
+            {
+                return false;
+            }
+
+            return effect.Kind switch
+            {
+                ShellWorkingDirectoryEffectKind.Unknown =>
+                    effect.Target.Kind == ShellValueDomainKind.Unknown,
+                ShellWorkingDirectoryEffectKind.Unchanged =>
+                    effect.Target.Kind == ShellValueDomainKind.Unknown,
+                ShellWorkingDirectoryEffectKind.ChangesOnSuccess =>
+                    effect.Target.Kind == ShellValueDomainKind.Unknown ||
+                    (effect.Target.Kind is ShellValueDomainKind.Exact or
+                        ShellValueDomainKind.FiniteSet &&
+                     HasValidWorkingDirectoryTargets(effect.Target, language)),
+                _ => false,
+            };
+        }
+
+        private static bool HasValidWorkingDirectoryTargets(
+            ShellValueDomainFacts target,
+            ShellProjectionLanguage language)
+        {
+            if (language == ShellProjectionLanguage.Unknown)
+            {
+                return false;
+            }
+
+            WorkingDirectoryPathStyle? expectedStyle = null;
+            foreach (var value in target.Values)
+            {
+                if (!TryGetNormalizedAbsolutePathStyle(value, out var style) ||
+                    language == ShellProjectionLanguage.Bash &&
+                    style != WorkingDirectoryPathStyle.Posix ||
+                    expectedStyle.HasValue && expectedStyle.Value != style)
+                {
+                    return false;
+                }
+
+                expectedStyle = style;
+            }
+
+            return expectedStyle.HasValue;
+        }
+
+        private static bool TryGetNormalizedAbsolutePathStyle(
+            string value,
+            out WorkingDirectoryPathStyle style)
+        {
+            style = default;
+            if (string.IsNullOrEmpty(value) ||
+                value.IndexOf('\\') >= 0 ||
+                value.IndexOf('\0') >= 0)
+            {
+                return false;
+            }
+
+            var segmentStart = 0;
+            if (value.StartsWith("//", StringComparison.Ordinal))
+            {
+                style = WorkingDirectoryPathStyle.Windows;
+                segmentStart = 2;
+            }
+            else if (value[0] == '/')
+            {
+                style = WorkingDirectoryPathStyle.Posix;
+                segmentStart = 1;
+            }
+            else if (value.Length >= 3 &&
+                     value[0] is >= 'A' and <= 'Z' &&
+                     value[1] == ':' &&
+                     value[2] == '/')
+            {
+                style = WorkingDirectoryPathStyle.Windows;
+                segmentStart = 3;
+            }
+            else
+            {
+                return false;
+            }
+
+            for (var index = segmentStart; index < value.Length; index++)
+            {
+                if (char.IsControl(value[index]))
+                {
+                    return false;
+                }
+
+                if (value[index] != '/')
+                {
+                    continue;
+                }
+
+                if (index == segmentStart ||
+                    index + 1 == value.Length ||
+                    value[index + 1] == '/')
+                {
+                    return false;
+                }
+            }
+
+            var segments = value.Substring(segmentStart).Split('/');
+            foreach (var segment in segments)
+            {
+                if (segment is "." or "..")
+                {
+                    return false;
+                }
+            }
+
+            return segmentStart == value.Length || segments.Length > 0;
+        }
+
+        private enum WorkingDirectoryPathStyle
+        {
+            Posix,
+            Windows,
         }
 
         private static bool AreValidConcatenationParts(

--- a/tests/ShellSyntaxTree.Tests/Corpus/AstAssert.cs
+++ b/tests/ShellSyntaxTree.Tests/Corpus/AstAssert.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using Xunit;
 using Xunit.Sdk;
 
 namespace ShellSyntaxTree.Tests.Corpus;
@@ -480,6 +481,14 @@ internal static class AstAssert
                     prefix + $"commands[{index}].workingDirectory");
             }
 
+            if (wanted.WorkingDirectoryEffect is not null)
+            {
+                AssertWorkingDirectoryEffectEqual(
+                    wanted.WorkingDirectoryEffect,
+                    observed.WorkingDirectoryEffect,
+                    prefix + $"commands[{index}].workingDirectoryEffect");
+            }
+
             if (wanted.Redirects is not null)
             {
                 AssertRedirectAnalysesEqual(
@@ -487,6 +496,32 @@ internal static class AstAssert
                     observed.Redirects,
                     prefix + $"commands[{index}].redirects");
             }
+        }
+    }
+
+    private static void AssertWorkingDirectoryEffectEqual(
+        ExpectedWorkingDirectoryEffect expected,
+        ShellWorkingDirectoryEffect actual,
+        string path)
+    {
+        switch (expected.Kind)
+        {
+            case ExpectedWorkingDirectoryEffectKind.Unknown:
+                Assert.IsType<ShellWorkingDirectoryEffect.Unknown>(actual);
+                Assert.Null(expected.Target);
+                break;
+            case ExpectedWorkingDirectoryEffectKind.Unchanged:
+                Assert.IsType<ShellWorkingDirectoryEffect.Unchanged>(actual);
+                Assert.Null(expected.Target);
+                break;
+            case ExpectedWorkingDirectoryEffectKind.ChangesOnSuccess:
+                var changed = Assert.IsType<
+                    ShellWorkingDirectoryEffect.ChangesOnSuccess>(actual);
+                Assert.NotNull(expected.Target);
+                AssertValueDomainEqual(expected.Target!, changed.Target, path + ".target");
+                break;
+            default:
+                throw new XunitException($"{path}.kind is unsupported: {expected.Kind}");
         }
     }
 

--- a/tests/ShellSyntaxTree.Tests/Corpus/CorpusRunnerTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Corpus/CorpusRunnerTests.cs
@@ -1063,7 +1063,23 @@ public sealed record ExpectedCommandOccurrence
 
     public ExpectedValueDomain? WorkingDirectory { get; init; }
 
+    public ExpectedWorkingDirectoryEffect? WorkingDirectoryEffect { get; init; }
+
     public List<ExpectedRedirectAnalysis>? Redirects { get; init; }
+}
+
+public enum ExpectedWorkingDirectoryEffectKind
+{
+    Unknown,
+    Unchanged,
+    ChangesOnSuccess,
+}
+
+public sealed record ExpectedWorkingDirectoryEffect
+{
+    public ExpectedWorkingDirectoryEffectKind Kind { get; init; }
+
+    public ExpectedValueDomain? Target { get; init; }
 }
 
 public sealed record ExpectedRedirectAnalysis

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/315_v03_working_directory_effect_causal_chain.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/315_v03_working_directory_effect_causal_chain.json
@@ -1,0 +1,128 @@
+{
+  "name": "v0.3 working-directory effect causal chain",
+  "input": "cd /tmp && inspect; head result.log",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["cd"],
+        "args": [
+          { "raw": "/tmp", "kind": "Literal", "isPath": true }
+        ],
+        "redirects": []
+      },
+      {
+        "operator": "AndIf",
+        "verb": ["inspect"],
+        "args": [
+          {
+            "raw": "/tmp",
+            "kind": "Literal",
+            "isPath": true,
+            "isCwdAttribution": true
+          }
+        ],
+        "redirects": []
+      },
+      {
+        "operator": "Sequence",
+        "verb": ["head"],
+        "args": [
+          { "raw": "result.log", "kind": "Literal", "isPath": true },
+          {
+            "raw": "<dynamic-cwd>",
+            "kind": "DynamicSkip",
+            "isPath": false,
+            "isCwdAttribution": true
+          }
+        ],
+        "redirects": []
+      }
+    ],
+    "commands": [
+      {
+        "clauseIndex": 0,
+        "immediateRole": "Ordinary",
+        "isComplete": true,
+        "ancestry": [
+          {
+            "ancestorKind": "Block",
+            "region": "Root",
+            "childIndex": 0,
+            "sourceStart": 0,
+            "sourceLength": 35
+          },
+          {
+            "ancestorKind": "CommandList",
+            "region": "Statement",
+            "childIndex": 0,
+            "sourceStart": 0,
+            "sourceLength": 35
+          }
+        ],
+        "workingDirectory": {
+          "kind": "Exact",
+          "values": ["/work"]
+        },
+        "workingDirectoryEffect": {
+          "kind": "ChangesOnSuccess",
+          "target": {
+            "kind": "Exact",
+            "values": ["/tmp"]
+          }
+        }
+      },
+      {
+        "clauseIndex": 1,
+        "immediateRole": "Ordinary",
+        "isComplete": true,
+        "ancestry": [
+          {
+            "ancestorKind": "Block",
+            "region": "Root",
+            "childIndex": 0,
+            "sourceStart": 0,
+            "sourceLength": 35
+          },
+          {
+            "ancestorKind": "CommandList",
+            "region": "Statement",
+            "childIndex": 1,
+            "sourceStart": 0,
+            "sourceLength": 35
+          }
+        ],
+        "workingDirectory": {
+          "kind": "Exact",
+          "values": ["/tmp"]
+        },
+        "workingDirectoryEffect": { "kind": "Unchanged" }
+      },
+      {
+        "clauseIndex": 2,
+        "immediateRole": "Ordinary",
+        "isComplete": true,
+        "ancestry": [
+          {
+            "ancestorKind": "Block",
+            "region": "Root",
+            "childIndex": 0,
+            "sourceStart": 0,
+            "sourceLength": 35
+          },
+          {
+            "ancestorKind": "CommandList",
+            "region": "Statement",
+            "childIndex": 2,
+            "sourceStart": 0,
+            "sourceLength": 35
+          }
+        ],
+        "workingDirectory": { "kind": "Unknown" },
+        "workingDirectoryEffect": { "kind": "Unchanged" }
+      }
+    ]
+  },
+  "notes": "Sanitized causal example. Effects describe each authored command; they do not resolve the later failure-path cwd."
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/316_v03_working_directory_effect_pushd_boundary.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/316_v03_working_directory_effect_pushd_boundary.json
@@ -1,0 +1,118 @@
+{
+  "name": "v0.3 working-directory effect stack boundary",
+  "input": "cd /tmp && pushd /other; head file",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["cd"],
+        "args": [
+          { "raw": "/tmp", "kind": "Literal", "isPath": true }
+        ],
+        "redirects": []
+      },
+      {
+        "operator": "AndIf",
+        "verb": ["pushd"],
+        "args": [
+          { "raw": "/other", "kind": "Literal", "isPath": true },
+          {
+            "raw": "/tmp",
+            "kind": "Literal",
+            "isPath": true,
+            "isCwdAttribution": true
+          }
+        ],
+        "redirects": []
+      },
+      {
+        "operator": "Sequence",
+        "verb": ["head"],
+        "args": [
+          { "raw": "file", "kind": "Literal", "isPath": true },
+          {
+            "raw": "<dynamic-cwd>",
+            "kind": "DynamicSkip",
+            "isPath": false,
+            "isCwdAttribution": true
+          }
+        ],
+        "redirects": []
+      }
+    ],
+    "commands": [
+      {
+        "clauseIndex": 0,
+        "immediateRole": "Ordinary",
+        "isComplete": true,
+        "ancestry": [
+          {
+            "ancestorKind": "Block",
+            "region": "Root",
+            "childIndex": 0,
+            "sourceStart": 0,
+            "sourceLength": 34
+          },
+          {
+            "ancestorKind": "CommandList",
+            "region": "Statement",
+            "childIndex": 0,
+            "sourceStart": 0,
+            "sourceLength": 34
+          }
+        ],
+        "workingDirectoryEffect": {
+          "kind": "ChangesOnSuccess",
+          "target": { "kind": "Exact", "values": ["/tmp"] }
+        }
+      },
+      {
+        "clauseIndex": 1,
+        "immediateRole": "Ordinary",
+        "isComplete": true,
+        "ancestry": [
+          {
+            "ancestorKind": "Block",
+            "region": "Root",
+            "childIndex": 0,
+            "sourceStart": 0,
+            "sourceLength": 34
+          },
+          {
+            "ancestorKind": "CommandList",
+            "region": "Statement",
+            "childIndex": 1,
+            "sourceStart": 0,
+            "sourceLength": 34
+          }
+        ],
+        "workingDirectoryEffect": { "kind": "Unknown" }
+      },
+      {
+        "clauseIndex": 2,
+        "immediateRole": "Ordinary",
+        "isComplete": true,
+        "ancestry": [
+          {
+            "ancestorKind": "Block",
+            "region": "Root",
+            "childIndex": 0,
+            "sourceStart": 0,
+            "sourceLength": 34
+          },
+          {
+            "ancestorKind": "CommandList",
+            "region": "Statement",
+            "childIndex": 2,
+            "sourceStart": 0,
+            "sourceLength": 34
+          }
+        ],
+        "workingDirectory": { "kind": "Unknown" },
+        "workingDirectoryEffect": { "kind": "Unchanged" }
+      }
+    ]
+  },
+  "notes": "Sanitized counterexample. The directory-stack mutation prevents a consumer from carrying the earlier cd target to head."
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/317_v03_working_directory_effect_finite_loop.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/317_v03_working_directory_effect_finite_loop.json
@@ -1,0 +1,62 @@
+{
+  "name": "v0.3 finite working-directory effect",
+  "input": "for d in /work/a /work/b; do cd \"$d\"; done",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": ["cd"],
+        "args": [
+          { "raw": "\"$d\"", "kind": "DynamicSkip", "isPath": false },
+          {
+            "raw": "<dynamic-cwd>",
+            "kind": "DynamicSkip",
+            "isPath": false,
+            "isCwdAttribution": true
+          }
+        ],
+        "redirects": []
+      }
+    ],
+    "commands": [
+      {
+        "clauseIndex": 0,
+        "immediateRole": "LoopBody",
+        "isComplete": true,
+        "ancestry": [
+          {
+            "ancestorKind": "Block",
+            "region": "Root",
+            "childIndex": 0,
+            "sourceStart": 0,
+            "sourceLength": 42
+          },
+          {
+            "ancestorKind": "ForEach",
+            "region": "LoopBody",
+            "childIndex": null,
+            "sourceStart": 0,
+            "sourceLength": 42
+          },
+          {
+            "ancestorKind": "Block",
+            "region": "Statement",
+            "childIndex": 0,
+            "sourceStart": 28,
+            "sourceLength": 10
+          }
+        ],
+        "workingDirectory": { "kind": "Unknown" },
+        "workingDirectoryEffect": {
+          "kind": "ChangesOnSuccess",
+          "target": {
+            "kind": "FiniteSet",
+            "values": ["/work/a", "/work/b"]
+          }
+        }
+      }
+    ]
+  },
+  "notes": "Sanitized isolated-state loop. The effect joins repeated exact targets without claiming one final cwd."
+}

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/79_chdir_propagates_like_cd.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/79_chdir_propagates_like_cd.json
@@ -1,5 +1,5 @@
 {
-  "name": "cd-attribution: chdir /target && cmd (chdir also propagates)",
+  "name": "language boundary: Bash chdir does not propagate cwd",
   "input": "chdir /target && cmd",
   "expected": {
     "isUnparseable": false,
@@ -17,14 +17,12 @@
       {
         "operator": "AndIf",
         "verb": ["cmd"],
-        "args": [
-          { "raw": "/target", "kind": "Literal", "isPath": true, "resolved": "/target", "isCwdAttribution": true }
-        ],
+        "args": [],
         "redirects": [],
         "isSubshell": false,
         "isCommandStringWrapped": false
       }
     ]
   },
-  "notes": "Locked interpretation #5: chdir is the other propagating CwdVerb (forward-compat with PowerShell-style invocation)."
+  "notes": "Bash chdir is an ordinary external command. Native PowerShell may canonicalize chdir to Set-Location, but Bash does not inherit that alias."
 }

--- a/tests/ShellSyntaxTree.Tests/Parsing/PwshForEachStructuralTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Parsing/PwshForEachStructuralTests.cs
@@ -672,7 +672,10 @@ public class PwshForEachStructuralTests
         Assert.False(result.IsUnparseable, result.UnparseableReason);
         var command = result.Commands.Last();
         Assert.False(command.IsComplete);
-        Assert.Equal(ShellValueDomainKind.Unknown, command.WorkingDirectory.Kind);
+        AssertDomain(
+            command.WorkingDirectory,
+            ShellValueDomainKind.Exact,
+            "C:/target");
         Assert.Equal(
             ShellValueDomainKind.Unknown,
             Assert.Single(command.EffectiveArguments).Value.Kind);

--- a/tests/ShellSyntaxTree.Tests/Parsing/WorkingDirectoryEffectTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Parsing/WorkingDirectoryEffectTests.cs
@@ -1,0 +1,585 @@
+// -----------------------------------------------------------------------
+// <copyright file="WorkingDirectoryEffectTests.cs" company="Aaron Stannard">
+//      Copyright (C) 2026 - 2026 Aaron Stannard <https://github.com/Aaronontheweb>
+// </copyright>
+// -----------------------------------------------------------------------
+using System.Linq;
+using Xunit;
+
+namespace ShellSyntaxTree.Tests.Parsing;
+
+public class WorkingDirectoryEffectTests
+{
+    [Fact]
+    public void Bash_ordinary_command_preserves_working_directory()
+    {
+        var command = Assert.Single(ParseBash("inspect artifact").Commands);
+
+        Assert.IsType<ShellWorkingDirectoryEffect.Unchanged>(
+            command.WorkingDirectoryEffect);
+    }
+
+    [Theory]
+    [InlineData("cd /tmp")]
+    [InlineData("command cd /tmp")]
+    [InlineData("builtin cd /tmp")]
+    public void Bash_static_cd_changes_exactly_on_success(string source)
+    {
+        var command = Assert.Single(ParseBash(source).Commands);
+
+        AssertExactChange(command, "/tmp");
+    }
+
+    [Theory]
+    [InlineData("cd /tmp extra")]
+    [InlineData("cd -z /tmp")]
+    public void Bash_failure_only_cd_shape_is_unchanged(string source)
+    {
+        var command = Assert.Single(ParseBash(source).Commands);
+
+        Assert.IsType<ShellWorkingDirectoryEffect.Unchanged>(
+            command.WorkingDirectoryEffect);
+    }
+
+    [Theory]
+    [InlineData("pushd /tmp")]
+    [InlineData("popd")]
+    public void Bash_directory_stack_effect_is_unknown(string source)
+    {
+        var command = Assert.Single(ParseBash(source).Commands);
+
+        Assert.IsType<ShellWorkingDirectoryEffect.Unknown>(
+            command.WorkingDirectoryEffect);
+    }
+
+    [Fact]
+    public void Bash_directory_stack_counterexample_keeps_later_scope_unknown()
+    {
+        var result = ParseBash("cd /tmp && pushd /other; head file");
+
+        AssertExactChange(result.Commands[0], "/tmp");
+        Assert.IsType<ShellWorkingDirectoryEffect.Unknown>(
+            result.Commands[1].WorkingDirectoryEffect);
+        Assert.IsType<ShellValueDomain.Unknown>(result.Commands[2].WorkingDirectory);
+        Assert.IsType<ShellWorkingDirectoryEffect.Unchanged>(
+            result.Commands[2].WorkingDirectoryEffect);
+    }
+
+    [Theory]
+    [InlineData("source setup.sh")]
+    [InlineData(". setup.sh")]
+    [InlineData("eval 'cd /tmp'")]
+    public void Bash_hidden_current_scope_execution_stays_atomic(string source)
+    {
+        var result = ParseBash(source);
+
+        Assert.True(result.IsUnparseable);
+        Assert.Empty(result.Commands);
+    }
+
+    [Fact]
+    public void Bash_chdir_is_not_a_parent_shell_transfer()
+    {
+        var result = ParseBash("chdir /tmp; head file");
+
+        Assert.Equal(2, result.Commands.Count);
+        Assert.IsType<ShellWorkingDirectoryEffect.Unchanged>(
+            result.Commands[0].WorkingDirectoryEffect);
+        Assert.Equal(
+            "/work",
+            Assert.IsType<ShellValueDomain.Exact>(
+                result.Commands[1].WorkingDirectory).Value);
+    }
+
+    [Fact]
+    public void Bash_finite_loop_cd_target_joins_under_isolated_state()
+    {
+        var result = ParseBash(
+            "for d in /work/a /work/b; do cd \"$d\"; done");
+        var command = Assert.Single(result.Commands);
+        var effect = Assert.IsType<ShellWorkingDirectoryEffect.ChangesOnSuccess>(
+            command.WorkingDirectoryEffect);
+        var target = Assert.IsType<ShellValueDomain.FiniteSet>(effect.Target);
+
+        Assert.Equal(new[] { "/work/a", "/work/b" }, target.Values);
+    }
+
+    [Fact]
+    public void Bash_mixed_finite_cd_targets_join_to_unknown_target()
+    {
+        var result = ParseBash(
+            "for d in /tmp -; do cd \"$d\"; done");
+        var effect = Assert.IsType<ShellWorkingDirectoryEffect.ChangesOnSuccess>(
+            Assert.Single(result.Commands).WorkingDirectoryEffect);
+
+        Assert.IsType<ShellValueDomain.Unknown>(effect.Target);
+    }
+
+    [Fact]
+    public void Bash_dynamic_cd_target_keeps_success_target_unknown()
+    {
+        var command = Assert.Single(ParseBash("cd \"$1\"").Commands);
+        var effect = Assert.IsType<ShellWorkingDirectoryEffect.ChangesOnSuccess>(
+            command.WorkingDirectoryEffect);
+
+        Assert.IsType<ShellValueDomain.Unknown>(effect.Target);
+    }
+
+    [Fact]
+    public void Bash_pipeline_stage_effect_does_not_claim_parent_transfer()
+    {
+        var result = ParseBash("printf x | cd /tmp; pwd");
+
+        AssertExactChange(result.Commands[1], "/tmp");
+        Assert.IsType<ShellValueDomain.Unknown>(result.Commands[2].WorkingDirectory);
+    }
+
+    [Fact]
+    public void Bash_first_pipeline_stage_effect_does_not_reach_parent()
+    {
+        var result = ParseBash("cd /tmp | cat; pwd");
+
+        AssertExactChange(result.Commands[0], "/tmp");
+        Assert.Equal(
+            "/work",
+            Assert.IsType<ShellValueDomain.Exact>(
+                result.Commands.Last().WorkingDirectory).Value);
+    }
+
+    [Fact]
+    public void Bash_decoded_child_shell_keeps_nested_effect_in_child_ancestry()
+    {
+        var result = ParseBash("bash -c 'cd /tmp; pwd'; pwd");
+        var nested = result.Commands.Single(command =>
+            command.Clause.Verb.Joined == "cd");
+
+        AssertExactChange(nested, "/tmp");
+        Assert.Contains(nested.Ancestry, frame =>
+            frame.Region == CommandAncestryRegion.GroupBody &&
+            frame.Ancestor is GroupSyntax
+            {
+                GroupKind: ShellGroupKind.IsolatedScope,
+            });
+        Assert.Equal(
+            "/work",
+            Assert.IsType<ShellValueDomain.Exact>(
+                result.Commands.Last().WorkingDirectory).Value);
+    }
+
+    [Fact]
+    public void Bash_proved_empty_loop_has_unknown_body_effect()
+    {
+        var result = ParseBash("for d in; do cd /tmp; done");
+
+        Assert.IsType<ShellWorkingDirectoryEffect.Unknown>(
+            Assert.Single(result.Commands).WorkingDirectoryEffect);
+    }
+
+    [Fact]
+    public void Bash_substitution_effect_is_local_to_its_ancestry()
+    {
+        var result = ParseBash("echo \"$(cd /tmp && pwd)\"; pwd");
+        var innerCd = result.Commands.Single(command =>
+            command.Clause.Verb.Joined == "cd");
+        var outerPwd = result.Commands.Last();
+
+        AssertExactChange(innerCd, "/tmp");
+        Assert.Contains(innerCd.Ancestry, frame =>
+            frame.Region == CommandAncestryRegion.Substitution);
+        Assert.Equal(
+            "/work",
+            Assert.IsType<ShellValueDomain.Exact>(outerPwd.WorkingDirectory).Value);
+    }
+
+    [Fact]
+    public void Bash_parenthesized_subshell_effect_is_local_to_its_ancestry()
+    {
+        var result = ParseBash("(cd /tmp; pwd); pwd");
+        var innerCd = result.Commands.Single(command =>
+            command.Clause.Verb.Joined == "cd");
+
+        AssertExactChange(innerCd, "/tmp");
+        Assert.Contains(innerCd.Ancestry, frame =>
+            frame.Region == CommandAncestryRegion.GroupBody &&
+            frame.Ancestor is GroupSyntax
+            {
+                GroupKind: ShellGroupKind.IsolatedScope,
+            });
+        Assert.Equal(
+            "/work",
+            Assert.IsType<ShellValueDomain.Exact>(
+                result.Commands.Last().WorkingDirectory).Value);
+    }
+
+    [Fact]
+    public void PowerShell_ordinary_command_preserves_location()
+    {
+        var command = Assert.Single(ParsePowerShell("Get-Content file.txt").Commands);
+
+        Assert.IsType<ShellWorkingDirectoryEffect.Unchanged>(
+            command.WorkingDirectoryEffect);
+    }
+
+    [Theory]
+    [InlineData("Set-Location C:\\temp")]
+    [InlineData("Set-Location -Lit C:\\temp")]
+    [InlineData("Set-Location -LP C:\\temp")]
+    [InlineData("Set-Location -PSPath C:\\temp")]
+    [InlineData("Set-Location -ps C:\\temp")]
+    [InlineData("Set-Location -psp C:\\temp")]
+    [InlineData("cd C:\\temp")]
+    [InlineData("chdir C:\\temp")]
+    [InlineData("sl C:\\temp")]
+    public void PowerShell_set_location_and_aliases_change_on_success(string source)
+    {
+        var command = Assert.Single(ParsePowerShell(source).Commands);
+
+        AssertExactChange(command, "C:/temp");
+    }
+
+    [Theory]
+    [InlineData("Set-Location -Verbose C:\\temp")]
+    [InlineData("Set-Location -ErrorAction Stop C:\\temp")]
+    public void PowerShell_common_parameters_preserve_exact_location_target(string source)
+    {
+        var command = Assert.Single(ParsePowerShell(source).Commands);
+
+        AssertExactChange(command, "C:/temp");
+    }
+
+    [Theory]
+    [InlineData("Set-Location -Verbose C:\\temp && Get-Location")]
+    [InlineData("Set-Location -Verbose:$true C:\\temp && Get-Location")]
+    [InlineData("Set-Location -Verbose:$false C:\\temp && Get-Location")]
+    [InlineData("Set-Location -ErrorAction Stop C:\\temp && Get-Location")]
+    [InlineData("Set-Location -psp C:\\temp && Get-Location")]
+    public void PowerShell_effect_and_following_flow_share_parameter_binding(
+        string source)
+    {
+        var result = ParsePowerShell(source);
+
+        AssertExactChange(result.Commands[0], "C:/temp");
+        Assert.Equal(
+            "C:/temp",
+            Assert.IsType<ShellValueDomain.Exact>(
+                result.Commands[1].WorkingDirectory).Value);
+    }
+
+    [Theory]
+    [InlineData("Set-Location C:\\temp C:\\other")]
+    [InlineData("Set-Location -Path")]
+    [InlineData("Set-Location -Unsupported C:\\temp")]
+    public void PowerShell_failure_only_set_location_shape_is_unchanged(string source)
+    {
+        var command = Assert.Single(ParsePowerShell(source).Commands);
+
+        Assert.IsType<ShellWorkingDirectoryEffect.Unchanged>(
+            command.WorkingDirectoryEffect);
+    }
+
+    [Theory]
+    [InlineData("Set-Location -Unsupported C:\\temp; Get-Location")]
+    [InlineData("Set-Location -Verbose:no C:\\temp; Get-Location")]
+    public void PowerShell_failure_only_binding_preserves_following_flow(string source)
+    {
+        var result = ParsePowerShell(source);
+
+        Assert.IsType<ShellWorkingDirectoryEffect.Unchanged>(
+            result.Commands[0].WorkingDirectoryEffect);
+        Assert.Equal(
+            "C:/work",
+            Assert.IsType<ShellValueDomain.Exact>(
+                result.Commands[1].WorkingDirectory).Value);
+    }
+
+    [Theory]
+    [InlineData("Set-Location -Verbose:$switch C:\\temp && Get-Location")]
+    [InlineData("Set-Location -PassThru:$switch C:\\temp && Get-Location")]
+    [InlineData("Set-Location -Verbose:$(Get-Flag) C:\\temp && Get-Location")]
+    [InlineData("Set-Location -Verbose:0 C:\\temp && Get-Location")]
+    [InlineData("Set-Location -Verbose:1 C:\\temp && Get-Location")]
+    [InlineData("Set-Location -Verbose:2 C:\\temp && Get-Location")]
+    [InlineData("Set-Location -Verbose:.0 C:\\temp && Get-Location")]
+    [InlineData("Set-Location -Verbose:.5 C:\\temp && Get-Location")]
+    public void PowerShell_dynamic_switch_value_keeps_success_transfer_reachable(
+        string source)
+    {
+        var result = ParsePowerShell(source);
+        var location = result.Commands.Single(command =>
+            command.Clause.Verb.Joined == "Set-Location");
+        var following = result.Commands.Last();
+
+        AssertExactChange(location, "C:/temp");
+        Assert.Equal(
+            "C:/temp",
+            Assert.IsType<ShellValueDomain.Exact>(following.WorkingDirectory).Value);
+    }
+
+    [Fact]
+    public void PowerShell_escaped_switch_value_is_static_and_invalid()
+    {
+        var result = ParsePowerShell(
+            "Set-Location -Verbose:`$switch C:\\temp; Get-Location");
+
+        Assert.IsType<ShellWorkingDirectoryEffect.Unchanged>(
+            result.Commands[0].WorkingDirectoryEffect);
+        Assert.Equal(
+            "C:/work",
+            Assert.IsType<ShellValueDomain.Exact>(
+                result.Commands[1].WorkingDirectory).Value);
+    }
+
+    [Theory]
+    [InlineData("Push-Location C:\\temp")]
+    [InlineData("Pop-Location")]
+    public void PowerShell_directory_stack_effect_is_unknown(string source)
+    {
+        var command = Assert.Single(ParsePowerShell(source).Commands);
+
+        Assert.IsType<ShellWorkingDirectoryEffect.Unknown>(
+            command.WorkingDirectoryEffect);
+    }
+
+    [Fact]
+    public void PowerShell_non_filesystem_location_has_unknown_success_target()
+    {
+        var command = Assert.Single(ParsePowerShell("Set-Location Env:").Commands);
+        var effect = Assert.IsType<ShellWorkingDirectoryEffect.ChangesOnSuccess>(
+            command.WorkingDirectoryEffect);
+
+        Assert.IsType<ShellValueDomain.Unknown>(effect.Target);
+    }
+
+    [Fact]
+    public void PowerShell_dynamic_location_has_unknown_success_target()
+    {
+        var result = ParsePowerShell(
+            "Set-Location $target; Get-Location");
+        var effect = Assert.IsType<ShellWorkingDirectoryEffect.ChangesOnSuccess>(
+            result.Commands[0].WorkingDirectoryEffect);
+
+        Assert.IsType<ShellValueDomain.Unknown>(effect.Target);
+        Assert.IsType<ShellValueDomain.Unknown>(result.Commands[1].WorkingDirectory);
+    }
+
+    [Fact]
+    public void PowerShell_dynamic_location_failure_retains_incoming_location()
+    {
+        var result = ParsePowerShell(
+            "Set-Location $target || Get-Location");
+
+        Assert.IsType<ShellWorkingDirectoryEffect.ChangesOnSuccess>(
+            result.Commands[0].WorkingDirectoryEffect);
+        Assert.Equal(
+            "C:/work",
+            Assert.IsType<ShellValueDomain.Exact>(
+                result.Commands[1].WorkingDirectory).Value);
+    }
+
+    [Fact]
+    public void PowerShell_dynamic_path_parameter_has_unknown_success_target()
+    {
+        var command = Assert.Single(
+            ParsePowerShell("Set-Location -Path $target").Commands);
+        var effect = Assert.IsType<ShellWorkingDirectoryEffect.ChangesOnSuccess>(
+            command.WorkingDirectoryEffect);
+
+        Assert.IsType<ShellValueDomain.Unknown>(effect.Target);
+    }
+
+    [Fact]
+    public void PowerShell_stack_name_has_unknown_success_target()
+    {
+        var command = Assert.Single(
+            ParsePowerShell("Set-Location -StackName missing").Commands);
+        var effect = Assert.IsType<ShellWorkingDirectoryEffect.ChangesOnSuccess>(
+            command.WorkingDirectoryEffect);
+
+        Assert.IsType<ShellValueDomain.Unknown>(effect.Target);
+    }
+
+    [Fact]
+    public void PowerShell_abbreviated_stack_name_has_unknown_success_target()
+    {
+        var command = Assert.Single(
+            ParsePowerShell("Set-Location -s missing").Commands);
+        var effect = Assert.IsType<ShellWorkingDirectoryEffect.ChangesOnSuccess>(
+            command.WorkingDirectoryEffect);
+
+        Assert.IsType<ShellValueDomain.Unknown>(effect.Target);
+    }
+
+    [Fact]
+    public void PowerShell_preserving_current_runspace_host_is_unchanged()
+    {
+        var result = ParsePowerShell("Measure-Command { Get-Date }");
+        var host = result.Commands.Single(command =>
+            command.Clause.Verb.Joined == "Measure-Command");
+        var nested = result.Commands.Single(command =>
+            command.Clause.Verb.Joined == "Get-Date");
+
+        Assert.IsType<ShellWorkingDirectoryEffect.Unchanged>(
+            nested.WorkingDirectoryEffect);
+        Assert.IsType<ShellWorkingDirectoryEffect.Unchanged>(
+            host.WorkingDirectoryEffect);
+    }
+
+    [Fact]
+    public void PowerShell_mutating_current_runspace_host_is_unknown()
+    {
+        var result = ParsePowerShell(
+            "Measure-Command { Set-Location C:\\temp }");
+        var host = result.Commands.Single(command =>
+            command.Clause.Verb.Joined == "Measure-Command");
+        var nested = result.Commands.Single(command =>
+            command.Clause.Verb.Joined == "Set-Location");
+
+        AssertExactChange(nested, "C:/temp");
+        Assert.IsType<ShellWorkingDirectoryEffect.Unknown>(
+            host.WorkingDirectoryEffect);
+    }
+
+    [Fact]
+    public void PowerShell_same_target_mutation_does_not_look_preserving()
+    {
+        var result = ParsePowerShell(
+            "Measure-Command { Set-Location C:\\work }");
+        var host = result.Commands.Single(command =>
+            command.Clause.Verb.Joined == "Measure-Command");
+
+        Assert.IsType<ShellWorkingDirectoryEffect.Unknown>(
+            host.WorkingDirectoryEffect);
+    }
+
+    [Fact]
+    public void PowerShell_unknown_domain_equality_does_not_prove_host_preservation()
+    {
+        var result = new PwshParser(
+            new PwshParserOptions
+            {
+                HomeDirectory = "C:/Users/test",
+                InitialStateMode = PwshInitialStateMode.Unknown,
+                Dialect = PwshDialect.PowerShell7,
+            }).Parse("Measure-Command { Set-Location $target }");
+        var host = result.Commands.Single(command =>
+            command.Clause.Verb.Joined == "Measure-Command");
+
+        Assert.IsType<ShellWorkingDirectoryEffect.Unknown>(
+            host.WorkingDirectoryEffect);
+    }
+
+    [Fact]
+    public void PowerShell_child_process_host_is_unchanged()
+    {
+        var result = ParsePowerShell(
+            "Start-Job -ScriptBlock { Set-Location C:\\temp }");
+        var host = result.Commands.Single(command =>
+            command.Clause.Verb.Joined == "Start-Job");
+        var nested = result.Commands.Single(command =>
+            command.Clause.Verb.Joined == "Set-Location");
+
+        AssertExactChange(nested, "C:/temp");
+        Assert.IsType<ShellWorkingDirectoryEffect.Unchanged>(
+            host.WorkingDirectoryEffect);
+    }
+
+    [Fact]
+    public void PowerShell_proved_data_script_block_does_not_create_nested_effect()
+    {
+        var result = ParsePowerShell("Write-Output { Set-Location C:\\temp }");
+        var host = Assert.Single(result.Commands);
+
+        Assert.Equal("Write-Output", host.Clause.Verb.Joined);
+        Assert.IsType<ShellWorkingDirectoryEffect.Unchanged>(
+            host.WorkingDirectoryEffect);
+    }
+
+    [Fact]
+    public void PowerShell_unmodeled_execution_region_host_is_unknown()
+    {
+        var result = ParsePowerShell("Invoke-Custom { Get-Date }");
+        var host = result.Commands.Single(command =>
+            command.Clause.Verb.Joined == "Invoke-Custom");
+
+        Assert.IsType<ShellWorkingDirectoryEffect.Unknown>(
+            host.WorkingDirectoryEffect);
+    }
+
+    [Fact]
+    public void PowerShell_subexpression_effect_retains_current_runspace_ancestry()
+    {
+        var result = ParsePowerShell(
+            "$(Set-Location C:\\temp); Get-Location");
+        var nested = result.Commands.Single(command =>
+            command.Clause.Verb.Joined == "Set-Location");
+
+        AssertExactChange(nested, "C:/temp");
+        Assert.Contains(nested.Ancestry, frame =>
+            frame.Region == CommandAncestryRegion.Substitution);
+        Assert.IsType<ShellValueDomain.Unknown>(
+            result.Commands.Last().WorkingDirectory);
+    }
+
+    [Fact]
+    public void PowerShell_parenthesized_effect_reaches_containing_runspace()
+    {
+        var result = ParsePowerShell(
+            "(Set-Location C:\\temp); Get-Location");
+        var nested = result.Commands.Single(command =>
+            command.Clause.Verb.Joined == "Set-Location");
+
+        AssertExactChange(nested, "C:/temp");
+        Assert.Contains(nested.Ancestry, frame =>
+            frame.Region == CommandAncestryRegion.GroupBody &&
+            frame.Ancestor is GroupSyntax
+            {
+                GroupKind: ShellGroupKind.CurrentScope,
+            });
+        Assert.IsType<ShellValueDomain.Unknown>(
+            result.Commands.Last().WorkingDirectory);
+    }
+
+    [Fact]
+    public void PowerShell_empty_loop_body_has_no_reusable_effect()
+    {
+        var result = ParsePowerShell(
+            "foreach ($x in @()) { Set-Location C:\\temp }");
+        var command = Assert.Single(result.Commands);
+
+        Assert.IsType<ShellWorkingDirectoryEffect.Unknown>(
+            command.WorkingDirectoryEffect);
+    }
+
+    [Fact]
+    public void PowerShell_pipeline_location_transfer_stays_atomic()
+    {
+        var result = ParsePowerShell("Set-Location C:\\temp | Get-Location");
+
+        Assert.True(result.IsUnparseable);
+        Assert.Empty(result.Commands);
+    }
+
+    private static ParsedCommand ParseBash(string source) => new BashParser(
+        new BashParserOptions
+        {
+            HomeDirectory = "/home/test",
+            WorkingDirectory = "/work",
+            InitialStateMode = BashInitialStateMode.IsolatedNonInteractive,
+        }).Parse(source);
+
+    private static ParsedCommand ParsePowerShell(string source) => new PwshParser(
+        new PwshParserOptions
+        {
+            HomeDirectory = "C:/Users/test",
+            WorkingDirectory = "C:/work",
+            InitialStateMode = PwshInitialStateMode.IsolatedNonInteractiveNoProfile,
+            Dialect = PwshDialect.PowerShell7,
+        }).Parse(source);
+
+    private static void AssertExactChange(CommandOccurrence command, string target)
+    {
+        var effect = Assert.IsType<ShellWorkingDirectoryEffect.ChangesOnSuccess>(
+            command.WorkingDirectoryEffect);
+        Assert.Equal(target, Assert.IsType<ShellValueDomain.Exact>(effect.Target).Value);
+    }
+}

--- a/tests/ShellSyntaxTree.Tests/PublicApiSnapshotTests.cs
+++ b/tests/ShellSyntaxTree.Tests/PublicApiSnapshotTests.cs
@@ -640,6 +640,7 @@ public class PublicApiSnapshotTests
             nameof(ShellSourceFragment),
             nameof(ShellSyntaxNode),
             nameof(ShellValueDomain),
+            nameof(ShellWorkingDirectoryEffect),
             nameof(SimpleCommandSyntax),
             nameof(HereDocumentRedirectAnalysis),
             nameof(HereStringRedirectAnalysis),

--- a/tests/ShellSyntaxTree.Tests/ShellSyntaxProjectionTests.cs
+++ b/tests/ShellSyntaxTree.Tests/ShellSyntaxProjectionTests.cs
@@ -981,6 +981,109 @@ public class ShellSyntaxProjectionTests
     }
 
     [Fact]
+    public void Invalid_working_directory_effect_facts_project_as_unknown()
+    {
+        var root = Block(0, Leaf("inspect", 0));
+        var invalidEffects = new ShellWorkingDirectoryEffectFacts?[]
+        {
+            null,
+            new()
+            {
+                Kind = (ShellWorkingDirectoryEffectKind)999,
+            },
+            new()
+            {
+                Kind = ShellWorkingDirectoryEffectKind.Unchanged,
+                Target = new ShellValueDomainFacts
+                {
+                    Kind = ShellValueDomainKind.Exact,
+                    Values = new[] { "/work" },
+                },
+            },
+            new()
+            {
+                Kind = ShellWorkingDirectoryEffectKind.ChangesOnSuccess,
+                Target = new ShellValueDomainFacts
+                {
+                    Kind = ShellValueDomainKind.FiniteSet,
+                    Values = new[] { "/only-one" },
+                },
+            },
+            new()
+            {
+                Kind = ShellWorkingDirectoryEffectKind.ChangesOnSuccess,
+                Target = new ShellValueDomainFacts
+                {
+                    Kind = ShellValueDomainKind.Pattern,
+                    Pattern = "/work/*.txt",
+                    CoveringDirectory = "/work",
+                },
+            },
+            new()
+            {
+                Kind = ShellWorkingDirectoryEffectKind.ChangesOnSuccess,
+                Target = ShellValueDomainFacts.IntegerRange(0, 1),
+            },
+            new()
+            {
+                Kind = ShellWorkingDirectoryEffectKind.ChangesOnSuccess,
+                Target = ShellValueDomainFacts.Concatenate(new[]
+                {
+                    new ShellValueDomainFacts
+                    {
+                        Kind = ShellValueDomainKind.Exact,
+                        Values = new[] { "/work/" },
+                    },
+                    ShellValueDomainFacts.IntegerRange(0, 1),
+                }),
+            },
+            new()
+            {
+                Kind = ShellWorkingDirectoryEffectKind.ChangesOnSuccess,
+                Target = new ShellValueDomainFacts
+                {
+                    Kind = ShellValueDomainKind.Exact,
+                    Values = new[] { "relative" },
+                },
+            },
+            new()
+            {
+                Kind = ShellWorkingDirectoryEffectKind.ChangesOnSuccess,
+                Target = new ShellValueDomainFacts
+                {
+                    Kind = ShellValueDomainKind.Exact,
+                    Values = new[] { "C:/work/../temp" },
+                },
+            },
+            new()
+            {
+                Kind = ShellWorkingDirectoryEffectKind.ChangesOnSuccess,
+                Target = new ShellValueDomainFacts
+                {
+                    Kind = ShellValueDomainKind.FiniteSet,
+                    Values = new[] { "/tmp", "C:/temp" },
+                },
+            },
+        };
+
+        foreach (var effect in invalidEffects)
+        {
+            var succeeded = ShellSyntaxProjection.TryProject(
+                root,
+                _ => new CommandOccurrenceFacts
+                {
+                    WorkingDirectoryEffect = effect!,
+                },
+                ShellProjectionLanguage.PowerShell,
+                out var result);
+
+            Assert.True(succeeded);
+            Assert.IsType<ShellWorkingDirectoryEffect.Unknown>(
+                Assert.Single(result.Commands).WorkingDirectoryEffect);
+        }
+    }
+
+    [Fact]
     public void Unknown_projection_language_keeps_strong_filesystem_facts_disabled()
     {
         var clause = ClauseFor("cat") with

--- a/tests/ShellSyntaxTree.Tests/V03PublicApiSnapshotTests.cs
+++ b/tests/ShellSyntaxTree.Tests/V03PublicApiSnapshotTests.cs
@@ -108,6 +108,8 @@ public class V03PublicApiSnapshotTests
                 typeof(IReadOnlyList<CommandAncestryFrame>)),
             (nameof(CommandOccurrence.Arguments), typeof(IReadOnlyList<AnalyzedArgument>)),
             (nameof(CommandOccurrence.WorkingDirectory), typeof(ShellValueDomain)),
+            (nameof(CommandOccurrence.WorkingDirectoryEffect),
+                typeof(ShellWorkingDirectoryEffect)),
             (nameof(CommandOccurrence.Redirects), typeof(IReadOnlyList<RedirectAnalysis>)),
             (nameof(CommandOccurrence.IsComplete), typeof(bool)));
         AssertResultRecord(
@@ -158,6 +160,18 @@ public class V03PublicApiSnapshotTests
             typeof(ShellValueDomain.Concatenation),
             (nameof(ShellValueDomain.Concatenation.Parts),
                 typeof(IReadOnlyList<ShellValueDomain>), false));
+    }
+
+    [Fact]
+    public void Working_directory_effect_is_a_closed_runtime_discriminated_family()
+    {
+        AssertClosedBase(typeof(ShellWorkingDirectoryEffect));
+        AssertResultRecord(typeof(ShellWorkingDirectoryEffect.Unknown));
+        AssertResultRecord(typeof(ShellWorkingDirectoryEffect.Unchanged));
+        AssertResultRecordAccessors(
+            typeof(ShellWorkingDirectoryEffect.ChangesOnSuccess),
+            (nameof(ShellWorkingDirectoryEffect.ChangesOnSuccess.Target),
+                typeof(ShellValueDomain), false));
     }
 
     [Fact]
@@ -370,6 +384,40 @@ public class V03PublicApiSnapshotTests
         Assert.Contains(
             "\"AuthoredFileSystemValue\"",
             JsonSerializer.Serialize(positive),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Working_directory_effect_is_non_null_and_part_of_record_shape()
+    {
+        var unknown = new CommandOccurrence();
+        var unchanged = unknown with
+        {
+            WorkingDirectoryEffect = new ShellWorkingDirectoryEffect.Unchanged(),
+        };
+        var changed = unknown with
+        {
+            WorkingDirectoryEffect = new ShellWorkingDirectoryEffect.ChangesOnSuccess(
+                new ShellValueDomain.Exact("/work")),
+        };
+        var equivalent = unknown with
+        {
+            WorkingDirectoryEffect = new ShellWorkingDirectoryEffect.ChangesOnSuccess(
+                new ShellValueDomain.Exact("/work")),
+        };
+
+        Assert.IsType<ShellWorkingDirectoryEffect.Unknown>(
+            unknown.WorkingDirectoryEffect);
+        Assert.NotEqual(unknown, unchanged);
+        Assert.Equal(changed, equivalent);
+        Assert.Equal(changed.GetHashCode(), equivalent.GetHashCode());
+        Assert.Contains(
+            "WorkingDirectoryEffect = ChangesOnSuccess",
+            changed.ToString(),
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "\"WorkingDirectoryEffect\"",
+            JsonSerializer.Serialize(changed),
             StringComparison.Ordinal);
     }
 

--- a/tools/PwshCorpusTool/CorpusJson.cs
+++ b/tools/PwshCorpusTool/CorpusJson.cs
@@ -373,6 +373,8 @@ internal static class CorpusJson
 
                 commandJson["arguments"] = arguments;
                 commandJson["workingDirectory"] = BuildValueDomain(command.WorkingDirectory);
+                commandJson["workingDirectoryEffect"] =
+                    BuildWorkingDirectoryEffect(command.WorkingDirectoryEffect);
 
                 if (command.Redirects.Count > 0)
                 {
@@ -428,6 +430,24 @@ internal static class CorpusJson
                 (domain as ShellValueDomain.PathPattern)?.CoveringDirectory,
         };
     }
+
+    private static JsonObject BuildWorkingDirectoryEffect(
+        ShellWorkingDirectoryEffect effect) => effect switch
+        {
+            ShellWorkingDirectoryEffect.Unchanged => new JsonObject
+            {
+                ["kind"] = nameof(ShellWorkingDirectoryEffect.Unchanged),
+            },
+            ShellWorkingDirectoryEffect.ChangesOnSuccess changed => new JsonObject
+            {
+                ["kind"] = nameof(ShellWorkingDirectoryEffect.ChangesOnSuccess),
+                ["target"] = BuildValueDomain(changed.Target),
+            },
+            _ => new JsonObject
+            {
+                ["kind"] = nameof(ShellWorkingDirectoryEffect.Unknown),
+            },
+        };
 
     private static JsonObject BuildRedirectAnalysis(
         RedirectAnalysis analysis,


### PR DESCRIPTION
## Summary

- add a closed, additive `ShellWorkingDirectoryEffect` family to each command occurrence
- derive Bash and native PowerShell cwd effects during abstract-state transfer
- preserve strict boundaries for stack mutation, hidden execution, invalid shapes, and malformed targets
- document the consumer contract and add sanitized corpus plus adversarial regressions

This supplies the general parser fact Netclaw needs to reason about causal directory intent without adding command-specific policy parsing. It does not grant authority.

## Validation

- `dotnet build -c Release` — 0 warnings/errors
- `dotnet test -c Release` — 3,074 passed
- strict OpenSpec — pass
- headers — pass
- Slopwatch changed-file hook — pass
- corpus/PII focused suite — 865 passed
- package build — pass
- API diff against public 0.3.3 on net8.0 and netstandard2.0 — five additive changes, zero breaking
- adversarial review — pass after PowerShell/native and projection counterexamples

## Remaining gates

- native Windows CI
- downstream Netclaw integration
- release/version work in a later bounded slice