### PR TITLE
Specify authored non-filesystem operand facts

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -96,9 +96,16 @@ priorities.
       Linux and native Windows CI, 3,074 tests, strict OpenSpec, headers,
       Slopwatch, package validation, API comparison, and adversarial review
       passed.
-- [ ] **Publish and consume v0.3.4.** Merge the bounded release PR, publish the
-      package through the bare `0.3.4` tag, then upgrade Netclaw and complete
-      its causal-directory acceptance matrix before merging that policy slice.
+- [x] **Publish and consume v0.3.4.** PR #166 merged as `59479788`. Bare tag
+      `0.3.4` completed release workflow run 31728782396 and published the
+      package, symbols, and non-prerelease GitHub release. Netclaw consumed the
+      exact public package and completed its causal-directory acceptance slice.
+- [ ] **Approve authored non-filesystem value facts for v0.3.5.** Live Netclaw
+      traffic exposed `tr -d '\n'` as a false local-path scope ending in `/n`.
+      The `publish-authored-operand-semantics` OpenSpec proposes one additive
+      value-domain property, one audited `tr` data binding, a single-token
+      compatibility correction, and a strict consumer boundary. Complete
+      adversarial review before implementation.
 
 ## Completed v0.3.0 host integration and release acceptance
 

--- a/openspec/changes/publish-authored-operand-semantics/.openspec.yaml
+++ b/openspec/changes/publish-authored-operand-semantics/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-08-14

