### PR TITLE
Support bundled Bash command options

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -116,6 +116,15 @@ priorities.
 - [ ] **Publish and consume v0.3.5.** Merge the bounded release PR, publish the
       package through the bare `0.3.5` tag, then upgrade Netclaw and complete
       the exact live `tr -d '\n'` policy regression before merging that slice.
+- [x] **Parse static bundled Bash command-string options.** Treat literal
+      no-operand short-option clusters such as `-lc`, `-cl`, and `-xec` as the
+      same parser-owned wrapper boundary as standalone `-c`. Keep operand-
+      bearing, unknown, dynamic, attached-text, and trailing-argument forms
+      fail closed. Direct regressions and the locked grammar pin both sides.
+- [ ] **Publish and consume the bundled-wrapper correction.** Release the
+      reviewed parser correction, upgrade Netclaw, and remove its duplicate
+      recursive Bash-wrapper fallback without changing the public tokenizer
+      compatibility surface.
 
 ## Completed v0.3.0 host integration and release acceptance
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -1509,8 +1509,12 @@ command         := clause (compound_op clause)*
 compound_op     := "&&" | "||" | ";" | "|" | NEWLINE
 clause          := subshell | bash_c_wrapper | simple_clause
 subshell        := "(" command ")"
-bash_c_wrapper  := ("bash" | "sh") static_flag* "-c" STATIC_QUOTED_STRING
+bash_c_wrapper  := ("bash" | "sh") static_flag* command_string_option
+                   STATIC_QUOTED_STRING
 static_flag     := exact-one literal Word beginning with "-"
+command_string_option := exact-one literal "-" Word containing at least one
+                         "c" and otherwise only no-operand Bash short options
+                         from "abefhkmnptuvxBCEHPTilrsD"
 STATIC_QUOTED_STRING := QuotedString whose outer-shell provenance is entirely
                         literal and exactly one value
 simple_clause   := verb_chain arg* redirect*
@@ -2275,7 +2279,11 @@ Clause 2: Op=AndIf, Verb=cmd2, Args=[]   // no /b attribution — subshell isola
 `bash -c "inner command"` and `sh -c "inner command"` are common wrappers
 the agent emits. The parser:
 
-1. Recognizes the `bash -c` or `sh -c` prefix.
+1. Recognizes the `bash -c` or `sh -c` prefix. A literal short-option cluster
+   such as `-lc`, `-cl`, or `-xec` also selects command-string mode when every
+   character is a documented no-operand Bash invocation option. Options `-o`
+   and `-O`, unknown letters, dynamic spellings, and attached text remain
+   unsupported.
 2. Parses the quoted argument as a fresh `ParsedCommand`.
 3. Surfaces the inner command's clauses inline in the outer's `Clauses`
    list, each with `IsCommandStringWrapped=true`.
@@ -2292,9 +2300,9 @@ by the recursion. Consumers that care that this came from a wrapper can
 inspect `IsCommandStringWrapped` on the surfaced clauses.
 
 A `bash` or `sh` clause whose authored arguments are dynamic, contain a decoded
-`-c`, or contain a combined short option that may select command-string mode,
-but that does not match the complete static wrapper production, remains visible
-through its v0.2 compatibility leaf, including its direct outer source spans.
+`-c`, or contain an unsupported combined short option that may select
+command-string mode remains visible through its v0.2 compatibility leaf,
+including its direct outer source spans.
 Its v0.3 command occurrence has `IsComplete=false`. Wrapper-control tokens and
 the quoted body must each have literal, exactly-one outer-shell provenance;
 token kind or decoded spelling alone is insufficient. A proved `--` ends this

--- a/src/ShellSyntaxTree/Internal/Bash/Parsing/BashCommandParser.cs
+++ b/src/ShellSyntaxTree/Internal/Bash/Parsing/BashCommandParser.cs
@@ -231,10 +231,11 @@ internal static partial class BashCommandParser
     /// the full clause parser first) so the wrapper is consumed cleanly —
     /// the outer clause never appears in <c>ParsedCommand.Clauses</c>. The
     /// scan looks for an exact literal Word verb of <c>bash</c> or <c>sh</c>,
-    /// followed by exact literal flag tokens, an exact <c>-c</c> Word flag,
-    /// and a quoted body whose outer-shell provenance is entirely literal
-    /// and exactly one value. Decoded spelling alone is insufficient because
-    /// outer expansions could change the command before the inner shell sees it.
+    /// followed by exact literal flag tokens, a supported static command-string
+    /// option, and a quoted body whose outer-shell provenance is entirely
+    /// literal and exactly one value. Decoded spelling alone is insufficient
+    /// because outer expansions could change the command before the inner shell
+    /// sees it.
     /// </remarks>
     private static bool TryDetectBashCWrapper(Segment segment, string source, out string? innerCommand)
     {
@@ -267,7 +268,7 @@ internal static partial class BashCommandParser
                 return false;
             }
 
