### PR TITLE
Release ShellSyntaxTree 0.3.5

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <VersionPrefix>0.3.4</VersionPrefix>
+    <VersionPrefix>0.3.5</VersionPrefix>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Target framework matrix -->

--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -106,12 +106,16 @@ priorities.
       value-domain property, one audited `tr` data binding, a single-token
       compatibility correction, and a strict consumer boundary. PR #167 merged
       the contract after strict OpenSpec plus Linux and Windows CI passed.
-- [ ] **Implement and publish v0.3.5 authored non-filesystem facts.** Add the
+- [x] **Implement and validate v0.3.5 authored non-filesystem facts.** Add the
       approved property and generalized audited operand projection. Preserve
       the existing `cat` and `Get-Content -LiteralPath` facts. Pin direct,
       corpus, API, PowerShell, redirect, dynamic, and over-limit boundaries.
-      Complete adversarial review, package comparison, native Windows CI,
-      publication, and downstream Netclaw acceptance before completion.
+      PR #168 merged as `336807bf` after all 3,090 tests, strict OpenSpec,
+      headers, Slopwatch, package validation, exact 0.3.4 API comparison,
+      adversarial review, and Linux plus native Windows CI passed.
+- [ ] **Publish and consume v0.3.5.** Merge the bounded release PR, publish the
+      package through the bare `0.3.5` tag, then upgrade Netclaw and complete
+      the exact live `tr -d '\n'` policy regression before merging that slice.
 
 ## Completed v0.3.0 host integration and release acceptance
 

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ Hand-rolled, AOT-trim friendly, zero native dependencies. Multi-targets
 
 ```bash
 # Current package
-dotnet add package ShellSyntaxTree --version 0.3.4
+dotnet add package ShellSyntaxTree --version 0.3.5
 ```
 
-Version `0.3.4` includes the typed syntax tree, command-occurrence API,
-bounded authored-value analysis, audited authored-filesystem projection, and
-parser-owned working-directory effects documented below.
+Version `0.3.5` includes the typed syntax tree, command-occurrence API,
+bounded authored-value analysis, audited filesystem and non-filesystem operand
+facts, and parser-owned working-directory effects documented below.
 
 ## What you get
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,8 @@
-#### Unreleased ####
+#### 0.3.5 2026-08-14 ####
+
+This additive release distinguishes audited non-filesystem operand data from
+compatibility path heuristics. Security consumers can stop treating bounded
+translation sets as filesystem scope without relaxing independent shell facts.
 
 ## Added
 

--- a/openspec/changes/publish-authored-operand-semantics/tasks.md
+++ b/openspec/changes/publish-authored-operand-semantics/tasks.md
@@ -49,7 +49,7 @@
   0.3.5 behavior and unchanged public signatures.
 - [x] 5.2 Run Release build, full unit and corpus suite, PII audit, headers,
   Slopwatch, package validation, and 0.3.4 API comparison.
-- [ ] 5.3 Run Linux and native Windows CI plus an independent adversarial
+- [x] 5.3 Run Linux and native Windows CI plus an independent adversarial
   security review before publication.
 - [ ] 5.4 Publish the package, consume the exact public version in Netclaw, and
   run its complete policy and cross-platform gates.


### PR DESCRIPTION
## Summary

- bump package metadata and README to 0.3.5
- publish the reviewed authored non-filesystem operand notes
- record the merged implementation and completed cross-platform review gates
- leave package publication, Netclaw consumption, and live validation explicitly pending

## Validation

- Release build: 0 warnings and 0 errors
- full suite: 3,090 of 3,090 passed
- package contains README, icon, net8.0 and netstandard2.0 assemblies
- symbol package contains both PDBs
- API diff versus public 0.3.4: exactly one additive property on both TFMs
- strict OpenSpec, headers, release-note extraction, tag-format validation, and diff check pass
- independent adversarial release review: PASS

Slopwatch reports only the repository's pre-existing CS1591 suppression from commit 80e276a; this release hunk changes only VersionPrefix and adds no suppression.