--- a/openspec/changes/publish-authored-operand-semantics/design.md
+++ b/openspec/changes/publish-authored-operand-semantics/design.md
@@ -1,0 +1,162 @@
+## Context
+
+`AuthoredPathShape` is deliberately lexical. It classifies `\n` as a
+Windows-shaped word even when Bash passes that word to `tr` as translation
+data. Compatibility `Arg.IsPath` has the same false positive because `tr`
+currently falls through to the generic path heuristic.
+
+ShellSyntaxTree 0.3.4 can publish a strong positive
+`AuthoredFileSystemValue`, but `Unknown` combines two different states:
+unaudited semantics and audited non-filesystem semantics. Netclaw cannot safely
+distinguish them. Its reviewed-safe policy must therefore prompt for the live
+`tr -d '\n'` case.
+
+The parser already owns a small audited operand-binding subsystem. This change
+extends that boundary instead of adding executable grammar to Netclaw.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Publish a bounded value only when an audited binding proves that the
+  argument is not a local-filesystem operand.
+- Preserve lexical path shape as independent evidence.
+- Correct compatibility path classification for audited `tr` operands.
+- Let Netclaw ignore only the contradicted lexical path fact.
+- Keep the public addition and implementation small.
+
+**Non-Goals:**
+
+- Declare a command safe or read-only.
+- Suppress redirect, hidden-execution, dynamic-identity, or completeness
+  checks.
+- Add a complete `tr`, `grep`, or native-option grammar.
+- Treat every compatibility `IsPath=false` argument as audited data.
+- Publish an exact value after unbounded splitting or pathname expansion.
+- Add a positive PowerShell binder in this slice.
+
+## Decisions
+
+### 1. Publish one direct non-filesystem value domain
+
+Add one property to `AnalyzedArgument`:
+
+```csharp
+public ShellValueDomain AuthoredNonFileSystemValue { get; internal init; }
+```
+
+The default is `ShellValueDomain.Unknown`. The positive alternatives in this
+slice are `Exact` and `FiniteSet`.
+
+This mirrors `AuthoredFileSystemValue` and reuses the closed value family. It
+avoids a new public enum and avoids making consumers recombine a role with
+`AuthoredValue` transformation rules.
+
+A boolean was rejected because it would not bind the proof to the bounded
+value. A three-state enum was rejected because it would duplicate the positive
+filesystem state already carried by `AuthoredFileSystemValue`. Reinterpreting
+`Arg.IsPath=false` was rejected because that compatibility value also covers
+unaudited and unknown executables.
+
+### 2. Extend the audited operand-binding subsystem
+
+Rename the internal filesystem-only catalog and projector to describe audited
+operand semantics. Each catalog entry selects:
+
+- a shell and canonical command identity;
+- a reusable binding category;
+- either local-filesystem or non-filesystem projection; and
+- the complete accepted argument shape.
+
+The existing Bash `cat` and PowerShell `Get-Content -LiteralPath` entries keep
+their exact filesystem behavior. The initial non-filesystem entry is Bash
+`tr`, whose arguments are translation sets or options and never name files
+opened by `tr`.
+
+The `tr` entry classifies the command as a single-token identity and all
+bounded authored arguments as non-filesystem. The greedy verb walk consumes
+that same catalog fact, so ordinary `tr abc def` retains two analyzed
+arguments. Redirects remain separate occurrence facts. Command substitutions
+remain separate command occurrences. Unknown command identity, unbounded
+values, active pathname expansion, or incomplete provenance produce `Unknown`.
+
+The positive filesystem and non-filesystem domains are mutually exclusive for
+one argument. Projection validation fails closed on an impossible pairing.
+
+### 3. Correct the compatibility leaf through parser-owned data
+
+Use the audited `tr` entry to stop verb extraction after the command name and
+classify every positional as non-path data. This makes both `tr abc def` and
+`tr -d '\n'` retain `IsPath=false` and `Resolved=null` for their translation
+operands.
+
+The generic heuristic remains unchanged. An unknown command receiving `\n`
+continues to classify it as path-shaped. Netclaw therefore receives the
+compatibility correction only from parser-owned command knowledge.
+
+### 4. Keep lexical shape independent
+
+`AuthoredPathShape` remains `Windows` for the exact `\n` word. That fact is
+truthful lexical evidence and can still matter to consumers without audited
+semantic binding.
+
+Netclaw may omit broad compatibility `IsPath` and authored lexical-path facts
+only when the same analyzed argument has a positive
+`AuthoredNonFileSystemValue`. It must not remove positive
+`AuthoredFileSystemValue` facts, redirect facts, or the raw protected-path
+defense scan.
+
+### 5. Keep authorization and execution checks unchanged
+
+The new property is not an allow decision. A consumer still requires a
+complete occurrence, approved command effects, safe cwd, and independent
+coverage for every command and redirect.
+
+Therefore `tr -d '\n' > /outside/result` remains strict because of the output
+redirect. `tr "$(tool)"` still exposes and evaluates the substitution. An
+unknown or unrecognized property/domain shape remains strict.
+
+### 6. Pin both the parser fact and the observed consumer outcome
+
+ShellSyntaxTree receives direct and executable-corpus cases for ordinary
+translation sets, the exact backslash data shape, path-looking translation
+data, active globs, redirects, unknown commands, and the
+positive-filesystem mutual-exclusion invariant.
+
+Netclaw receives the sanitized full diagnostic loop from the live session. It
+must derive the real project cwd, produce no `/n` candidate scope, and allow
+the reviewed `tr` phrase only after every other command and redirect is
+covered.
+
+The shell-write observations remain an agent-guidance corpus category. This
+change does not authorize `cat >`, heredocs, `tee`, or other file-writing
+shell shapes.
+
+## Risks / Trade-offs
+
+- **Risk: an overbroad data entry hides a filesystem operand.** → Require an
+  invariant over every accepted argument shape and adversarial option tests.
+- **Risk: consumers treat data as globally safe.** → The contract permits
+  skipping only local-path interpretation for that argument.
+- **Risk: two authored domains disagree.** → Validate mutual exclusion before
+  publishing the occurrence.
+- **Risk: the catalog grows into executable grammars.** → Keep reusable
+  binding categories small and add entries only from observed, tested cases.
+- **Trade-off: dynamic `tr` values may still prompt.** → Unknown remains strict
+  until bounded transformation proof exists.
+
+## Migration Plan
+
+1. Publish the additive ShellSyntaxTree package after API, corpus, Linux, and
+   native Windows validation.
+2. Upgrade Netclaw and consume the new fact in typed path projection only.
+3. Run the exact live-derived approval fixture and full policy matrix.
+4. Binary-swap the merged Netclaw build and harvest another traffic window.
+
+Rollback removes the Netclaw consumer branch first, then restores the prior
+package. Existing consumers ignore the additive property.
+
+## Open Questions
+
+- Which later observed commands justify additional audited non-filesystem
+  entries? No command beyond `tr` is required for this slice.

