### PR TITLE
Publish authored non-filesystem operand facts

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -100,12 +100,18 @@ priorities.
       `0.3.4` completed release workflow run 31728782396 and published the
       package, symbols, and non-prerelease GitHub release. Netclaw consumed the
       exact public package and completed its causal-directory acceptance slice.
-- [ ] **Approve authored non-filesystem value facts for v0.3.5.** Live Netclaw
+- [x] **Approve authored non-filesystem value facts for v0.3.5.** Live Netclaw
       traffic exposed `tr -d '\n'` as a false local-path scope ending in `/n`.
-      The `publish-authored-operand-semantics` OpenSpec proposes one additive
+      The `publish-authored-operand-semantics` OpenSpec defines one additive
       value-domain property, one audited `tr` data binding, a single-token
-      compatibility correction, and a strict consumer boundary. Complete
-      adversarial review before implementation.
+      compatibility correction, and a strict consumer boundary. PR #167 merged
+      the contract after strict OpenSpec plus Linux and Windows CI passed.
+- [ ] **Implement and publish v0.3.5 authored non-filesystem facts.** Add the
+      approved property and generalized audited operand projection. Preserve
+      the existing `cat` and `Get-Content -LiteralPath` facts. Pin direct,
+      corpus, API, PowerShell, redirect, dynamic, and over-limit boundaries.
+      Complete adversarial review, package comparison, native Windows CI,
+      publication, and downstream Netclaw acceptance before completion.
 
 ## Completed v0.3.0 host integration and release acceptance
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,30 @@
 #### Unreleased ####
 
+## Added
+
+- Add `AnalyzedArgument.AuthoredNonFileSystemValue`. The non-null default is
+  `Unknown`; positive `Exact` and `FiniteSet` values require an audited operand
+  binding.
+- Add one audited Bash `tr` entry. It proves bounded options and translation
+  sets are non-filesystem data.
+
+## Fixed
+
+- Keep `tr` as a single-token command identity, so `tr abc def` retains both
+  arguments.
+- Stop classifying the quoted `\n` translation set as a compatibility path
+  that resolves to a false `n` child scope.
+
+## Security and compatibility
+
+- Keep `AuthoredPathShape` independent. The exact `\n` word remains
+  Windows-shaped lexical evidence.
+- Let consumers omit only the same argument's broad compatibility path facts
+  after a positive non-filesystem proof.
+- Preserve redirects, substitutions, command effects, completeness, working
+  directories, and every other argument as independent policy inputs.
+- Preserve every 0.3.4 public signature. The new property is additive.
+
 #### 0.3.4 2026-08-13 ####
 
 This additive release publishes parser-owned working-directory effects for

--- a/SPEC.md
+++ b/SPEC.md
@@ -651,6 +651,8 @@ public sealed record AnalyzedArgument
     public ShellValueDomain AuthoredValue { get; internal init; } = null!;
     public ShellValueDomain AuthoredFileSystemValue { get; internal init; } =
         new ShellValueDomain.Unknown();
+    public ShellValueDomain AuthoredNonFileSystemValue { get; internal init; } =
+        new ShellValueDomain.Unknown();
     public ShellPathShape AuthoredPathShape { get; internal init; }
 }
 
@@ -913,6 +915,27 @@ contract, check every represented path through their own path policy, and
 independently evaluate executable identity, redirects, substitutions,
 ancestry, and all other occurrences. `AuthoredValue`, `AuthoredPathShape`, and
 compatibility `IsPath` are not substitutes for this fact.
+
+`AnalyzedArgument.AuthoredNonFileSystemValue` is a separate positive parser
+fact for bounded authored values that an audited binding proves are not local-
+filesystem operands. `Unknown` combines unaudited semantics and values whose
+non-filesystem role is not proved. In v0.3.5, only `Exact` and `FiniteSet` are
+positive. The fact retains the authored value and does not alter lexical path
+shape. One argument never has positive filesystem and non-filesystem domains.
+
+The initial non-filesystem catalog contains all Bash `tr` arguments. These
+arguments are options or translation data; `tr` reads standard input and writes
+standard output. The same catalog entry keeps `tr` as a single-token command
+identity and classifies its arguments as compatibility non-path data. Active
+field splitting, pathname expansion, command substitution, dynamic identity,
+over-limit joins, and incomplete provenance remain `Unknown` or incomplete.
+
+A positive authored non-filesystem value permits a consumer to omit only the
+same argument's compatibility and lexical local-path interpretations. It does
+not prove that the command is safe or read-only. Redirects, command effects,
+substitutions, ancestry, completeness, working directory, and every other
+argument remain independent. Unknown commands and unknown future domains stay
+strict.
 
 #### Bash bounded loop state
 

--- a/docs/CONSUMER_GUIDE.md
+++ b/docs/CONSUMER_GUIDE.md
@@ -656,6 +656,50 @@ compatibility path bit or slash characters are not enough:
 | `scp user@example.invalid:/srv/file .` | `Unknown` for the remote endpoint | Remote syntax is not a local filesystem path. |
 | `show /api/v1` | `Unknown` | Path-shaped data has no audited binding. |
 
+An audited non-filesystem value can contradict only broad path heuristics for
+the same argument. It does not erase any other command fact. For example:
+
+```bash
+tr -d '\n'
+```
+
+projects the second argument as:
+
+```text
+AuthoredValue:                 Exact("\n")
+AuthoredPathShape:             Windows
+AuthoredFileSystemValue:       Unknown
+AuthoredNonFileSystemValue:    Exact("\n")
+```
+
+The lexical shape is still truthful. The audited `tr` binding proves that this
+specific value is translation data, so a consumer need not turn that shape or
+the compatibility `IsPath` bit into a local path candidate:
+
+```csharp
+static bool RequiresCompatibilityPathCheck(AnalyzedArgument argument)
+{
+    if (argument.AuthoredFileSystemValue is not ShellValueDomain.Unknown)
+    {
+        return true;
+    }
+
+    return argument.AuthoredNonFileSystemValue switch
+    {
+        ShellValueDomain.Exact => false,
+        ShellValueDomain.FiniteSet => false,
+        ShellValueDomain.Unknown => true,
+        _ => true,
+    };
+}
+```
+
+Fail closed if both authored semantic domains are positive. A positive
+non-filesystem value does not relax output redirects, command substitutions,
+dynamic identity, incomplete occurrences, working-directory policy, command
+effects, or other arguments. Thus `tr -d '\n' > /outside/result` still sends
+the redirect target through path policy.
+
 PowerShell uses the same public property and the selected dialect's argument
 binding. For example:
 

--- a/openspec/changes/publish-authored-operand-semantics/tasks.md
+++ b/openspec/changes/publish-authored-operand-semantics/tasks.md
@@ -1,38 +1,38 @@
 ## 1. Public Contract
 