-            if (string.Equals(t.Value, "-c", StringComparison.Ordinal))
+            if (IsStaticCommandStringOption(t))
             {
                 var next = segment.Tokens[i + 1];
                 if (next.Kind == BashTokenKind.QuotedString &&
@@ -291,6 +292,41 @@ internal static partial class BashCommandParser
         }
 
         return false;
+    }
+
+    private static bool IsStaticCommandStringOption(BashToken token)
+    {
+        if (token.Kind != BashTokenKind.Word || !HasExactLiteralValue(token))
+        {
+            return false;
+        }
+
+        var value = token.Value;
+        if (value.Length < 2 || value[0] != '-' || value[1] == '-')
+        {
+            return false;
+        }
+
+        var containsCommandStringOption = false;
+        for (var index = 1; index < value.Length; index++)
+        {
+            var option = value[index];
+            if (option == 'c')
+            {
+                containsCommandStringOption = true;
+                continue;
+            }
+
+            // Bash documents these invocation and `set` options as
+            // single-character switches with no operand. Excluding `o` and
+            // `O` is load-bearing: both consume a separate option name.
+            if ("abefhkmnptuvxBCEHPTilrsD".IndexOf(option) < 0)
+            {
+                return false;
+            }
+        }
+
+        return containsCommandStringOption;
     }
 
     // ---------------------------------------------------------------- token filtering

--- a/src/ShellSyntaxTree/Internal/Bash/Parsing/BashStructuralCoordinator.cs
+++ b/src/ShellSyntaxTree/Internal/Bash/Parsing/BashStructuralCoordinator.cs
@@ -1896,8 +1896,7 @@ internal static partial class BashCommandParser
     {
         for (var index = 1; index + 1 < tokens.Count; index++)
         {
-            if (tokens[index].Kind == BashTokenKind.Word &&
-                string.Equals(tokens[index].Value, "-c", StringComparison.Ordinal))
+            if (IsStaticCommandStringOption(tokens[index]))
             {
                 if (index + 2 != tokens.Count ||
                     tokens[index + 1].Kind != BashTokenKind.QuotedString)

--- a/tests/ShellSyntaxTree.Tests/Parsing/BashStructuralProjectionTests.cs
+++ b/tests/ShellSyntaxTree.Tests/Parsing/BashStructuralProjectionTests.cs
@@ -484,6 +484,13 @@ public class BashStructuralProjectionTests
     [InlineData("bash -c 'echo $HOME'")]
     [InlineData("bash -c \"echo \\$HOME\"")]
     [InlineData("bash -x -c 'echo $HOME'")]
+    [InlineData("bash -lc 'echo $HOME'")]
+    [InlineData("bash -cl 'echo $HOME'")]
+    [InlineData("bash -ce 'echo $HOME'")]
+    [InlineData("bash -ec 'echo $HOME'")]
+    [InlineData("bash -xc 'echo $HOME'")]
+    [InlineData("bash -cc 'echo $HOME'")]
+    [InlineData("sh -xec 'echo $HOME'")]
     public void Outer_literal_command_string_is_recursively_analyzed(string source)
     {
         var result = Parse(source);
@@ -500,10 +507,11 @@ public class BashStructuralProjectionTests
     [InlineData("bash -$opts -c 'echo safe'")]
     [InlineData("bash $opts 'echo hidden'")]
     [InlineData("bash \"-c\" 'echo hidden'")]
-    [InlineData("bash -ce 'echo hidden'")]
-    [InlineData("bash -ec 'echo hidden'")]
-    [InlineData("bash -xc 'echo hidden'")]
     [InlineData("bash -O extglob -c 'echo hidden'")]
+    [InlineData("bash -Oc 'echo hidden'")]
+    [InlineData("bash -co 'echo hidden'")]
+    [InlineData("bash -zc 'echo hidden'")]
+    [InlineData("bash -cfoo 'echo hidden'")]
     public void Noncanonical_command_string_options_remain_outer_and_incomplete(string source)
     {
         var result = Parse(source);


### PR DESCRIPTION
## Summary

- parse literal bundled Bash command-string options such as `-lc`, `-cl`, and `-xec`
- keep operand-bearing, unknown, dynamic, and attached-text forms fail closed
- update the locked grammar, implementation plan, and direct projection tests

## Validation

- `dotnet build -c Release --no-restore`
- `dotnet test -c Release --no-build` (3,098 passed)
- `pwsh ./scripts/Add-FileHeaders.ps1 -Verify`
- `slopwatch analyze --no-baseline --fail-on warning --files ...` (0 issues)
- `git diff --check`

No public API changes.