--- a/openspec/changes/publish-authored-operand-semantics/proposal.md
+++ b/openspec/changes/publish-authored-operand-semantics/proposal.md
@@ -1,0 +1,42 @@
+## Why
+
+ShellSyntaxTree exposes positive local-filesystem facts but cannot prove that
+path-shaped text is non-filesystem data. Netclaw therefore prompts for reviewed
+diagnostics such as `tr -d '\n'`, even though the operand is transform data.
+
+## What Changes
+
+- Add one additive authored non-filesystem value domain with an unknown
+  default.
+- Distinguish audited local-filesystem operands from audited non-filesystem
+  data without changing compatibility `IsPath` behavior.
+- Extend the parser-owned binding catalog with bounded, full-shape data
+  entries, beginning with Bash `tr` translation operands.
+- Keep unknown, dynamic, executable, remote, relational, and unaudited
+  operands strict.
+- Add direct, corpus, consumer-guide, and downstream Netclaw regressions for
+  the observed `tr -d '\n'` approval case.
+
+## Capabilities
+
+### New Capabilities
+
+- `authored-operand-semantics`: Publish audited filesystem-versus-data
+  semantics independently from lexical shape and bounded value domains.
+
+### Modified Capabilities
+
+None.
+
+## Impact
+
+- Public API: one additive `AnalyzedArgument` property using the existing
+  closed `ShellValueDomain` family.
+  Generated record equality, hashing, `ToString()`, reflection, and default
+  serialization include the property.
+- Parser internals: the audited binder catalog gains non-filesystem data
+  bindings without changing broad compatibility tables.
+- Package: intended as additive ShellSyntaxTree 0.3.5 behavior.
+- Consumer: Netclaw may skip compatibility and lexical local-path checks only
+  for the exact argument carrying an audited non-filesystem value. Command
+  effects, redirects, completeness, and every unknown fact retain their checks.