-- [ ] 1.1 Add `AuthoredNonFileSystemValue` to `SPEC.md`, source, defaults, and
+- [x] 1.1 Add `AuthoredNonFileSystemValue` to `SPEC.md`, source, defaults, and
   exact public API snapshots.
-- [ ] 1.2 Document the independent authored-value, lexical-shape,
+- [x] 1.2 Document the independent authored-value, lexical-shape,
   filesystem-value, and non-filesystem-value invariants.
-- [ ] 1.3 Add equality, hashing, `ToString()`, reflection, default serializer,
+- [x] 1.3 Add equality, hashing, `ToString()`, reflection, default serializer,
   and corruption-boundary tests.
 
 ## 2. Audited Operand Projection
 
-- [ ] 2.1 Generalize the internal audited operand catalog and projector without
+- [x] 2.1 Generalize the internal audited operand catalog and projector without
   duplicating filesystem and non-filesystem binding logic.
-- [ ] 2.2 Preserve the existing Bash `cat` and PowerShell `Get-Content
+- [x] 2.2 Preserve the existing Bash `cat` and PowerShell `Get-Content
   -LiteralPath` filesystem projections exactly.
-- [ ] 2.3 Add the Bash `tr` all-argument non-filesystem binding with bounded
+- [x] 2.3 Add the Bash `tr` all-argument non-filesystem binding with bounded
   provenance and value-domain checks.
-- [ ] 2.4 Reject positive filesystem and non-filesystem domains on the same
+- [x] 2.4 Reject positive filesystem and non-filesystem domains on the same
   argument before publishing an occurrence.
-- [ ] 2.5 Route the `tr` audited entry into single-token verb extraction and
+- [x] 2.5 Route the `tr` audited entry into single-token verb extraction and
   compatibility non-path classification while retaining generic heuristics.
 
 ## 3. Parser and Corpus Coverage
 
-- [ ] 3.1 Add direct cases for `tr abc def`, `tr -d '\n'`, path-looking
+- [x] 3.1 Add direct cases for `tr abc def`, `tr -d '\n'`, path-looking
   translation data, active globs, dynamic values, substitutions, and redirects.
-- [ ] 3.2 Add adversarial cases for unknown commands, `grep -f`, cat paths,
+- [x] 3.2 Add adversarial cases for unknown commands, `grep -f`, cat paths,
   option-like translation values, and over-limit joins.
-- [ ] 3.3 Add the sanitized Bash executable-corpus entry with exact clauses,
+- [x] 3.3 Add the sanitized Bash executable-corpus entry with exact clauses,
   elements, occurrences, authored facts, and no PII.
-- [ ] 3.4 Add PowerShell default-unknown and cross-shell API consistency cases.
+- [x] 3.4 Add PowerShell default-unknown and cross-shell API consistency cases.
 
 ## 4. Consumer Integration
 
-- [ ] 4.1 Update the consumer guide with the exact path-specific use rule and
+- [x] 4.1 Update the consumer guide with the exact path-specific use rule and
   independent redirect/effect checks.
 - [ ] 4.2 Upgrade Netclaw's typed path-fact projection to omit compatibility
   and lexical path facts only for positive non-filesystem values.
@@ -45,9 +45,9 @@
 
 ## 5. Release and Live Validation
 
-- [ ] 5.1 Update `IMPLEMENTATION_PLAN.md` and release notes with the bounded
+- [x] 5.1 Update `IMPLEMENTATION_PLAN.md` and release notes with the bounded
   0.3.5 behavior and unchanged public signatures.
-- [ ] 5.2 Run Release build, full unit and corpus suite, PII audit, headers,
+- [x] 5.2 Run Release build, full unit and corpus suite, PII audit, headers,
   Slopwatch, package validation, and 0.3.4 API comparison.
 - [ ] 5.3 Run Linux and native Windows CI plus an independent adversarial
   security review before publication.

--- a/src/ShellSyntaxTree/CommandOccurrence.cs
+++ b/src/ShellSyntaxTree/CommandOccurrence.cs
@@ -224,6 +224,13 @@ public sealed record AnalyzedArgument
     public ShellValueDomain AuthoredFileSystemValue { get; internal init; } =
         new ShellValueDomain.Unknown();
 
+    /// <summary>
+    /// Gets bounded values proved to be non-filesystem data from this authored
+    /// argument. This parser fact does not grant authority.
+    /// </summary>
+    public ShellValueDomain AuthoredNonFileSystemValue { get; internal init; } =
+        new ShellValueDomain.Unknown();
+
     /// <summary>Gets the authored word's uniform lexical path shape.</summary>
     public ShellPathShape AuthoredPathShape { get; internal init; }
 

--- a/src/ShellSyntaxTree/Internal/Bash/Parsing/BashCommandParser.cs
+++ b/src/ShellSyntaxTree/Internal/Bash/Parsing/BashCommandParser.cs
@@ -554,8 +554,12 @@ internal static partial class BashCommandParser
         BashVerbs.FlagsWithValue.TryGetValue(firstVerb ?? string.Empty, out var flagsForVerb);
         var fileVerbCarveout = firstVerb is not null
             && BashVerbs.FileVerbs.Contains(firstVerb);
+        var auditedSingleTokenVerb = firstVerb is not null &&
+            AuditedOperandBindingCatalog.StopsVerbChain(
+                ShellProjectionLanguage.Bash,
+                firstVerb);
 
-        if (firstVerb is not null)
+        if (firstVerb is not null && !auditedSingleTokenVerb)
         {
             for (var i = 1; i < segment.Tokens.Count; i++)
             {

--- a/src/ShellSyntaxTree/Internal/Bash/Verbs/BashPerVerbRules.cs
+++ b/src/ShellSyntaxTree/Internal/Bash/Verbs/BashPerVerbRules.cs
@@ -83,7 +83,23 @@ internal static class BashPerVerbRules
     /// <param name="positionalIndex">0-based positional index among non-flag args.</param>
     /// <param name="token">The token text itself (used for the LooksLikePath fallback).</param>
     /// <returns>True when this slot is a path; false otherwise.</returns>
-    internal static bool IsPositionalPathArg(VerbChain verb, int positionalIndex, string token)
+    internal static bool IsPositionalPathArg(
+        VerbChain verb,
+        int positionalIndex,
+        string token) =>
+        IsPositionalPathArg(verb, positionalIndex, token, useBashAuditedSemantics: true);
+
+    internal static bool IsNativePositionalPathArg(
+        VerbChain verb,
+        int positionalIndex,
+        string token) =>
+        IsPositionalPathArg(verb, positionalIndex, token, useBashAuditedSemantics: false);
+
+    private static bool IsPositionalPathArg(
+        VerbChain verb,
+        int positionalIndex,
+        string token,
+        bool useBashAuditedSemantics)
     {
         if (verb is null || verb.Tokens is null || verb.Tokens.Count == 0)
         {
@@ -93,6 +109,14 @@ internal static class BashPerVerbRules
         }
 
         var firstVerb = verb.Tokens[0];
+
+        if (useBashAuditedSemantics &&
+            AuditedOperandBindingCatalog.ClassifiesAllArgumentsAsNonFileSystem(
+                ShellProjectionLanguage.Bash,
+                firstVerb))
+        {
+            return false;
+        }
 
         // Explicit override first (chmod / find / curl / ...).
         if (Overrides.TryGetValue(firstVerb, out var rule))

--- a/src/ShellSyntaxTree/Internal/Pwsh/Parsing/PwshCommandParser.cs
+++ b/src/ShellSyntaxTree/Internal/Pwsh/Parsing/PwshCommandParser.cs
@@ -1422,7 +1422,10 @@ internal static partial class PwshCommandParser
             {
                 treatAsPath = cmdletStyle
                     ? PwshPerVerbRules.IsPositionalPathArg(canonical, isFileVerb, positionalIndex, t.Value)
-                    : BashPerVerbRules.IsPositionalPathArg(nativeVerbChain, positionalIndex, t.Value);
+                    : BashPerVerbRules.IsNativePositionalPathArg(
+                        nativeVerbChain,
+                        positionalIndex,
+                        t.Value);
                 if (cmdletStyle && treatAsPath)
                 {
                     consumer = ShellResolutionConsumer.PowerShellCmdletPath;

--- a/src/ShellSyntaxTree/Internal/Pwsh/Parsing/PwshForEachValueAnalysis.cs
+++ b/src/ShellSyntaxTree/Internal/Pwsh/Parsing/PwshForEachValueAnalysis.cs
@@ -5350,7 +5350,7 @@ internal sealed class PwshForEachValueAnalyzer
                             PwshVerbs.FileVerbs.Contains(canonicalVerb!),
                         positionalIndex,
                         element.Value)
-                    : BashPerVerbRules.IsPositionalPathArg(
+                    : BashPerVerbRules.IsNativePositionalPathArg(
                         clause.Verb,
                         positionalIndex,
                         element.Value);

--- a/src/ShellSyntaxTree/Internal/Resolving/AuthoredOperandSemanticsProjection.cs
+++ b/src/ShellSyntaxTree/Internal/Resolving/AuthoredOperandSemanticsProjection.cs
@@ -1,5 +1,5 @@
 // -----------------------------------------------------------------------
-// <copyright file="AuthoredFileSystemValueProjection.cs" company="Aaron Stannard">
+// <copyright file="AuthoredOperandSemanticsProjection.cs" company="Aaron Stannard">
 //      Copyright (C) 2026 - 2026 Aaron Stannard <https://github.com/Aaronontheweb>
 // </copyright>
 // -----------------------------------------------------------------------
@@ -8,23 +8,37 @@ using System.Collections.Generic;
 
 namespace ShellSyntaxTree.Internal.Resolving;
 
-internal enum AuditedFileSystemBindingCategory
+internal enum AuditedOperandBindingCategory
 {
     Unknown,
     AllNonOptionOperands,
     ExactNamedParameterValue,
+    AllArguments,
 }
 
-internal sealed class AuthoredFileSystemBindingCatalogEntry
+internal enum AuditedOperandSemantic
 {
-    internal AuthoredFileSystemBindingCatalogEntry(
+    Unknown,
+    LocalFileSystem,
+    NonFileSystem,
+}
+
+internal readonly record struct AuditedOperandBinding(
+    AuditedOperandBindingCategory Category,
+    AuditedOperandSemantic Semantic);
+
+internal sealed class AuditedOperandBindingCatalogEntry
+{
+    internal AuditedOperandBindingCatalogEntry(
         ShellProjectionLanguage language,
         string canonicalVerb,
         StringComparison verbComparison,
-        AuditedFileSystemBindingCategory category,
-        string? parameterName = null)
+        AuditedOperandBindingCategory category,
+        AuditedOperandSemantic semantic,
+        string? parameterName = null,
+        bool stopsVerbChain = false)
     {
-        if (category == AuditedFileSystemBindingCategory.ExactNamedParameterValue &&
+        if (category == AuditedOperandBindingCategory.ExactNamedParameterValue &&
             string.IsNullOrEmpty(parameterName))
         {
             throw new ArgumentException(
@@ -32,7 +46,7 @@ internal sealed class AuthoredFileSystemBindingCatalogEntry
                 nameof(parameterName));
         }
 
-        if (category != AuditedFileSystemBindingCategory.ExactNamedParameterValue &&
+        if (category != AuditedOperandBindingCategory.ExactNamedParameterValue &&
             parameterName != null)
         {
             throw new ArgumentException(
@@ -40,11 +54,21 @@ internal sealed class AuthoredFileSystemBindingCatalogEntry
                 nameof(parameterName));
         }
 
+        if (semantic == AuditedOperandSemantic.Unknown ||
+            category == AuditedOperandBindingCategory.Unknown)
+        {
+            throw new ArgumentException(
+                "An audited binding requires a known category and semantic.",
+                nameof(semantic));
+        }
+
         Language = language;
         CanonicalVerb = canonicalVerb;
         VerbComparison = verbComparison;
         Category = category;
+        Semantic = semantic;
         ParameterName = parameterName;
+        StopsVerbChain = stopsVerbChain;
     }
 
     internal ShellProjectionLanguage Language { get; }
@@ -53,39 +77,52 @@ internal sealed class AuthoredFileSystemBindingCatalogEntry
 
     internal StringComparison VerbComparison { get; }
 
-    internal AuditedFileSystemBindingCategory Category { get; }
+    internal AuditedOperandBindingCategory Category { get; }
+
+    internal AuditedOperandSemantic Semantic { get; }
 
     internal string? ParameterName { get; }
+
+    internal bool StopsVerbChain { get; }
 }
 
 /// <summary>
-/// Owns the deliberately small catalog whose entries prove local-filesystem
-/// argument semantics. Compatibility path tables do not feed this catalog.
+/// Owns the deliberately small catalog whose entries prove audited operand
+/// semantics. Compatibility path tables do not feed this catalog.
 /// </summary>
-internal static class AuthoredFileSystemBindingCatalog
+internal static class AuditedOperandBindingCatalog
 {
-    private static readonly IReadOnlyList<AuthoredFileSystemBindingCatalogEntry> Entries =
+    private static readonly IReadOnlyList<AuditedOperandBindingCatalogEntry> Entries =
         new[]
         {
-            new AuthoredFileSystemBindingCatalogEntry(
+            new AuditedOperandBindingCatalogEntry(
                 ShellProjectionLanguage.Bash,
                 "cat",
                 StringComparison.Ordinal,
-                AuditedFileSystemBindingCategory.AllNonOptionOperands),
-            new AuthoredFileSystemBindingCatalogEntry(
+                AuditedOperandBindingCategory.AllNonOptionOperands,
+                AuditedOperandSemantic.LocalFileSystem),
+            new AuditedOperandBindingCatalogEntry(
                 ShellProjectionLanguage.PowerShell,
                 "Get-Content",
                 StringComparison.OrdinalIgnoreCase,
-                AuditedFileSystemBindingCategory.ExactNamedParameterValue,
+                AuditedOperandBindingCategory.ExactNamedParameterValue,
+                AuditedOperandSemantic.LocalFileSystem,
                 "-LiteralPath"),
+            new AuditedOperandBindingCatalogEntry(
+                ShellProjectionLanguage.Bash,
+                "tr",
+                StringComparison.Ordinal,
+                AuditedOperandBindingCategory.AllArguments,
+                AuditedOperandSemantic.NonFileSystem,
+                stopsVerbChain: true),
         };
 
-    internal static IReadOnlyList<AuditedFileSystemBindingCategory> Bind(
+    internal static IReadOnlyList<AuditedOperandBinding> Bind(
         ShellProjectionLanguage language,
         Clause clause,
         IReadOnlyList<AnalyzedArgument> arguments)
     {
-        var bindings = new AuditedFileSystemBindingCategory[arguments.Count];
+        var bindings = new AuditedOperandBinding[arguments.Count];
         if (clause.Verb.IsDynamic || clause.Verb.Tokens.Count != 1)
         {
             return bindings;
@@ -109,39 +146,62 @@ internal static class AuthoredFileSystemBindingCatalog
         return bindings;
     }
 
-    internal static IReadOnlyList<AuditedFileSystemBindingCategory> Bind(
-        AuthoredFileSystemBindingCatalogEntry entry,
+    internal static IReadOnlyList<AuditedOperandBinding> Bind(
+        AuditedOperandBindingCatalogEntry entry,
         IReadOnlyList<AnalyzedArgument> arguments)
     {
-        var bindings = new AuditedFileSystemBindingCategory[arguments.Count];
+        var bindings = new AuditedOperandBinding[arguments.Count];
         return entry.Category switch
         {
-            AuditedFileSystemBindingCategory.AllNonOptionOperands =>
-                BindAllNonOptionOperands(bindings),
-            AuditedFileSystemBindingCategory.ExactNamedParameterValue =>
+            AuditedOperandBindingCategory.AllNonOptionOperands =>
+                BindAllNonOptionOperands(bindings, entry),
+            AuditedOperandBindingCategory.ExactNamedParameterValue =>
                 BindExactNamedParameterValue(
                     arguments,
                     bindings,
-                    entry.ParameterName!),
+                    entry),
+            AuditedOperandBindingCategory.AllArguments =>
+                BindAllArguments(bindings, entry),
             _ => bindings,
         };
     }
 
-    private static IReadOnlyList<AuditedFileSystemBindingCategory> BindAllNonOptionOperands(
-        AuditedFileSystemBindingCategory[] bindings)
+    internal static bool StopsVerbChain(
+        ShellProjectionLanguage language,
+        string canonicalVerb)
+    {
+        var entry = Find(language, canonicalVerb);
+        return entry is not null && entry.StopsVerbChain;
+    }
+
+    internal static bool ClassifiesAllArgumentsAsNonFileSystem(
+        ShellProjectionLanguage language,
+        string canonicalVerb)
+    {
+        var entry = Find(language, canonicalVerb);
+        return entry is
+        {
+            Category: AuditedOperandBindingCategory.AllArguments,
+            Semantic: AuditedOperandSemantic.NonFileSystem,
+        };
+    }
+
+    private static IReadOnlyList<AuditedOperandBinding> BindAllNonOptionOperands(
+        AuditedOperandBinding[] bindings,
+        AuditedOperandBindingCatalogEntry entry)
     {
         for (var index = 0; index < bindings.Length; index++)
         {
-            bindings[index] = AuditedFileSystemBindingCategory.AllNonOptionOperands;
+            bindings[index] = new AuditedOperandBinding(entry.Category, entry.Semantic);
         }
 
         return bindings;
     }
 
-    private static IReadOnlyList<AuditedFileSystemBindingCategory> BindExactNamedParameterValue(
+    private static IReadOnlyList<AuditedOperandBinding> BindExactNamedParameterValue(
         IReadOnlyList<AnalyzedArgument> arguments,
-        AuditedFileSystemBindingCategory[] bindings,
-        string parameterName)
+        AuditedOperandBinding[] bindings,
+        AuditedOperandBindingCatalogEntry entry)
     {
         var expectsValue = false;
         for (var index = 0; index < arguments.Count; index++)
@@ -151,7 +211,9 @@ internal static class AuthoredFileSystemBindingCatalog
             {
                 if (!argument.Argument.IsFlag)
                 {
-                    bindings[index] = AuditedFileSystemBindingCategory.ExactNamedParameterValue;
+                    bindings[index] = new AuditedOperandBinding(
+                        entry.Category,
+                        entry.Semantic);
                 }
 
                 expectsValue = false;
@@ -159,7 +221,7 @@ internal static class AuthoredFileSystemBindingCatalog
 
             if (argument.Argument.IsFlag && string.Equals(
                     argument.Argument.Raw,
-                    parameterName,
+                    entry.ParameterName!,
                     StringComparison.OrdinalIgnoreCase))
             {
                 expectsValue = true;
@@ -168,13 +230,41 @@ internal static class AuthoredFileSystemBindingCatalog
 
         return bindings;
     }
+
+    private static IReadOnlyList<AuditedOperandBinding> BindAllArguments(
+        AuditedOperandBinding[] bindings,
+        AuditedOperandBindingCatalogEntry entry)
+    {
+        for (var index = 0; index < bindings.Length; index++)
+        {
+            bindings[index] = new AuditedOperandBinding(entry.Category, entry.Semantic);
+        }
+
+        return bindings;
+    }
+
+    private static AuditedOperandBindingCatalogEntry? Find(
+        ShellProjectionLanguage language,
+        string canonicalVerb)
+    {
+        for (var index = 0; index < Entries.Count; index++)
+        {
+            var entry = Entries[index];
+            if (entry.Language == language &&
+                string.Equals(canonicalVerb, entry.CanonicalVerb, entry.VerbComparison))
+            {
+                return entry;
+            }
+        }
+
+        return null;
+    }
 }
 
 /// <summary>
-/// Combines an audited binding, transform provenance, and the existing path
-/// resolver into one fail-closed public value domain.
+/// Combines audited bindings with transform provenance and path resolution.
 /// </summary>
-internal static class AuthoredFileSystemValueProjection
+internal static class AuthoredOperandSemanticsProjection
 {
     internal static IReadOnlyList<AnalyzedArgument> Apply(
         ShellProjectionLanguage language,
@@ -188,7 +278,7 @@ internal static class AuthoredFileSystemValueProjection
             return arguments;
         }
 
-        var bindings = AuthoredFileSystemBindingCatalog.Bind(language, clause, arguments);
+        var bindings = AuditedOperandBindingCatalog.Bind(language, clause, arguments);
         if (!HasAuditedBinding(bindings))
         {
             return arguments;
@@ -200,11 +290,14 @@ internal static class AuthoredFileSystemValueProjection
         for (var index = 0; index < arguments.Count; index++)
         {
             var argument = arguments[index];
-            ShellValueDomain domain = new ShellValueDomain.Unknown();
+            var fileSystemDomain = argument.AuthoredFileSystemValue;
+            var nonFileSystemDomain = argument.AuthoredNonFileSystemValue;
             var candidates = Values(argument.AuthoredValue);
-            switch (bindings[index])
+            var binding = bindings[index];
+            switch (binding.Category, binding.Semantic)
             {
-                case AuditedFileSystemBindingCategory.AllNonOptionOperands:
+                case (AuditedOperandBindingCategory.AllNonOptionOperands,
+                    AuditedOperandSemantic.LocalFileSystem):
                     var allCandidatesArePaths = ClassifyNonOptionOperand(
                         candidates,
                         bashOptionsEnded,
@@ -219,11 +312,12 @@ internal static class AuthoredFileSystemValueProjection
                             workingDirectory,
                             out var bashDomain))
                     {
-                        domain = bashDomain;
+                        fileSystemDomain = bashDomain;
                     }
 
                     break;
-                case AuditedFileSystemBindingCategory.ExactNamedParameterValue:
+                case (AuditedOperandBindingCategory.ExactNamedParameterValue,
+                    AuditedOperandSemantic.LocalFileSystem):
                     if (candidates.Count > 0 &&
                         TryGetProvenance(argument, clause, provenanceByElement, out var pwshValue) &&
                         IsSingleField(pwshValue) &&
@@ -233,24 +327,57 @@ internal static class AuthoredFileSystemValueProjection
                             workingDirectory,
                             out var pwshDomain))
                     {
-                        domain = pwshDomain;
+                        fileSystemDomain = pwshDomain;
+                    }
+
+                    break;
+                case (AuditedOperandBindingCategory.AllArguments,
+                    AuditedOperandSemantic.NonFileSystem):
+                    if (candidates.Count > 0 &&
+                        TryGetProvenance(argument, clause, provenanceByElement, out var dataValue) &&
+                        IsBashTransformSafe(dataValue, candidates))
+                    {
+                        nonFileSystemDomain = argument.AuthoredValue;
                     }
 
                     break;
             }
 
-            projected[index] = argument with { AuthoredFileSystemValue = domain };
+            projected[index] = argument with
+            {
+                AuthoredFileSystemValue = fileSystemDomain,
+                AuthoredNonFileSystemValue = nonFileSystemDomain,
+            };
         }
 
-        return projected;
+        return HasValidDomains(projected) ? projected : Array.Empty<AnalyzedArgument>();
+    }
+
+    internal static bool HasValidDomains(IReadOnlyList<AnalyzedArgument> arguments)
+    {
+        for (var index = 0; index < arguments.Count; index++)
+        {
+            var argument = arguments[index];
+            var hasFileSystemValue = IsPositiveDomain(argument.AuthoredFileSystemValue);
+            var hasNonFileSystemValue = IsPositiveDomain(
+                argument.AuthoredNonFileSystemValue);
+            if (hasFileSystemValue && hasNonFileSystemValue ||
+                !IsAuditedDomain(argument.AuthoredFileSystemValue) ||
+                !IsAuditedDomain(argument.AuthoredNonFileSystemValue))
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static bool HasAuditedBinding(
-        IReadOnlyList<AuditedFileSystemBindingCategory> bindings)
+        IReadOnlyList<AuditedOperandBinding> bindings)
     {
         for (var index = 0; index < bindings.Count; index++)
         {
-            if (bindings[index] != AuditedFileSystemBindingCategory.Unknown)
+            if (bindings[index].Category != AuditedOperandBindingCategory.Unknown)
             {
                 return true;
             }
@@ -258,6 +385,15 @@ internal static class AuthoredFileSystemValueProjection
 
         return false;
     }
+
+    private static bool IsAuditedDomain(ShellValueDomain domain) => domain is
+        ShellValueDomain.Unknown or
+        ShellValueDomain.Exact or
+        ShellValueDomain.FiniteSet;
+
+    private static bool IsPositiveDomain(ShellValueDomain domain) => domain is
+        ShellValueDomain.Exact or
+        ShellValueDomain.FiniteSet;
 
     private static Dictionary<int, ShellValue> IndexProvenance(
         IReadOnlyList<ShellValueElementProvenance> provenance)

--- a/src/ShellSyntaxTree/ShellSyntaxProjection.cs
+++ b/src/ShellSyntaxTree/ShellSyntaxProjection.cs
@@ -1168,6 +1168,7 @@ internal static class ShellSyntaxProjection
                         Value = value,
                         AuthoredValue = authoredValue,
                         AuthoredFileSystemValue = new ShellValueDomain.Unknown(),
+                        AuthoredNonFileSystemValue = new ShellValueDomain.Unknown(),
                         AuthoredPathShape = publishAuthoredPathShape
                             ? ShellPathShapeClassifier.Classify(authoredValue)
                             : ShellPathShape.Unknown,
@@ -1183,13 +1184,14 @@ internal static class ShellSyntaxProjection
                 return false;
             }
 
-            arguments = AuthoredFileSystemValueProjection.Apply(
+            arguments = AuthoredOperandSemanticsProjection.Apply(
                 language,
                 clause,
                 provenance,
                 workingDirectory,
                 projected);
-            return true;
+            return arguments.Count == projected.Count &&
+                   AuthoredOperandSemanticsProjection.HasValidDomains(arguments);
         }
 
         private static bool IsInlineArgumentPair(

--- a/tests/ShellSyntaxTree.Tests/Corpus/AstAssert.cs
+++ b/tests/ShellSyntaxTree.Tests/Corpus/AstAssert.cs
@@ -470,6 +470,14 @@ internal static class AstAssert
                             actualArgument.AuthoredFileSystemValue,
                             prefix + $"commands[{index}].arguments[{argumentIndex}].authoredFileSystemValue");
                     }
+
+                    if (expectedArgument.AuthoredNonFileSystemValue is not null)
+                    {
+                        AssertValueDomainEqual(
+                            expectedArgument.AuthoredNonFileSystemValue,
+                            actualArgument.AuthoredNonFileSystemValue,
+                            prefix + $"commands[{index}].arguments[{argumentIndex}].authoredNonFileSystemValue");
+                    }
                 }
             }
 

--- a/tests/ShellSyntaxTree.Tests/Corpus/CorpusRunnerTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Corpus/CorpusRunnerTests.cs
@@ -1134,6 +1134,8 @@ public sealed record ExpectedAnalyzedArgument
     public ExpectedValueDomain Value { get; init; } = new();
 
     public ExpectedValueDomain? AuthoredFileSystemValue { get; init; }
+
+    public ExpectedValueDomain? AuthoredNonFileSystemValue { get; init; }
 }
 
 public sealed record ExpectedValueDomain

--- a/tests/ShellSyntaxTree.Tests/Corpus/bash/318_v03_tr_non_filesystem_data.json
+++ b/tests/ShellSyntaxTree.Tests/Corpus/bash/318_v03_tr_non_filesystem_data.json
@@ -1,0 +1,161 @@
+{
+  "name": "v0.3.5 tr translation data is not a filesystem operand",
+  "input": "tr -d '\\n'",
+  "expected": {
+    "isUnparseable": false,
+    "clauses": [
+      {
+        "operator": "None",
+        "verb": [
+          "tr"
+        ],
+        "args": [
+          {
+            "raw": "-d",
+            "kind": "Literal",
+            "isPath": false,
+            "resolved": "__NULL__",
+            "isFlag": true
+          },
+          {
+            "raw": "'\\n'",
+            "kind": "Literal",
+            "isPath": false,
+            "resolved": "__NULL__",
+            "isFlag": false
+          }
+        ],
+        "redirects": [],
+        "elements": [
+          {
+            "raw": "tr",
+            "value": "tr",
+            "role": "Verb",
+            "sourceStart": 0,
+            "sourceLength": 2,
+            "precedingVerbElementCount": 0,
+            "kind": "Literal",
+            "isFlag": false,
+            "isPath": false
+          },
+          {
+            "raw": "-d",
+            "value": "-d",
+            "role": "Argument",
+            "sourceStart": 3,
+            "sourceLength": 2,
+            "precedingVerbElementCount": 1,
+            "kind": "Literal",
+            "isFlag": true,
+            "isPath": false
+          },
+          {
+            "raw": "'\\n'",
+            "value": "\\n",
+            "role": "Argument",
+            "sourceStart": 6,
+            "sourceLength": 4,
+            "precedingVerbElementCount": 1,
+            "kind": "Literal",
+            "isFlag": false,
+            "isPath": false
+          }
+        ]
+      }
+    ],
+    "syntax": [
+      {
+        "kind": "Block",
+        "parentIndex": null,
+        "region": "Unknown",
+        "childIndex": null,
+        "sourceStart": 0,
+        "sourceLength": 10,
+        "clauseIndex": null,
+        "groupKind": null,
+        "listOperator": null
+      },
+      {
+        "kind": "SimpleCommand",
+        "parentIndex": 0,
+        "region": "Root",
+        "childIndex": 0,
+        "sourceStart": 0,
+        "sourceLength": 10,
+        "clauseIndex": 0,
+        "groupKind": null,
+        "listOperator": null
+      }
+    ],
+    "commands": [
+      {
+        "clauseIndex": 0,
+        "immediateRole": "Ordinary",
+        "isComplete": true,
+        "ancestry": [
+          {
+            "ancestorKind": "Block",
+            "region": "Root",
+            "childIndex": 0,
+            "sourceStart": 0,
+            "sourceLength": 10
+          }
+        ],
+        "arguments": [
+          {
+            "clauseArgumentIndex": 0,
+            "clauseElementIndex": 1,
+            "value": {
+              "kind": "Exact",
+              "values": [
+                "-d"
+              ],
+              "pattern": null,
+              "coveringDirectory": null
+            },
+            "authoredNonFileSystemValue": {
+              "kind": "Exact",
+              "values": [
+                "-d"
+              ],
+              "pattern": null,
+              "coveringDirectory": null
+            }
+          },
+          {
+            "clauseArgumentIndex": 1,
+            "clauseElementIndex": 2,
+            "value": {
+              "kind": "Exact",
+              "values": [
+                "\\n"
+              ],
+              "pattern": null,
+              "coveringDirectory": null
+            },
+            "authoredNonFileSystemValue": {
+              "kind": "Exact",
+              "values": [
+                "\\n"
+              ],
+              "pattern": null,
+              "coveringDirectory": null
+            }
+          }
+        ],
+        "workingDirectory": {
+          "kind": "Exact",
+          "values": [
+            "/work"
+          ],
+          "pattern": null,
+          "coveringDirectory": null
+        },
+        "workingDirectoryEffect": {
+          "kind": "Unchanged"
+        }
+      }
+    ]
+  },
+  "notes": "Sanitized live-derived fact: the quoted backslash sequence is tr translation data, not a child path scope."
+}

--- a/tests/ShellSyntaxTree.Tests/Parsing/AuthoredOperandSemanticsTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Parsing/AuthoredOperandSemanticsTests.cs
@@ -1,5 +1,5 @@
 // -----------------------------------------------------------------------
-// <copyright file="AuthoredFileSystemValueTests.cs" company="Aaron Stannard">
+// <copyright file="AuthoredOperandSemanticsTests.cs" company="Aaron Stannard">
 //      Copyright (C) 2026 - 2026 Aaron Stannard <https://github.com/Aaronontheweb>
 // </copyright>
 // -----------------------------------------------------------------------
@@ -10,41 +10,242 @@ using Xunit;
 
 namespace ShellSyntaxTree.Tests.Parsing;
 
-public class AuthoredFileSystemValueTests
+public class AuthoredOperandSemanticsTests
 {
     [Fact]
     public void Audited_commands_opt_into_reusable_binding_categories_through_data()
     {
         var operandArguments = Assert.Single(
             Bash().Parse("example-command README.md").Commands).Arguments;
-        var operandEntry = new AuthoredFileSystemBindingCatalogEntry(
+        var operandEntry = new AuditedOperandBindingCatalogEntry(
             ShellProjectionLanguage.Bash,
             "example-command",
             StringComparison.Ordinal,
-            AuditedFileSystemBindingCategory.AllNonOptionOperands);
+            AuditedOperandBindingCategory.AllNonOptionOperands,
+            AuditedOperandSemantic.LocalFileSystem);
 
         Assert.Equal(
-            new[] { AuditedFileSystemBindingCategory.AllNonOptionOperands },
-            AuthoredFileSystemBindingCatalog.Bind(operandEntry, operandArguments));
+            new[]
+            {
+                new AuditedOperandBinding(
+                    AuditedOperandBindingCategory.AllNonOptionOperands,
+                    AuditedOperandSemantic.LocalFileSystem),
+            },
+            AuditedOperandBindingCatalog.Bind(operandEntry, operandArguments));
 
         var parameterArguments = Assert.Single(
             PowerShell(PwshDialect.PowerShell7)
                 .Parse("Example-Command -Source C:\\work\\a.txt")
                 .Commands).Arguments;
-        var parameterEntry = new AuthoredFileSystemBindingCatalogEntry(
+        var parameterEntry = new AuditedOperandBindingCatalogEntry(
             ShellProjectionLanguage.PowerShell,
             "Example-Command",
             StringComparison.OrdinalIgnoreCase,
-            AuditedFileSystemBindingCategory.ExactNamedParameterValue,
+            AuditedOperandBindingCategory.ExactNamedParameterValue,
+            AuditedOperandSemantic.LocalFileSystem,
             "-Source");
 
         Assert.Equal(
             new[]
             {
-                AuditedFileSystemBindingCategory.Unknown,
-                AuditedFileSystemBindingCategory.ExactNamedParameterValue,
+                default,
+                new AuditedOperandBinding(
+                    AuditedOperandBindingCategory.ExactNamedParameterValue,
+                    AuditedOperandSemantic.LocalFileSystem),
             },
-            AuthoredFileSystemBindingCatalog.Bind(parameterEntry, parameterArguments));
+            AuditedOperandBindingCatalog.Bind(parameterEntry, parameterArguments));
+    }
+
+    [Theory]
+    [InlineData("tr abc def", "abc", "def")]
+    [InlineData("tr -d '\\n'", "-d", "\\n")]
+    [InlineData("tr -- -d x", "--", "-d", "x")]
+    public void Audited_bash_tr_arguments_publish_non_filesystem_values(
+        string source,
+        params string[] expected)
+    {
+        var command = Assert.Single(Bash().Parse(source).Commands);
+
+        Assert.Equal(new[] { "tr" }, command.Clause.Verb.Tokens);
+        Assert.Equal(expected.Length, command.Arguments.Count);
+        for (var index = 0; index < expected.Length; index++)
+        {
+            var argument = command.Arguments[index];
+            Assert.Equal(
+                expected[index],
+                Assert.IsType<ShellValueDomain.Exact>(argument.AuthoredValue).Value);
+            Assert.False(argument.Argument.IsPath);
+            Assert.Null(argument.Argument.Resolved);
+            AssertNonFileSystemExact(argument, expected[index]);
+            AssertUnknownFileSystem(argument);
+        }
+    }
+
+    [Fact]
+    public void Path_shaped_tr_data_keeps_lexical_shape_without_path_semantics()
+    {
+        var arguments = Assert.Single(
+            Bash().Parse("tr /etc/passwd 'C:\\temp'").Commands).Arguments;
+
+        Assert.Equal(ShellPathShape.Posix, arguments[0].AuthoredPathShape);
+        Assert.Equal(ShellPathShape.Windows, arguments[1].AuthoredPathShape);
+        Assert.All(arguments, argument =>
+        {
+            Assert.False(argument.Argument.IsPath);
+            Assert.Null(argument.Argument.Resolved);
+            Assert.IsType<ShellValueDomain.Exact>(argument.AuthoredNonFileSystemValue);
+        });
+    }
+
+    [Fact]
+    public void Active_glob_and_dynamic_tr_data_remain_unknown()
+    {
+        var glob = Assert.Single(Bash().Parse("tr *.txt x").Commands).Arguments;
+        var dynamic = Bash().Parse("tr \"$chars\" x");
+
+        AssertUnknownNonFileSystem(glob[0]);
+        AssertNonFileSystemExact(glob[1], "x");
+        Assert.True(dynamic.IsUnparseable);
+        Assert.Empty(dynamic.Commands);
+    }
+
+    [Fact]
+    public void Tr_substitution_and_redirect_remain_independent_facts()
+    {
+        var substitution = Bash().Parse("tr \"$(printf x)\" y");
+        var outer = Assert.Single(
+            substitution.Commands,
+            command => command.Clause.Verb.Joined == "tr");
+        AssertUnknownNonFileSystem(outer.Arguments[0]);
+        AssertNonFileSystemExact(outer.Arguments[1], "y");
+        Assert.Contains(
+            substitution.Commands,
+            command => command.ImmediateRole == CommandOccurrenceRole.Substitution);
+
+        var redirected = Assert.Single(
+            Bash().Parse("tr -d '\\n' > /outside/result").Commands);
+        Assert.All(redirected.Arguments, argument =>
+            Assert.IsType<ShellValueDomain.Exact>(argument.AuthoredNonFileSystemValue));
+        Assert.Equal(
+            "/outside/result",
+            Assert.IsType<ShellValueDomain.Exact>(
+                Assert.IsType<FileRedirectAnalysis>(
+                    Assert.Single(redirected.Redirects)).Target).Value);
+    }
+
+    [Fact]
+    public void Unknown_command_keeps_backslash_argument_on_the_compatibility_path()
+    {
+        var argument = Assert.Single(
+            Assert.Single(Bash().Parse("tool -d '\\n'").Commands).Arguments,
+            candidate => candidate.AuthoredValue is ShellValueDomain.Exact
+            {
+                Value: "\\n",
+            });
+
+        Assert.True(argument.Argument.IsPath);
+        Assert.Equal("/work/n", argument.Argument.Resolved);
+        AssertUnknownNonFileSystem(argument);
+    }
+
+    [Fact]
+    public void Over_limit_tr_join_remains_unknown()
+    {
+        var values = Enumerable.Range(1, ShellAnalysisLimits.MaxValueCandidates + 1)
+            .Select(index => $"v{index:00}");
+        var result = Bash(authoredFacts: true).Parse(
+            $"for f in {string.Join(" ", values)}; do tr \"$f\" x; done");
+
+        var arguments = Assert.Single(result.Commands).Arguments;
+        AssertUnknownNonFileSystem(arguments[0]);
+        AssertNonFileSystemExact(arguments[1], "x");
+    }
+
+    [Fact]
+    public void Finite_tr_loop_publishes_a_non_filesystem_value_set()
+    {
+        var result = Bash(authoredFacts: true).Parse(
+            "for f in a b; do tr \"$f\" x; done");
+
+        var arguments = Assert.Single(result.Commands).Arguments;
+        AssertFinite(arguments[0].AuthoredNonFileSystemValue, "a", "b");
+        AssertUnknownFileSystem(arguments[0]);
+        AssertNonFileSystemExact(arguments[1], "x");
+        AssertUnknownFileSystem(arguments[1]);
+    }
+
+    [Theory]
+    [InlineData(PwshDialect.PowerShell7)]
+    [InlineData(PwshDialect.WindowsPowerShell51)]
+    public void PowerShell_tr_arguments_do_not_gain_bash_semantics(PwshDialect dialect)
+    {
+        var result = PowerShell(dialect).Parse("tr -d '\\n'");
+
+        var arguments = Assert.Single(result.Commands).Arguments;
+        Assert.All(arguments, AssertUnknownNonFileSystem);
+        Assert.True(arguments[^1].Argument.IsPath);
+    }
+
+    [Fact]
+    public void Audited_filesystem_and_non_filesystem_domains_are_mutually_exclusive()
+    {
+        var argument = new AnalyzedArgument
+        {
+            AuthoredFileSystemValue = new ShellValueDomain.Exact("/work/a.txt"),
+            AuthoredNonFileSystemValue = new ShellValueDomain.Exact("data"),
+        };
+
+        Assert.False(AuthoredOperandSemanticsProjection.HasValidDomains([argument]));
+    }
+
+    [Fact]
+    public void Unsupported_authored_operand_domains_fail_closed()
+    {
+        ShellValueDomain[] unsupported =
+        [
+            new ShellValueDomain.IntegerRange(0, 1),
+            new ShellValueDomain.Concatenation(
+            [
+                new ShellValueDomain.Exact("a"),
+                new ShellValueDomain.Exact("b"),
+            ]),
+            new ShellValueDomain.PathPattern("*.txt", "/work"),
+        ];
+
+        foreach (var domain in unsupported)
+        {
+            Assert.False(AuthoredOperandSemanticsProjection.HasValidDomains(
+            [
+                new AnalyzedArgument { AuthoredFileSystemValue = domain },
+            ]));
+            Assert.False(AuthoredOperandSemanticsProjection.HasValidDomains(
+            [
+                new AnalyzedArgument { AuthoredNonFileSystemValue = domain },
+            ]));
+        }
+    }
+
+    [Fact]
+    public void Unsupported_domain_rejects_the_entire_audited_projection()
+    {
+        var command = Assert.Single(Bash().Parse("tr a b").Commands);
+        var corrupted = command.Arguments
+            .Select((argument, index) => index == 0
+                ? argument with
+                {
+                    AuthoredFileSystemValue = new ShellValueDomain.IntegerRange(0, 1),
+                }
+                : argument)
+            .ToArray();
+
+        var projected = AuthoredOperandSemanticsProjection.Apply(
+            ShellProjectionLanguage.Bash,
+            command.Clause,
+            Array.Empty<ShellValueElementProvenance>(),
+            ShellValueDomainFacts.Unknown,
+            corrupted);
+
+        Assert.Empty(projected);
     }
 
     [Theory]
@@ -344,6 +545,20 @@ public class AuthoredFileSystemValueTests
 
     private static void AssertUnknown(AnalyzedArgument argument) =>
         Assert.IsType<ShellValueDomain.Unknown>(argument.AuthoredFileSystemValue);
+
+    private static void AssertUnknownFileSystem(AnalyzedArgument argument) =>
+        Assert.IsType<ShellValueDomain.Unknown>(argument.AuthoredFileSystemValue);
+
+    private static void AssertUnknownNonFileSystem(AnalyzedArgument argument) =>
+        Assert.IsType<ShellValueDomain.Unknown>(argument.AuthoredNonFileSystemValue);
+
+    private static void AssertNonFileSystemExact(
+        AnalyzedArgument argument,
+        string expected) =>
+        Assert.Equal(
+            expected,
+            Assert.IsType<ShellValueDomain.Exact>(
+                argument.AuthoredNonFileSystemValue).Value);
 
     private static void AssertExact(AnalyzedArgument argument, string expected) =>
         Assert.Equal(

--- a/tests/ShellSyntaxTree.Tests/V03PublicApiSnapshotTests.cs
+++ b/tests/ShellSyntaxTree.Tests/V03PublicApiSnapshotTests.cs
@@ -124,6 +124,7 @@ public class V03PublicApiSnapshotTests
             (nameof(AnalyzedArgument.Value), typeof(ShellValueDomain)),
             (nameof(AnalyzedArgument.AuthoredValue), typeof(ShellValueDomain)),
             (nameof(AnalyzedArgument.AuthoredFileSystemValue), typeof(ShellValueDomain)),
+            (nameof(AnalyzedArgument.AuthoredNonFileSystemValue), typeof(ShellValueDomain)),
             (nameof(AnalyzedArgument.AuthoredPathShape), typeof(ShellPathShape)));
 
         AssertEnum<ShellPathShape>("Unknown", "Posix", "Windows");
@@ -383,6 +384,28 @@ public class V03PublicApiSnapshotTests
             StringComparison.Ordinal);
         Assert.Contains(
             "\"AuthoredFileSystemValue\"",
+            JsonSerializer.Serialize(positive),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Authored_non_filesystem_value_is_non_null_and_part_of_record_shape()
+    {
+        var strict = new AnalyzedArgument();
+        var positive = strict with
+        {
+            AuthoredNonFileSystemValue = new ShellValueDomain.Exact("data"),
+        };
+
+        Assert.IsType<ShellValueDomain.Unknown>(strict.AuthoredNonFileSystemValue);
+        Assert.NotEqual(strict, positive);
+        Assert.NotEqual(strict.GetHashCode(), positive.GetHashCode());
+        Assert.Contains(
+            "AuthoredNonFileSystemValue = Exact",
+            positive.ToString(),
+            StringComparison.Ordinal);
+        Assert.Contains(
+            "\"AuthoredNonFileSystemValue\"",
             JsonSerializer.Serialize(positive),
             StringComparison.Ordinal);
     }

--- a/tools/PwshCorpusTool/CorpusJson.cs
+++ b/tools/PwshCorpusTool/CorpusJson.cs
@@ -368,6 +368,12 @@ internal static class CorpusJson
                             BuildValueDomain(analyzed.AuthoredFileSystemValue);
                     }
 
+                    if (analyzed.AuthoredNonFileSystemValue is not ShellValueDomain.Unknown)
+                    {
+                        argument["authoredNonFileSystemValue"] =
+                            BuildValueDomain(analyzed.AuthoredNonFileSystemValue);
+                    }
+
                     arguments.Add(argument);
                 }
 


### PR DESCRIPTION
## Summary

- add the additive AuthoredNonFileSystemValue argument fact
- model Bash tr operands as audited non-filesystem data while preserving lexical path shape
- generalize the existing audited operand catalog shared by cat and Get-Content
- add exact, finite-set, dynamic, cross-shell, corruption, corpus, and consumer-guide coverage

## Security boundary

Only bounded Exact and FiniteSet authored values may become positive non-filesystem facts. Redirects, substitutions, effects, working-directory facts, completeness, and other arguments remain independent. Unknown commands retain compatibility path behavior, and unsupported domain variants fail the entire audited projection.

## Validation

- Release build: 0 warnings and 0 errors
- full suite: 3,090 of 3,090 passed
- focused adversarial re-review: PASS
- API diff versus 0.3.4: exactly one additive property on net8.0 and netstandard2.0
- strict OpenSpec, headers, PII audit, package inspection, formatting, diff check, and changed-file Slopwatch pass

This PR intentionally does not bump or publish the package version. The 0.3.5 release remains a separate release-state change after CI.