### PR TITLE
Release ShellSyntaxTree 0.3.4

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.3.3</VersionPrefix>
+    <VersionPrefix>0.3.4</VersionPrefix>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Target framework matrix -->

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -89,11 +89,16 @@ priorities.
       relational fact to `CommandOccurrence` so consumers can distinguish
       proved preservation, success-only transfer, and unknown effects without
       parsing shell builtins. Strict OpenSpec and adversarial review passed.
-- [ ] **Implement and validate v0.3.4 working-directory effects.** Derive the
+- [x] **Implement and validate v0.3.4 working-directory effects.** Derive the
       fact from Bash and native PowerShell success/failure state, correct the
       v0.3 Bash `chdir` flow, add scope/join/corruption/corpus/guide coverage,
-      preserve v0.3.3 compatibility, and publish only after Linux and native
-      Windows CI plus downstream Netclaw causal-directory acceptance pass.
+      and preserve v0.3.3 compatibility. PR #165 merged as `53348698` after
+      Linux and native Windows CI, 3,074 tests, strict OpenSpec, headers,
+      Slopwatch, package validation, API comparison, and adversarial review
+      passed.
+- [ ] **Publish and consume v0.3.4.** Merge the bounded release PR, publish the
+      package through the bare `0.3.4` tag, then upgrade Netclaw and complete
+      its causal-directory acceptance matrix before merging that policy slice.
 
 ## Completed v0.3.0 host integration and release acceptance
 

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ Hand-rolled, AOT-trim friendly, zero native dependencies. Multi-targets
 
 ```bash
 # Current package
-dotnet add package ShellSyntaxTree --version 0.3.3
+dotnet add package ShellSyntaxTree --version 0.3.4
 ```
 
-Version `0.3.3` includes the typed syntax tree, command-occurrence API,
-bounded authored-value analysis, and audited authored-filesystem projection
-documented below.
+Version `0.3.4` includes the typed syntax tree, command-occurrence API,
+bounded authored-value analysis, audited authored-filesystem projection, and
+parser-owned working-directory effects documented below.
 
 ## What you get
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,45 @@
 #### Unreleased ####
 
+#### 0.3.4 2026-08-13 ####
+
+This additive release publishes parser-owned working-directory effects for
+each executable command occurrence. Security consumers can reason about a
+causal directory transition without reconstructing shell builtins or treating
+the syntax fact as authority.
+
+## Added
+
+- Add the closed `ShellWorkingDirectoryEffect` family with `Unknown`,
+  `Unchanged`, and `ChangesOnSuccess(Target)` alternatives.
+- Add `CommandOccurrence.WorkingDirectoryEffect` with a non-null `Unknown`
+  default for compatibility and malformed internal facts.
+- Publish bounded Bash `cd`, `command cd`, and `builtin cd` effects while
+  retaining strict `pushd`, `popd`, hidden execution, and invalid-shape
+  boundaries.
+- Publish selected-dialect native PowerShell `Set-Location` effects from the
+  same parameter-binding pass that computes success and failure flow.
+
+## Security and compatibility
+
+- Keep authorization, path containment, prerequisite coverage, ancestry, and
+  real fallback-directory checks in the consumer.
+- Require normalized absolute local targets. Reject relative, non-normalized,
+  mixed-style, malformed, or unsupported target domains as `Unknown`.
+- Preserve atomic failure for hidden Bash execution and strict PowerShell
+  location-stack, provider, script, dynamic-identity, and unmodeled-region
+  boundaries.
+- Preserve all 0.3.3 public signatures. Both target-framework API comparisons
+  report five additive members and zero breaking changes.
+
+## Consumer validation
+
+- Add input/output examples and default-deny pseudocode to the consumer guide.
+- Add sanitized Bash corpus cases for causal chains, directory-stack
+  invalidation, and finite loop targets.
+- Validate native PowerShell aliases, common parameters, unambiguous aliases
+  and prefixes, dynamic switch values, invalid switch values, and bounded or
+  unknown targets.
+
 #### 0.3.3 2026-08-13 ####
 
 This additive release publishes bounded local-filesystem values for audited

--- a/openspec/changes/publish-working-directory-effects/tasks.md
+++ b/openspec/changes/publish-working-directory-effects/tasks.md
@@ -102,7 +102,7 @@
   format checks, Slopwatch, package build, API diff, and PII audit.
 - [x] 7.3 Obtain adversarial reviews of the implementation, Bash/PowerShell
   semantics, public API, consumer guide, corpus, and final frozen diff.
-- [ ] 7.4 Open the bounded ShellSyntaxTree pull request and merge only after
+- [x] 7.4 Open the bounded ShellSyntaxTree pull request and merge only after
   Linux and native Windows checks pass.
 - [ ] 7.5 Publish the next additive v0.x package through the release workflow
   only after the implementation PR is merged and release gates pass.


### PR DESCRIPTION
## Summary

- bump package version to 0.3.4
- document the additive working-directory effect API and its security boundary
- update README and implementation/OpenSpec delivery state

## Validation

- Release build: 0 warnings/errors
- full suite: 3,074/3,074
- pack: nupkg + snupkg for net8.0 and netstandard2.0
- API diff vs public 0.3.3: five additive, zero breaking on both TFMs
- strict OpenSpec, headers, and diff check: pass
- adversarial release review: pass
- implementation PR #165: Ubuntu and Windows CI pass

Downstream Netclaw integration remains explicitly pending until the public package is available.