--- a/openspec/changes/publish-authored-operand-semantics/specs/authored-operand-semantics/spec.md
+++ b/openspec/changes/publish-authored-operand-semantics/specs/authored-operand-semantics/spec.md
@@ -1,0 +1,175 @@
+## ADDED Requirements
+
+### Requirement: Authored non-filesystem value projection
+
+`AnalyzedArgument` SHALL expose an additive
+`AuthoredNonFileSystemValue` property using `ShellValueDomain`. The default
+SHALL be `Unknown`.
+
+#### Scenario: Default remains fail closed
+
+- **WHEN** no audited non-filesystem binding applies
+- **THEN** `AuthoredNonFileSystemValue` is `Unknown`
+
+#### Scenario: Positive bounded data value
+
+- **WHEN** an audited non-filesystem binding and complete provenance prove one
+  authored value
+- **THEN** `AuthoredNonFileSystemValue` is `Exact`
+
+#### Scenario: Positive finite data values
+
+- **WHEN** every reachable visit proves the same audited non-filesystem slot
+  with two through 32 distinct bounded values
+- **THEN** `AuthoredNonFileSystemValue` is their `FiniteSet`
+
+#### Scenario: Unsupported domain stays unknown
+
+- **WHEN** the value is unbounded, actively glob-expanded, incomplete, or over
+  the fixed candidate limit
+- **THEN** `AuthoredNonFileSystemValue` is `Unknown`
+
+### Requirement: Independent authored facts
+
+The parser SHALL keep authored value, lexical path shape, local-filesystem
+value, and non-filesystem value as independent facts. One argument SHALL NOT
+publish positive filesystem and non-filesystem domains together.
+
+#### Scenario: Path-shaped data retains lexical evidence
+
+- **WHEN** Bash parses the exact single-quoted translation set `\n`
+- **THEN** `AuthoredPathShape` remains `Windows`
+- **AND** an audited `tr` binding publishes
+  `AuthoredNonFileSystemValue=Exact("\\n")`
+
+#### Scenario: Filesystem operand remains distinct
+
+- **WHEN** Bash parses `cat README.md` with an exact cwd
+- **THEN** `AuthoredFileSystemValue` is the normalized exact path
+- **AND** `AuthoredNonFileSystemValue` is `Unknown`
+
+#### Scenario: Impossible positive pairing fails closed
+
+- **WHEN** internal projection supplies positive filesystem and
+  non-filesystem domains for one argument
+- **THEN** the authorization projection is rejected atomically
+
+### Requirement: Audited non-filesystem binding catalog
+
+A positive non-filesystem domain SHALL require a parser-owned audited binding
+covering every accepted argument shape. Compatibility tables, lexical shape,
+and command spelling alone SHALL NOT supply the fact.
+
+#### Scenario: Bash tr translation set is data
+
+- **WHEN** Bash parses `tr -d '\n'`
+- **THEN** the translation set has
+  `AuthoredNonFileSystemValue=Exact("\\n")`
+
+#### Scenario: Ordinary tr operands remain arguments
+
+- **WHEN** Bash parses `tr abc def`
+- **THEN** the verb chain is exactly `tr`
+- **AND** `abc` and `def` are analyzed non-filesystem arguments
+
+#### Scenario: Path-looking tr translation set remains data
+
+- **WHEN** Bash parses `tr -d '/etc/passwd'`
+- **THEN** the translation set has
+  `AuthoredNonFileSystemValue=Exact("/etc/passwd")`
+- **AND** it has no positive `AuthoredFileSystemValue`
+
+#### Scenario: Active tr glob stays unknown
+
+- **WHEN** Bash parses `tr -d *.txt`
+- **THEN** the active glob has `AuthoredNonFileSystemValue=Unknown`
+
+#### Scenario: Tr redirect remains independent
+
+- **WHEN** Bash parses `tr -d '\n' > /outside/result`
+- **THEN** the translation set retains its non-filesystem value
+- **AND** the output redirect remains a path-relevant file redirect
+
+#### Scenario: Unknown executable does not inherit tr semantics
+
+- **WHEN** Bash parses `tool '\n'`
+- **THEN** the argument has `AuthoredNonFileSystemValue=Unknown`
+
+#### Scenario: Hidden option path remains unknown data
+
+- **WHEN** Bash parses `grep -f /outside/patterns input.txt`
+- **THEN** the option value has `AuthoredNonFileSystemValue=Unknown`
+
+#### Scenario: PowerShell default remains unknown
+
+- **WHEN** PowerShell parses path-shaped native or cmdlet data without a
+  positive binder from this slice
+- **THEN** `AuthoredNonFileSystemValue` is `Unknown`
+
+### Requirement: Tr compatibility path correction
+
+The Bash compatibility projection SHALL keep `tr` as one verb token and
+classify every positional translation operand as non-path data. Generic path
+heuristics SHALL remain unchanged for unknown commands.
+
+#### Scenario: Backslash translation set is not a compatibility path
+
+- **WHEN** Bash parses `tr -d '\n'` with cwd `/work`
+- **THEN** the translation argument has `IsPath=false`
+- **AND** its compatibility `Resolved` value is null
+
+#### Scenario: Plain translation sets do not extend the verb chain
+
+- **WHEN** Bash parses `tr abc def`
+- **THEN** `Clause.Verb.Tokens` contains only `tr`
+- **AND** both remaining tokens are compatibility arguments
+
+#### Scenario: Unknown command keeps conservative compatibility
+
+- **WHEN** Bash parses `tool '\n'` with cwd `/work`
+- **THEN** the generic path heuristic retains its current path classification
+
+### Requirement: Consumer use remains path-specific
+
+A consumer SHALL NOT omit compatibility or lexical local-path evaluation
+unless the same argument's `AuthoredNonFileSystemValue` is `Exact` or
+`FiniteSet`. The consumer SHALL retain every command, completeness, effect,
+cwd, redirect, raw protected-path, and occurrence check.
+
+#### Scenario: Reviewed tr diagnostic no longer creates n scope
+
+- **WHEN** Netclaw evaluates the sanitized live diagnostic containing
+  `gh run view ... | tr -d '\n'` under the project cwd
+- **THEN** the `tr` argument creates no child `n` directory scope
+- **AND** reviewed-safe coverage may apply only after all independent facts
+  pass
+
+#### Scenario: File-writing redirect remains strict
+
+- **WHEN** Netclaw evaluates `tr -d '\n' > /outside/result`
+- **THEN** the non-filesystem argument does not suppress redirect policy
+- **AND** the outside output remains strict
+
+#### Scenario: Unknown semantics remain strict
+
+- **WHEN** a path-shaped argument has
+  `AuthoredNonFileSystemValue=Unknown`
+- **THEN** the consumer retains its ordinary lexical-path policy
+
+### Requirement: Compatibility and package boundary
+
+The change SHALL be additive to public 0.3.4. Existing members, constructors,
+and parser entry points SHALL remain unchanged.
+
+#### Scenario: Public API comparison
+
+- **WHEN** both target frameworks are compared with public 0.3.4
+- **THEN** the only public API addition is
+  `AnalyzedArgument.AuthoredNonFileSystemValue`
+- **AND** no existing signature is removed or changed
+
+#### Scenario: Generated record behavior
+
+- **WHEN** consumers use generated equality, hashing, `ToString()`, reflection,
+  or default serialization
+- **THEN** the additive property participates in those generated behaviors

--- a/openspec/changes/publish-authored-operand-semantics/tasks.md
+++ b/openspec/changes/publish-authored-operand-semantics/tasks.md
@@ -1,0 +1,57 @@
+## 1. Public Contract
+
+- [ ] 1.1 Add `AuthoredNonFileSystemValue` to `SPEC.md`, source, defaults, and
+  exact public API snapshots.
+- [ ] 1.2 Document the independent authored-value, lexical-shape,
+  filesystem-value, and non-filesystem-value invariants.
+- [ ] 1.3 Add equality, hashing, `ToString()`, reflection, default serializer,
+  and corruption-boundary tests.
+
+## 2. Audited Operand Projection
+
+- [ ] 2.1 Generalize the internal audited operand catalog and projector without
+  duplicating filesystem and non-filesystem binding logic.
+- [ ] 2.2 Preserve the existing Bash `cat` and PowerShell `Get-Content
+  -LiteralPath` filesystem projections exactly.
+- [ ] 2.3 Add the Bash `tr` all-argument non-filesystem binding with bounded
+  provenance and value-domain checks.
+- [ ] 2.4 Reject positive filesystem and non-filesystem domains on the same
+  argument before publishing an occurrence.
+- [ ] 2.5 Route the `tr` audited entry into single-token verb extraction and
+  compatibility non-path classification while retaining generic heuristics.
+
+## 3. Parser and Corpus Coverage
+
+- [ ] 3.1 Add direct cases for `tr abc def`, `tr -d '\n'`, path-looking
+  translation data, active globs, dynamic values, substitutions, and redirects.
+- [ ] 3.2 Add adversarial cases for unknown commands, `grep -f`, cat paths,
+  option-like translation values, and over-limit joins.
+- [ ] 3.3 Add the sanitized Bash executable-corpus entry with exact clauses,
+  elements, occurrences, authored facts, and no PII.
+- [ ] 3.4 Add PowerShell default-unknown and cross-shell API consistency cases.
+
+## 4. Consumer Integration
+
+- [ ] 4.1 Update the consumer guide with the exact path-specific use rule and
+  independent redirect/effect checks.
+- [ ] 4.2 Upgrade Netclaw's typed path-fact projection to omit compatibility
+  and lexical path facts only for positive non-filesystem values.
+- [ ] 4.3 Add the sanitized live `gh run view | tr -d '\n'` coordinator fixture
+  and assert no child `n` scope.
+- [ ] 4.4 Retain strict Netclaw outcomes for unknown semantics, hidden option
+  paths, output redirects, dynamic commands, and incomplete occurrences.
+- [ ] 4.5 Record shell-authored file writes as agent-alignment corpus cases;
+  do not widen `cat`, heredoc, `tee`, or redirect authority.
+
+## 5. Release and Live Validation
+
+- [ ] 5.1 Update `IMPLEMENTATION_PLAN.md` and release notes with the bounded
+  0.3.5 behavior and unchanged public signatures.
+- [ ] 5.2 Run Release build, full unit and corpus suite, PII audit, headers,
+  Slopwatch, package validation, and 0.3.4 API comparison.
+- [ ] 5.3 Run Linux and native Windows CI plus an independent adversarial
+  security review before publication.
+- [ ] 5.4 Publish the package, consume the exact public version in Netclaw, and
+  run its complete policy and cross-platform gates.
+- [ ] 5.5 Binary-swap the merged Netclaw build and classify another live
+  traffic window before claiming approval-fatigue improvement.


### PR DESCRIPTION
## Why

Live Netclaw traffic parsed `tr -d '\n'` as a path under the project, producing a false `/n` approval scope. ShellSyntaxTree can prove local filesystem values, but cannot prove audited non-filesystem data.

## Scope

- Propose one additive `AuthoredNonFileSystemValue` domain.
- Keep `Unknown` strict.
- Use one audited `tr` entry for single-token identity and non-path operands.
- Preserve raw protected-path, redirect, effect, and completeness checks.
- Keep shell-authored file writes outside this policy change.

## Validation

- `openspec validate publish-authored-operand-semantics --strict`
- `git diff --check`
- Native syscall probe confirmed `tr` reads stdin and does not open translation-set operands.

Production implementation and downstream Netclaw consumption remain separate bounded slices.